### PR TITLE
Add SemVer versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,15 @@ Results are automatically logged and tracked for performance trend analysis.
 
 ---
 
+## 📦 Versioning
+
+Orus follows [Semantic Versioning 2.0.0](docs/VERSIONING.md) to clearly
+communicate API stability and compatibility. The current release is
+`v0.1.0`, which indicates that the language is still in early
+development and the public API may change at any time.
+
+---
+
 ## 🎓 Learn More
 
 - **[Complete Orus Tutorial](docs/COMPLETE_ORUS_TUTORIAL.md)** - 📚 Ultimate comprehensive guide covering every feature

--- a/docs/IMPLEMENTATION_GUIDE.md
+++ b/docs/IMPLEMENTATION_GUIDE.md
@@ -5198,3 +5198,7 @@ This enhanced IMPLEMENTATION_GUIDE.md now includes cutting-edge optimization tec
 
 This comprehensive roadmap consolidates all documentation into a single reference, providing clear implementation details, code signatures, and priorities for building Orus into a world-class programming language.\n### Recent Updates\n- Added compiler support for `f64` arithmetic operations and literals.
 - Implemented basic `u32` arithmetic and literals.
+
+### Versioning
+
+All Orus releases adhere to [Semantic Versioning 2.0.0](VERSIONING.md). The header `include/version.h` defines `ORUS_VERSION_MAJOR`, `ORUS_VERSION_MINOR`, and `ORUS_VERSION_PATCH` macros that encode the interpreter version. The `showVersion()` helper in `src/main.c` prints this version information for command line users.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,19 @@
+# Orus Versioning
+
+Orus uses **Semantic Versioning 2.0.0** to signal compatibility guarantees.
+Versions follow the `MAJOR.MINOR.PATCH` format with optional pre-release and
+build metadata.
+
+- **MAJOR** version increments when incompatible language or API changes are
+  introduced.
+- **MINOR** version increments when new, backwards compatible functionality is
+  added.
+- **PATCH** version increments for backwards compatible bug fixes.
+
+Pre-release identifiers (e.g. `1.0.0-alpha`) mark unstable releases and have
+lower precedence than the associated stable version. Build metadata may be
+appended with a plus sign (e.g. `1.0.0+20130313144700`) and is ignored when
+comparing versions.
+
+The current Orus version is **0.1.0**, indicating active initial development.
+No stability guarantees are made while the major version is zero.

--- a/include/version.h
+++ b/include/version.h
@@ -1,0 +1,10 @@
+#ifndef ORUS_VERSION_H
+#define ORUS_VERSION_H
+
+#define ORUS_VERSION_MAJOR 0
+#define ORUS_VERSION_MINOR 1
+#define ORUS_VERSION_PATCH 0
+
+#define ORUS_VERSION_STRING "0.1.0"
+
+#endif // ORUS_VERSION_H

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@
 #include "common.h"
 #include "compiler.h"
 #include "repl.h"
+#include "version.h"
 
 
 static char* readFile(const char* path) {
@@ -89,7 +90,7 @@ static void showUsage(const char* program) {
 }
 
 static void showVersion() {
-    printf("Orus Language Interpreter v0.1.0\n");
+    printf("Orus Language Interpreter v%s\n", ORUS_VERSION_STRING);
     printf("Built with register-based virtual machine\n");
 }
 


### PR DESCRIPTION
## Summary
- document Semantic Versioning in `docs/VERSIONING.md`
- mention versioning approach in README and implementation guide
- provide `include/version.h` with version macros
- use version macros in `src/main.c`