### PR TITLE
Remove unused parser helpers and fix path warning

### DIFF
--- a/include/memory.h
+++ b/include/memory.h
@@ -80,6 +80,11 @@
 // Allocates memory for a new object of a given type. It takes the type of the
 void* reallocate(void* pointer, size_t oldSize, size_t newSize);
 
+// Allocate memory and abort on failure
+void* checkedMalloc(size_t size);
+// Reallocate memory and abort on failure (size==0 frees)
+void* checkedRealloc(void* pointer, size_t newSize);
+
 
 // Allocate a new string object copying the given characters
 ObjString* allocateString(const char* str, int length);

--- a/src/vm/memory.c
+++ b/src/vm/memory.c
@@ -4,6 +4,7 @@
  */
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "../../include/memory.h"
 #include "../../include/vm.h"
@@ -28,6 +29,28 @@ void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
 
     void* result = realloc(pointer, newSize);
     if (result == NULL) exit(1);
+    return result;
+}
+
+void* checkedMalloc(size_t size) {
+    void* ptr = malloc(size);
+    if (!ptr && size > 0) {
+        fprintf(stderr, "Out of memory allocating %zu bytes\n", size);
+        exit(1);
+    }
+    return ptr;
+}
+
+void* checkedRealloc(void* pointer, size_t newSize) {
+    if (newSize == 0) {
+        free(pointer);
+        return NULL;
+    }
+    void* result = realloc(pointer, newSize);
+    if (!result) {
+        fprintf(stderr, "Out of memory reallocating to %zu bytes\n", newSize);
+        exit(1);
+    }
     return result;
 }
 


### PR DESCRIPTION
## Summary
- remove obsolete arena allocator functions from `parser.c`
- drop unused token helpers from parser
- allocate full path dynamically in `search_for_main`
- add `checkedMalloc` and `checkedRealloc` helpers for safer allocation
- use checked allocation in parser and driver code