### PR TITLE
Add comprehensive arithmetic type tests

### DIFF
--- a/docs/TEST_CATEGORIZATION.md
+++ b/docs/TEST_CATEGORIZATION.md
@@ -1,0 +1,15 @@
+# Orus Test Categorization
+
+This document outlines the canonical directory structure for Orus tests and the purpose of each category. All new tests must be placed in the appropriate directory and referenced from the makefile.
+
+| Directory | Purpose |
+|-----------|---------|
+| `tests/types/` | Valid type system behaviors and examples that compile and run. |
+| `tests/type_safety_fails/` | Programs that should fail to compile due to type errors. |
+| `tests/edge_cases/` | Runtime error cases and boundary value tests such as overflow or division by zero. |
+| `tests/expressions/` | Basic expression parsing and evaluation examples. |
+| `tests/literals/` | Literal parsing and printing. |
+| `tests/variables/` | Variable declarations and assignment semantics. |
+| `tests/benchmarks/` | Performance benchmarks. |
+
+All tests added in this repository should follow these categories. When introducing a new directory, update this file and the makefile accordingly.

--- a/makefile
+++ b/makefile
@@ -119,7 +119,11 @@ test: $(ORUS)
                           $(TESTDIR)/types/not_on_int_fail.orus \
                           $(TESTDIR)/types/type_rule_simple_pass.orus \
                           $(TESTDIR)/types/type_rule_complex_pass.orus \
-                          $(TESTDIR)/types/type_rule_edge_pass.orus; do \
+                          $(TESTDIR)/types/type_rule_edge_pass.orus \
+                          $(TESTDIR)/types/arithmetic_same_types_v2.orus \
+                          $(TESTDIR)/types/explicit_cast_arithmetic.orus \
+                          $(TESTDIR)/types/complex_expression_with_casts.orus \
+                          $(TESTDIR)/types/cross_type_comparison.orus; do \
 		if [ -f "$$test_file" ]; then \
 			printf "Testing: $$test_file ... "; \
 			if ./$(ORUS) "$$test_file" >/dev/null 2>&1; then \
@@ -143,7 +147,10 @@ test: $(ORUS)
                           $(TESTDIR)/type_safety_fails/minus_on_bool_fail.orus \
                           $(TESTDIR)/type_safety_fails/type_rule_simple_fail.orus \
                           $(TESTDIR)/type_safety_fails/type_rule_complex_fail.orus \
-                          $(TESTDIR)/type_safety_fails/type_rule_edge_fail.orus; do \
+                          $(TESTDIR)/type_safety_fails/type_rule_edge_fail.orus \
+                          $(TESTDIR)/type_safety_fails/mixed_type_operations_fail.orus \
+                          $(TESTDIR)/type_safety_fails/implicit_widening_fail.orus \
+                          $(TESTDIR)/type_safety_fails/chained_mixed_ops_fail.orus; do \
 		if [ -f "$$test_file" ]; then \
 			printf "Testing: $$test_file ... "; \
 			if ./$(ORUS) "$$test_file" >/dev/null 2>&1; then \
@@ -160,8 +167,9 @@ test: $(ORUS)
 	for test_file in $(TESTDIR)/edge_cases/arithmetic_edge_cases.orus \
 	                  $(TESTDIR)/edge_cases/operator_precedence.orus \
 	                  $(TESTDIR)/edge_cases/boundary_values.orus \
-	                  $(TESTDIR)/edge_cases/error_conditions.orus \
-	                  $(TESTDIR)/edge_cases/modulo_overflow_test.orus; do \
+                          $(TESTDIR)/edge_cases/error_conditions.orus \
+                          $(TESTDIR)/edge_cases/modulo_overflow_test.orus \
+                          $(TESTDIR)/edge_cases/overflow_i32_plus_one.orus; do \
 		if [ -f "$$test_file" ]; then \
 			printf "Testing: $$test_file ... "; \
 			if ./$(ORUS) "$$test_file" >/dev/null 2>&1; then \
@@ -248,8 +256,9 @@ test: $(ORUS)
 	echo "\033[36m=== Division by Zero Tests (Expected to Fail) ===\033[0m"; \
 	for test_file in $(TESTDIR)/edge_cases/modulo_by_zero_test.orus \
 	                  $(TESTDIR)/edge_cases/large_number_modulo_by_zero.orus \
