### PR TITLE
Add dot-based module imports

### DIFF
--- a/docs/ERROR_REFERENCE.md
+++ b/docs/ERROR_REFERENCE.md
@@ -76,8 +76,8 @@ The parser expects specific tokens at each point in the grammar. When a token do
 - `Expect alias name.`
 - `Expect symbol name.`
 - `Expect '}' after symbol list.`
-- `Expect symbol name after '::'.`
-- ``import` statements are deprecated; use `use module::path` instead``
+- `Expect symbol name after '.'.`
+- ``import` statements are deprecated; use `use module.path` instead``
 - `Expect module path after 'use'.`
 - `Expect module path string after 'import'.`
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -427,7 +427,7 @@ Code can be split into multiple files. Use `use` to load an entire module. Only 
 The import system design is described further in `docs/import.md`.
 
 ```orus
-use math::utils
+use math.utils
 use datetime as dt
 
 fn main() {
@@ -441,7 +441,7 @@ Modules are executed once. Importing the same file twice causes a runtime error.
 An alias can shorten the module name:
 
 ```orus
-use math::utils as mu
+use math.utils as mu
 mu.helper()
 ```
 

--- a/docs/MODULE_IMPORT_REDESIGN.md
+++ b/docs/MODULE_IMPORT_REDESIGN.md
@@ -1,0 +1,54 @@
+# Module Import Syntax Redesign Roadmap
+
+This document outlines the steps required to migrate Orus from the current `use module::path` syntax to the new dot separated syntax:
+
+```
+use tests.modules.hello_module
+```
+
+The goal is to remove the `::` separator entirely and replace it with `.` for module paths.
+
+**Status:** Phase 1 (Lexer and Parser updates) has been implemented.
+
+## 1. Lexer and Parser
+
+1. **Update the scanner**
+   - Remove the `TOKEN_DOUBLE_COLON` token definition and handling.
+   - Ensure `.` (`TOKEN_DOT`) is returned for single dots in module paths.
+
+2. **Update the parser**
+   - Modify `useStatement` to parse identifiers separated by `.` instead of `::`.
+   - Adjust error messages that reference the old syntax.
+   - Update the precedence table to drop `TOKEN_DOUBLE_COLON` if unused elsewhere.
+
+3. **Update error handling**
+   - Search for references to `"::"` in error helpers and revise examples to use dot notation.
+
+## 2. AST and Compiler
+
+1. **AST changes**
+   - Ensure module path representation (typically an array of strings) is unaffected by the separator change.
+   - Validate any functions that split module paths by `::` are updated to use `.`.
+
+2. **Compiler adjustments**
+   - Update module loader to interpret dot-separated paths when resolving filenames.
+
+## 3. Standard Library and Examples
+
+1. **Update shipped modules** to use the new syntax.
+2. **Update documentation** in `docs/`, examples in `web/`, and any code snippets referencing the old syntax.
+3. **Update all tests** under `tests/` to reflect the new import style.
+
+## 4. Migration Strategy
+
+1. Provide a temporary compatibility warning when the parser encounters `::` to guide users toward the new syntax.
+2. After a deprecation period, remove support for `::` entirely.
+
+## 5. Testing
+
+1. Adjust existing test cases to use dot notation.
+2. Run the full test suite with `tests/run_all_tests.sh` to ensure no regressions.
+
+---
+
+Following this roadmap will transition Orus to the simpler `use module.path` syntax while keeping backward compatibility during the migration period.

--- a/docs/ORUS_ROADMAP.md
+++ b/docs/ORUS_ROADMAP.md
@@ -91,13 +91,13 @@ This roadmap adopts a **conservative versioning approach** where:
 
 ```orus
 // Target API examples
-use std::fs
-use std::env
-use std::process
+use std.fs
+use std.env
+use std.process
 
-let content = fs::read_text("config.txt")?
-let home = env::get("HOME")
-let result = process::run("git", ["status"])
+let content = fs.read_text("config.txt")?
+let home = env.get("HOME")
+let result = process.run("git", ["status"])
 ```
 
 ### 🔧 **Priority 2: Core Tooling Infrastructure**

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -110,7 +110,7 @@ fn main() {
 Use `use *` to import everything:
 
 ```orus
