### PR TITLE
Add integer promotion stress tests

### DIFF
--- a/tests/edge_cases/integer_promotion_large_collection.orus
+++ b/tests/edge_cases/integer_promotion_large_collection.orus
@@ -1,0 +1,15 @@
+// Summing a large array forces promotion when total exceeds i32 range
+fn main() {
+    let data: [i32] = []
+    for i in 0..1_000_000 {
+        push(data, i as i32)
+    }
+    let mut total = 0
+    let mut idx: i32 = 0
+    let n: i32 = len(data)
+    while idx < n {
+        total += data[idx]
+        idx += 1
+    }
+    print(total)
+}

--- a/tests/edge_cases/integer_promotion_mixed_widths.orus
+++ b/tests/edge_cases/integer_promotion_mixed_widths.orus
@@ -1,0 +1,8 @@
+// Mixed width arithmetic combining i32 and i64 values
+fn main() {
+    let big: i64 = 3_000_000_000
+    let small: i32 = big as i32
+    let a: i64 = 2
+    let res = (big * a) + (small as i64) - (1 as i64)
+    print(res)
+}

--- a/tests/edge_cases/integer_promotion_shift_large.orus
+++ b/tests/edge_cases/integer_promotion_shift_large.orus
@@ -1,0 +1,9 @@
+// Bit shift operations exceeding normal 32/64-bit boundaries
+fn main() {
+    let a = 1 << 33
+    print(a)
+    let b = 1i64 << 63
+    print(b)
+    let c = 1i64 << 64
+    print(c)
+}

--- a/tests/edge_cases/integer_promotion_underflow_loop.orus
+++ b/tests/edge_cases/integer_promotion_underflow_loop.orus
@@ -1,0 +1,8 @@
+// Repeated subtraction to test underflow handling
+fn main() {
+    let mut x = -2147483648
+    for _ in 0..10 {
+        x -= 1
+    }
+    print(x)
+}


### PR DESCRIPTION
## Summary
- add stress tests for large collections, mixed width operations, big shifts and repeated underflow
- all existing tests continue to pass after adding new cases