-	                  $(TESTDIR)/edge_cases/expression_modulo_by_zero.orus \
-	                  $(TESTDIR)/edge_cases/division_by_zero_enhanced.orus; do \
+                          $(TESTDIR)/edge_cases/expression_modulo_by_zero.orus \
+                          $(TESTDIR)/edge_cases/division_by_zero_enhanced.orus \
+                          $(TESTDIR)/edge_cases/division_by_zero_runtime.orus; do \
 		if [ -f "$$test_file" ]; then \
 			printf "Testing: $$test_file ... "; \
 			if ./$(ORUS) "$$test_file" >/dev/null 2>&1; then \

--- a/tests/edge_cases/division_by_zero_runtime.orus
+++ b/tests/edge_cases/division_by_zero_runtime.orus
@@ -1,0 +1,7 @@
+// Division by zero should trigger a runtime error
+// Expected: runtime error when executing
+
+x: i32 = 10
+y: i32 = 0
+print(x / y)
+print("this should not print")

--- a/tests/edge_cases/overflow_i32_plus_one.orus
+++ b/tests/edge_cases/overflow_i32_plus_one.orus
@@ -1,0 +1,5 @@
+// Overflowing i32 addition should be detected
+// Expected: runtime error or compilation failure due to overflow
+
+a: i32 = 2147483647
+print(a + 1)

--- a/tests/type_safety_fails/chained_mixed_ops_fail.orus
+++ b/tests/type_safety_fails/chained_mixed_ops_fail.orus
@@ -1,0 +1,7 @@
+// Chained mixed-type operations without casts should fail
+// Expected: compilation error
+
+a: i32 = 1
+b: f64 = 2.0
+c: i64 = 3
+print(a + b + c)

--- a/tests/type_safety_fails/implicit_widening_fail.orus
+++ b/tests/type_safety_fails/implicit_widening_fail.orus
@@ -1,0 +1,7 @@
+// Implicit widening from i32 to i64 should not be allowed
+// Expected: compilation error
+
+x: i32 = 5
+y: i64 = 100
+z = x + y
+print(z)

--- a/tests/type_safety_fails/mixed_type_operations_fail.orus
+++ b/tests/type_safety_fails/mixed_type_operations_fail.orus
@@ -1,0 +1,6 @@
+// Mixed numeric types without casting should fail to compile
+// Expected: compilation error
+
+a: i32 = 10
+b: f64 = 2.5
+print(a + b)

--- a/tests/types/arithmetic_same_types_v2.orus
+++ b/tests/types/arithmetic_same_types_v2.orus
@@ -1,0 +1,14 @@
+// Arithmetic with same numeric types should compile and run
+// Expected: compile and run successfully
+
+a: i32 = 10
+b: i32 = 20
+print(a + b)
+
+x: f64 = 2.5
+y: f64 = 4.0
+print(x * y)
+
+u: i64 = 1000i64
+t: i64 = 500i64
+print(u - t)

--- a/tests/types/complex_expression_with_casts.orus
+++ b/tests/types/complex_expression_with_casts.orus
@@ -1,0 +1,7 @@
+// Complex expression with explicit casts
+// Expected: compile and run successfully
+
+a: i32 = 5
+b: f64 = 3.5
+c = (a as f64) * b + 2.0
+print(c)

--- a/tests/types/cross_type_comparison.orus
+++ b/tests/types/cross_type_comparison.orus
@@ -1,0 +1,6 @@
+// Cross-type comparison requires explicit cast
+// Expected: compile and run successfully
+
+x: i32 = 10
+y: f64 = 10.0
+print((x as f64) - y)

--- a/tests/types/explicit_cast_arithmetic.orus
+++ b/tests/types/explicit_cast_arithmetic.orus
@@ -1,0 +1,7 @@
+// Explicit casting should allow mixed-type arithmetic
+// Expected: compile and run successfully
+
+x: i32 = 5
+y: i64 = 100i64
+z = (x as i64) + y
+print(z)


### PR DESCRIPTION
## Summary
- create `docs/TEST_CATEGORIZATION.md` describing test directories
- extend `makefile` to run new arithmetic and type safety tests
- add strict arithmetic tests and edge case programs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6873b71663a083258a6aea6fda0d6de8