### PR TITLE
Add VM profiling infrastructure

### DIFF
--- a/docs/IMPLEMENTATION_GUIDE.md
+++ b/docs/IMPLEMENTATION_GUIDE.md
@@ -4398,6 +4398,15 @@ TIMED_SECTION(parse, {
 });
 ```
 
+```c
+// VM instruction profiling
+#ifdef VM_ENABLE_PROFILING
+#define PROFILE_INC(op) (vm.profile.instruction_counts[(op)]++)
+#else
+#define PROFILE_INC(op) ((void)0)
+#endif
+```
+
 ---
 
 ## 🚀 Implementation Priorities

--- a/docs/VM_REFACTOR_ROADMAP.md
+++ b/docs/VM_REFACTOR_ROADMAP.md
@@ -26,7 +26,7 @@ This roadmap tracks progress of the virtual machine refactoring work. It follows
 - [x] Introduce rope data structure and interning
 
 ## Phase 5 – Performance and Maintainability Enhancements
-- [ ] Add profiling infrastructure
+- [x] Add profiling infrastructure
 - [ ] Add validation functions
 - [ ] Improve documentation for public APIs
 

--- a/include/debug.h
+++ b/include/debug.h
@@ -7,5 +7,6 @@
 // Debug function declarations
 void disassembleChunk(Chunk* chunk, const char* name);
 int disassembleInstruction(Chunk* chunk, int offset);
+void dumpProfile(void);
 
 #endif

--- a/include/vm.h
+++ b/include/vm.h
@@ -800,6 +800,11 @@ typedef enum {
     REG_TYPE_HEAP
 } RegisterType;
 
+// Profiling counters
+typedef struct {
+    uint64_t instruction_counts[VM_DISPATCH_TABLE_SIZE];
+} VMProfile;
+
 // VM state
 typedef struct {
     // Registers (traditional boxed)
@@ -858,6 +863,8 @@ typedef struct {
     int currentColumn;
 
     double lastExecutionTime;
+
+    VMProfile profile;
 
     // Configuration
     bool trace;

--- a/src/vm/debug.c
+++ b/src/vm/debug.c
@@ -1,6 +1,7 @@
 // debug.c - Debug utilities for the VM
 #include "../../include/debug.h"
 #include "../../include/common.h"
+#include "../../include/vm_constants.h"
 #include <stdio.h>
 
 void disassembleChunk(Chunk* chunk, const char* name) {
@@ -283,5 +284,15 @@ int disassembleInstruction(Chunk* chunk, int offset) {
         default:
             printf("Unknown opcode %d\n", instruction);
             return offset + 1;
+    }
+}
+
+void dumpProfile(void) {
+    printf("=== VM Instruction Profile ===\n");
+    for (int i = 0; i < VM_DISPATCH_TABLE_SIZE; i++) {
+        if (vm.profile.instruction_counts[i] > 0) {
+            printf("%3d: %llu\n", i,
+                   (unsigned long long)vm.profile.instruction_counts[i]);
+        }
     }
 }

--- a/src/vm/vm_core.c
+++ b/src/vm/vm_core.c
@@ -4,6 +4,7 @@
 #include "memory.h"
 #include "vm_string_ops.h"
 #include "type.h"
+#include <string.h>
 
 VM vm; // Global VM instance
 
@@ -46,6 +47,7 @@ void initVM(void) {
     vm.nativeFunctionCount = 0;
     vm.gcCount = 0;
     vm.lastExecutionTime = 0.0;
+    memset(&vm.profile, 0, sizeof(VMProfile));
 
     vm.openUpvalues = NULL;
 

--- a/src/vm/vm_dispatch_switch.c
+++ b/src/vm/vm_dispatch_switch.c
@@ -43,6 +43,7 @@ InterpretResult vm_run_dispatch(void) {
             vm.instruction_count++;
 
             uint8_t instruction = READ_BYTE();
+            PROFILE_INC(instruction);
 
             switch (instruction) {
                 case OP_LOAD_CONST: {


### PR DESCRIPTION
## Summary
- implement basic profiling counters in the VM
- instrument dispatch macros to update instruction counts
- expose `dumpProfile()` in debug utilities
- initialize profiling data in `initVM`
- mark profiling task complete in roadmap
- document profiling macros in the implementation guide

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6873ea8eb2988325a87b2ca732a0b31f