### PR TITLE
Fix compile errors from removed BigInt support

### DIFF
--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -2068,12 +2068,6 @@ static InterpretResult run() {
                                                     (long long)AS_RANGE_ITERATOR(arg)->current,
                                                     (long long)AS_RANGE_ITERATOR(arg)->end);
                                 break;
-                            case VAL_BIGINT: {
-                                char* str = mpz_get_str(NULL, 10, AS_BIGINT(arg)->value);
-                                valueLen = snprintf(valueStr, sizeof(valueStr), "%s", str);
-                                free(str);
-                                break;
-                            }
                         }
 
                         if (valueLen > 0) {
@@ -2250,12 +2244,6 @@ static InterpretResult run() {
                                                     (long long)AS_RANGE_ITERATOR(arg)->current,
                                                     (long long)AS_RANGE_ITERATOR(arg)->end);
                                 break;
-                            case VAL_BIGINT: {
-                                char* str = mpz_get_str(NULL, 10, AS_BIGINT(arg)->value);
-                                valueLen = snprintf(valueStr, sizeof(valueStr), "%s", str);
-                                free(str);
-                                break;
-                            }
                         }
 
                         if (valueLen > 0) {


### PR DESCRIPTION
## Summary
- remove unreachable VAL_BIGINT cases

## Testing
- `make`
- `bash tests/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_685e85806fec8325a16700414c9e6b22