### PR TITLE
Investigate failing tests

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -28,7 +28,6 @@ typedef struct {
     Token previous;
     bool hadError;
     bool panicMode;
-    Scanner* scanner;
     int functionDepth; // Track nested function declarations
     Type* currentImplType; // Track struct type for methods
     ObjString** genericParams;
@@ -49,7 +48,7 @@ typedef struct {
     Precedence precedence;
 } ParseRule;
 
-void initParser(Parser* parser, Scanner* scanner, const char* filePath);
+void initParser(Parser* parser, const char* filePath);
 bool parse(const char* source, const char* filePath, ASTNode** ast);
 ParseRule* get_rule(TokenType type);
 


### PR DESCRIPTION
## Summary
- correct newline handling in grouping and ternary expressions
- fix generic lookahead logic to align with the new 2-token buffer

## Testing
- `make orusc`
- `tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860f31f8a788325aec4e36ac0253265