-use math::*
+use math.*
 ```
 
 ## Generics
@@ -148,7 +148,7 @@ Use `try`/`catch` to deal with failures:
 ```orus
 fn read(path: string) -> string {
     try {
-        return std::fs::read_to_string(path)
+        return std.fs.read_to_string(path)
     } catch err {
         print("failed: {}", err)
         return ""
@@ -1691,7 +1691,7 @@ fn main() {
 
 ### `tests/constants/use_module.orus`
 ```orus
-use tests::constants::math
+use tests.constants.math
 
 fn main() {
     print("Value: {}", math.PI)
@@ -2593,8 +2593,8 @@ fn main() {
 
 ### `tests/edge_cases/function_module_edges.orus`
 ```orus
-use tests::edge_cases::module_a
-use tests::edge_cases::module_b
+use tests.edge_cases.module_a
+use tests.edge_cases.module_b
 
 fn local_fn(a: i32, b: i32) -> i32 {
     return a + b
@@ -2706,8 +2706,8 @@ fn main() {
 
 ### `tests/edge_cases/module_imports.orus`
 ```orus
-use tests::edge_cases::module_a
-use tests::edge_cases::module_b
+use tests.edge_cases.module_a
+use tests.edge_cases.module_b
 
 fn main() {
     // Modules are imported for side effects only
@@ -2973,7 +2973,7 @@ fn main() {
 
 ### `tests/errors/import_cycle.orus`
 ```orus
-use tests::modules::cycles::cycle_a
+use tests.modules.cycles.cycle_a
 
 fn main() {
 }
@@ -2990,7 +2990,7 @@ fn main() {
 
 ### `tests/errors/import_missing.orus`
 ```orus
-use tests::modules::not_there
+use tests.modules.not_there
 
 fn main() {
 }
@@ -2998,7 +2998,7 @@ fn main() {
 
 ### `tests/errors/import_private.orus`
 ```orus
-use tests::modules::pub_module
+use tests.modules.pub_module
 
 fn main() {
     private_fn()
@@ -3008,8 +3008,8 @@ fn main() {
 
 ### `tests/errors/import_twice.orus`
 ```orus
-use tests::modules::hello_module
-use tests::modules::hello_module
+use tests.modules.hello_module
+use tests.modules.hello_module
 
 fn main() {
     print("done")
@@ -3019,7 +3019,7 @@ fn main() {
 
 ### `tests/errors/missing_export.orus`
 ```orus
-use tests::modules::hello_module::{unknown}
+use tests.modules.hello_module::{unknown}
 
 fn main() {
 }
@@ -3154,8 +3154,8 @@ fn main() {
 
 ### `tests/errors/use_twice.orus`
 ```orus
-use tests::modules::hello_module
-use tests::modules::hello_module::{greet}
+use tests.modules.hello_module
+use tests.modules.hello_module::{greet}
 
 fn main() {
     greet()
@@ -4181,7 +4181,7 @@ fn main() -> i32 {
 Test calling functions from main and importing modules
 ```orus
 // Test calling functions from main and importing modules
-use tests::modules::hello_module
+use tests.modules.hello_module
 
 fn main() {
     print("Main ran")
@@ -4239,7 +4239,7 @@ fn main() {
 
 ### `tests/modules/parse_use_alias.orus`
 ```orus
-use tests::modules::hello_module as hm
+use tests.modules.hello_module as hm
 
 fn main() {
     print("alias parsed")
@@ -4248,7 +4248,7 @@ fn main() {
 
 ### `tests/modules/parse_use_module.orus`
 ```orus
-use tests::modules::hello_module
+use tests.modules.hello_module
 
 fn main() {
     print("module parsed")
@@ -4257,7 +4257,7 @@ fn main() {
 
 ### `tests/modules/parse_use_selective.orus`
 ```orus
-use tests::modules::hello_module
+use tests.modules.hello_module
 
 fn main() {
     print("select parsed")
@@ -4300,7 +4300,7 @@ fn main() {
 
 ### `tests/modules/use_bind.orus`
 ```orus
-use tests::modules::hello_module
+use tests.modules.hello_module
 
 fn main() {
     hello_module.greet()
@@ -4309,7 +4309,7 @@ fn main() {
 
 ### `tests/modules/use_pub_function.orus`
 ```orus
-use tests::modules::pub_module
+use tests.modules.pub_module
 
 fn main() {
     pub_module.public_fn()
@@ -4319,7 +4319,7 @@ fn main() {
 
 ### `tests/modules/use_pub_struct.orus`
 ```orus
-use tests::modules::pub_struct_module
+use tests.modules.pub_struct_module
 
 fn main() {
     let p = pub_struct_module.make_point(3, 4)
@@ -4330,7 +4330,7 @@ fn main() {
 
 ### `tests/modules/use_selective.orus`
 ```orus
-use tests::modules::hello_module
+use tests.modules.hello_module
 
 fn main() {
     hello_module.greet()
@@ -4339,7 +4339,7 @@ fn main() {
 
 ### `tests/modules/cycles/cycle_a.orus`
 ```orus
-use tests::modules::cycles::cycle_b
+use tests.modules.cycles.cycle_b
 
 pub fn greet_a() {
     print("Hello from A")
@@ -4350,7 +4350,7 @@ fn main() {}
 
 ### `tests/modules/cycles/cycle_b.orus`
 ```orus
-use tests::modules::cycles::cycle_a
+use tests.modules.cycles.cycle_a
 
 pub fn greet_b() {
     print("Hello from B")
@@ -4361,7 +4361,7 @@ fn main() {}
 
 ### `tests/projects/cross_module_generics/src/main.orus`
 ```orus
-use src::util
+use src.util
 
 fn main() {
     print(util.identity<i32>(42))
@@ -4385,7 +4385,7 @@ pub fn greet() {
 
 ### `tests/projects/simple_project/src/main.orus`
 ```orus
-use src::helper::{greet}
+use src.helper::{greet}
 
 fn main() {
     greet()
@@ -4394,7 +4394,7 @@ fn main() {
 
 ### `tests/stdlib/datetime_module.orus`
 ```orus
-use std::datetime
+use std.datetime
 
 fn main() {
     let epoch = datetime.from_timestamp(0.0)
@@ -4424,7 +4424,7 @@ fn main() {
 
 ### `tests/stdlib/math_module.orus`
 ```orus
-use std::math
+use std.math
 
 fn main() {
     print(math.abs(-5.0))
@@ -4448,7 +4448,7 @@ fn main() {
 
 ### `tests/stdlib/random_module.orus`
 ```orus
-use std::random
+use std.random
 
 fn main() {
     print(random.randint(1, 10))

--- a/include/scanner.h
+++ b/include/scanner.h
@@ -53,7 +53,6 @@ typedef enum {
   TOKEN_NEWLINE,
 
   TOKEN_COLON,      // Add this for type annotations
-  TOKEN_DOUBLE_COLON,
 } TokenType;
 
 typedef struct {

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1356,7 +1356,7 @@ static void importStatement(Parser* parser, ASTNode** ast) {
 
     // Emit an error recommending the new `use` statement syntax
     errorAt(parser, &parser->previous,
-            "`import` statements are deprecated; use `use module::path` instead");
+            "`import` statements are deprecated; use `use module.path` instead");
 
     consumeStatementEnd(parser);
     *ast = createImportNode(path);
@@ -1376,9 +1376,9 @@ static void useStatement(Parser* parser, ASTNode** ast) {
     parts = realloc(parts, sizeof(ObjString*) * (partCount + 1));
     parts[partCount++] = allocateString(nameTok.start, nameTok.length);
 
-    while (check(parser, TOKEN_DOUBLE_COLON) && checkNext(TOKEN_IDENTIFIER)) {
-        advance(parser); // consume '::'
-        consume(parser, TOKEN_IDENTIFIER, "Expect identifier after '::'.");
+    while (check(parser, TOKEN_DOT) && checkNext(TOKEN_IDENTIFIER)) {
+        advance(parser); // consume '.'
+        consume(parser, TOKEN_IDENTIFIER, "Expect identifier after '.'.");
         Token t = parser->previous;
         parts = realloc(parts, sizeof(ObjString*) * (partCount + 1));
         parts[partCount++] = allocateString(t.start, t.length);
@@ -1392,10 +1392,6 @@ static void useStatement(Parser* parser, ASTNode** ast) {
     if (match(parser, TOKEN_AS)) {
         consume(parser, TOKEN_IDENTIFIER, "Expect alias after 'as'.");
         alias = allocateString(parser->previous.start, parser->previous.length);
-    } else if (match(parser, TOKEN_DOUBLE_COLON)) {
-        error(parser, "Only whole modules may be imported.");
-        // Consume the rest of the line for error recovery
-        while (!check(parser, TOKEN_NEWLINE) && !check(parser, TOKEN_EOF)) advance(parser);
     }
 
     // Build path string
@@ -1948,7 +1944,7 @@ ParseRule rules[] = {
     [TOKEN_MATCH] = {NULL, NULL, PREC_NONE},
     [TOKEN_USE] = {NULL, NULL, PREC_NONE},
     [TOKEN_AS] = {NULL, parseCast, PREC_COMPARISON},
-    [TOKEN_DOUBLE_COLON] = {NULL, NULL, PREC_NONE},
+    [TOKEN_COLON] = {NULL, NULL, PREC_NONE},
 };
 
 /**

--- a/src/scanner/scanner.c
+++ b/src/scanner/scanner.c
@@ -609,7 +609,6 @@ Token scan_token() {
             return make_token(TOKEN_BIT_XOR);
         case '"': return string();
         case ':':
-            if (match(':')) return make_token(TOKEN_DOUBLE_COLON);
             return make_token(TOKEN_COLON);
     }
 

--- a/tests/constants/use_module.orus
+++ b/tests/constants/use_module.orus
@@ -1,4 +1,4 @@
-use tests::constants::math
+use tests.constants.math
 
 fn main() {
     print("Value: {}", math.PI)

--- a/tests/edge_cases/function_module_edges.orus
+++ b/tests/edge_cases/function_module_edges.orus
@@ -1,5 +1,5 @@
-use tests::edge_cases::module_a
-use tests::edge_cases::module_b
+use tests.edge_cases.module_a
+use tests.edge_cases.module_b
 
 fn local_fn(a: i32, b: i32) -> i32 {
     return a + b

--- a/tests/edge_cases/module_imports.orus
+++ b/tests/edge_cases/module_imports.orus
@@ -1,5 +1,5 @@
-use tests::edge_cases::module_a
-use tests::edge_cases::module_b
+use tests.edge_cases.module_a
+use tests.edge_cases.module_b
 
 fn main() {
     // Modules are imported for side effects only

--- a/tests/errors/import_cycle.orus
+++ b/tests/errors/import_cycle.orus
@@ -1,4 +1,4 @@
-use tests::modules::cycles::cycle_a
+use tests.modules.cycles.cycle_a
 
 fn main() {
 }

--- a/tests/errors/import_missing.orus
+++ b/tests/errors/import_missing.orus
@@ -1,4 +1,4 @@
-use tests::modules::not_there
+use tests.modules.not_there
 
 fn main() {
 }

--- a/tests/errors/import_private.orus
+++ b/tests/errors/import_private.orus
@@ -1,4 +1,4 @@
-use tests::modules::pub_module
+use tests.modules.pub_module
 
 fn main() {
     private_fn()

--- a/tests/errors/import_twice.orus
+++ b/tests/errors/import_twice.orus
@@ -1,5 +1,5 @@
-use tests::modules::hello_module
-use tests::modules::hello_module
+use tests.modules.hello_module
+use tests.modules.hello_module
 
 fn main() {
     print("done")

--- a/tests/errors/missing_export.orus
+++ b/tests/errors/missing_export.orus
@@ -1,4 +1,4 @@
-use tests::modules::hello_module::{unknown}
+use tests.modules.hello_module::{unknown}
 
 fn main() {
 }

--- a/tests/errors/use_twice.orus
+++ b/tests/errors/use_twice.orus
@@ -1,5 +1,5 @@
-use tests::modules::hello_module
-use tests::modules::hello_module::{greet}
+use tests.modules.hello_module
+use tests.modules.hello_module::{greet}
 
 fn main() {
     greet()

--- a/tests/main/module_main.orus
+++ b/tests/main/module_main.orus
@@ -1,5 +1,5 @@
 // Test calling functions from main and importing modules
-use tests::modules::hello_module
+use tests.modules.hello_module
 
 fn main() {
     print("Main ran")

--- a/tests/modules/cycles/cycle_a.orus
+++ b/tests/modules/cycles/cycle_a.orus
@@ -1,4 +1,4 @@
-use tests::modules::cycles::cycle_b
+use tests.modules.cycles.cycle_b
 
 pub fn greet_a() {
     print("Hello from A")

--- a/tests/modules/cycles/cycle_b.orus
+++ b/tests/modules/cycles/cycle_b.orus
@@ -1,4 +1,4 @@
-use tests::modules::cycles::cycle_a
+use tests.modules.cycles.cycle_a
 
 pub fn greet_b() {
     print("Hello from B")

--- a/tests/modules/parse_use_alias.orus
+++ b/tests/modules/parse_use_alias.orus
@@ -1,4 +1,4 @@
-use tests::modules::hello_module as hm
+use tests.modules.hello_module as hm
 
 fn main() {
     print("alias parsed")

--- a/tests/modules/parse_use_module.orus
+++ b/tests/modules/parse_use_module.orus
@@ -1,4 +1,4 @@
-use tests::modules::hello_module
+use tests.modules.hello_module
 
 fn main() {
     print("module parsed")

--- a/tests/modules/parse_use_selective.orus
+++ b/tests/modules/parse_use_selective.orus
@@ -1,4 +1,4 @@
-use tests::modules::hello_module
+use tests.modules.hello_module
 
 fn main() {
     print("select parsed")

--- a/tests/modules/use_bind.orus
+++ b/tests/modules/use_bind.orus
@@ -1,4 +1,4 @@
-use tests::modules::hello_module
+use tests.modules.hello_module
 
 fn main() {
     hello_module.greet()

--- a/tests/modules/use_pub_function.orus
+++ b/tests/modules/use_pub_function.orus
@@ -1,4 +1,4 @@
-use tests::modules::pub_module
+use tests.modules.pub_module
 
 fn main() {
     pub_module.public_fn()

--- a/tests/modules/use_pub_struct.orus
+++ b/tests/modules/use_pub_struct.orus
@@ -1,4 +1,4 @@
-use tests::modules::pub_struct_module
+use tests.modules.pub_struct_module
 
 fn main() {
     let p = pub_struct_module.make_point(3 as i32, 4 as i32)

--- a/tests/modules/use_selective.orus
+++ b/tests/modules/use_selective.orus
@@ -1,4 +1,4 @@
-use tests::modules::hello_module
+use tests.modules.hello_module
 
 fn main() {
     hello_module.greet()

--- a/tests/projects/cross_module_generics/src/main.orus
+++ b/tests/projects/cross_module_generics/src/main.orus
@@ -1,4 +1,4 @@
-use src::util
+use src.util
 
 fn main() {
     print(util.identity<i32>(42 as i32))

--- a/tests/projects/simple_project/src/main.orus
+++ b/tests/projects/simple_project/src/main.orus
@@ -1,4 +1,4 @@
-use src::helper::{greet}
+use src.helper::{greet}
 
 fn main() {
     greet()

--- a/tests/stdlib/datetime_module.orus
+++ b/tests/stdlib/datetime_module.orus
@@ -1,4 +1,4 @@
-use std::datetime
+use std.datetime
 
 fn main() {
     let epoch = datetime.from_timestamp(0.0)

--- a/tests/stdlib/math_module.orus
+++ b/tests/stdlib/math_module.orus
@@ -1,4 +1,4 @@
-use std::math
+use std.math
 
 fn main() {
     print(math.abs(-5.0))

--- a/tests/stdlib/random_module.orus
+++ b/tests/stdlib/random_module.orus
@@ -1,4 +1,4 @@
-use std::random
+use std.random
 
 fn main() {
     print(random.randint(1 as i32, 10 as i32))


### PR DESCRIPTION
## Summary
- implement lexer and parser changes for `use` paths
- convert tests and docs to new `use module.path` style
- mark progress in `MODULE_IMPORT_REDESIGN.md`