### PR TITLE
Enable cross-width integer equality

### DIFF
--- a/docs/AUTO_PROMOTION_ROADMAP.md
+++ b/docs/AUTO_PROMOTION_ROADMAP.md
@@ -11,7 +11,7 @@ It complements the design in `auto_integer_promotion.md` and breaks down the wor
 - Provide an environment flag to disable overflow warnings during rollout.
 
 ## Phase 2 – IR and Type Adjustments (3-4 weeks)
-- Allow `Value` instances to upgrade from `VAL_I32` to `VAL_I64` without type errors.
+- ✅ Allow `Value` instances to upgrade from `VAL_I32` to `VAL_I64` without type errors.
 - Extend `checkValueAgainstType` so an `i64` value is acceptable for `i32` variables when it still fits.
 - Review built‑in functions and the standard library for assumptions about fixed widths.
 - Update serialization and bytecode formats if necessary to record promoted widths.

--- a/src/vm/value.c
+++ b/src/vm/value.c
@@ -75,30 +75,46 @@ void printValue(Value value) {
  * @return  True if values are equal.
  */
 bool valuesEqual(Value a, Value b) {
-    if (a.type != b.type) return false;
-    
-    switch (a.type) {
-        case VAL_I32: return a.as.i32 == b.as.i32;
-        case VAL_I64: return a.as.i64 == b.as.i64;
-        case VAL_U32: return a.as.u32 == b.as.u32;
-        case VAL_U64: return a.as.u64 == b.as.u64;
-        case VAL_F64: return a.as.f64 == b.as.f64;
-        case VAL_BOOL: return a.as.boolean == b.as.boolean;
-        case VAL_NIL: return true;
-        case VAL_STRING:
-            return a.as.string->length == b.as.string->length &&
-                   memcmp(a.as.string->chars, b.as.string->chars, a.as.string->length) == 0;
-        case VAL_ARRAY: {
-            if (a.as.array->length != b.as.array->length) return false;
-            for (int i = 0; i < a.as.array->length; i++) {
-                if (!valuesEqual(a.as.array->elements[i], b.as.array->elements[i])) return false;
+    if (a.type == b.type) {
+        switch (a.type) {
+            case VAL_I32: return a.as.i32 == b.as.i32;
+            case VAL_I64: return a.as.i64 == b.as.i64;
+            case VAL_U32: return a.as.u32 == b.as.u32;
+            case VAL_U64: return a.as.u64 == b.as.u64;
+            case VAL_F64: return a.as.f64 == b.as.f64;
+            case VAL_BOOL: return a.as.boolean == b.as.boolean;
+            case VAL_NIL: return true;
+            case VAL_STRING:
+                return a.as.string->length == b.as.string->length &&
+                       memcmp(a.as.string->chars, b.as.string->chars, a.as.string->length) == 0;
+            case VAL_ARRAY: {
+                if (a.as.array->length != b.as.array->length) return false;
+                for (int i = 0; i < a.as.array->length; i++) {
+                    if (!valuesEqual(a.as.array->elements[i], b.as.array->elements[i])) return false;
+                }
+                return true;
             }
-            return true;
+            case VAL_ERROR:
+                return a.as.error == b.as.error;
+            case VAL_RANGE_ITERATOR:
+                return a.as.rangeIter == b.as.rangeIter;
+            default: return false;
         }
-        case VAL_ERROR:
-            return a.as.error == b.as.error;
-        case VAL_RANGE_ITERATOR:
-            return a.as.rangeIter == b.as.rangeIter;
-        default: return false;
     }
+
+    // Cross-width integer comparisons used after automatic promotion.
+    if (IS_I32(a) && IS_I64(b)) {
+        return (int64_t)AS_I32(a) == AS_I64(b);
+    }
+    if (IS_I64(a) && IS_I32(b)) {
+        return AS_I64(a) == (int64_t)AS_I32(b);
+    }
+    if (IS_U32(a) && IS_U64(b)) {
+        return (uint64_t)AS_U32(a) == AS_U64(b);
+    }
+    if (IS_U64(a) && IS_U32(b)) {
+        return AS_U64(a) == (uint64_t)AS_U32(b);
+    }
+
+    return false;
 }


### PR DESCRIPTION
## Summary
- support comparing `i32`/`i64` and `u32`/`u64` values directly
- mark integer promotion step as completed in roadmap

## Testing
- `make orusc`
- `tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e11d5b7bc8325a26d28c743c2d7c7