### PR TITLE
Fix debug prints and register type in VM components

### DIFF
--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -44,8 +44,7 @@ InterpretResult vm_run_dispatch(void) {
                     printValue(vm_get_register_safe(i));
                     DEBUG_VM_PRINT(" ]");
                 }
-                DEBUG_VM_PRINT("
-");
+                DEBUG_VM_PRINT("\n");
 
                 disassembleInstruction(vm.chunk, (int)(vm.ip - vm.chunk->code));
             }
@@ -1550,8 +1549,7 @@ InterpretResult vm_run_dispatch(void) {
 
                 // Function operations
                 case OP_CALL_R: {
-                    DEBUG_VM_PRINT("OP_CALL_R executed
-");
+                    DEBUG_VM_PRINT("OP_CALL_R executed");
                     uint8_t funcReg = READ_BYTE();
                     uint8_t firstArgReg = READ_BYTE();
                     uint8_t argCount = READ_BYTE();
@@ -1641,8 +1639,7 @@ InterpretResult vm_run_dispatch(void) {
                             frame->savedRegisters[i] = vm_get_register_safe(FRAME_REG_START + i);
                             // Debug: Print saved values for first few registers
                             if (i < 8) {
-                                DEBUG_VM_PRINT("SAVE FRAME R%d (type=%d)
-", FRAME_REG_START + i, vm_get_register_safe(FRAME_REG_START + i).type);
+                                DEBUG_VM_PRINT("SAVE FRAME R%d (type=%d)", FRAME_REG_START + i, vm_get_register_safe(FRAME_REG_START + i).type);
                                 if (vm_get_register_safe(FRAME_REG_START + i).type == VALUE_I32) {
                                     DEBUG_VM_PRINT("  value = %d\n", AS_I32(vm_get_register_safe(FRAME_REG_START + i)));
                                 }
@@ -1654,8 +1651,7 @@ InterpretResult vm_run_dispatch(void) {
                             frame->savedRegisters[64 + i] = vm_get_register_safe(temp_reg_start + i);
                             // Debug: Print saved temp register values for first few
                             if (i < 8) {
-                                DEBUG_VM_PRINT("SAVE TEMP R%d (type=%d)
-", temp_reg_start + i, vm_get_register_safe(temp_reg_start + i).type);
+                                DEBUG_VM_PRINT("SAVE TEMP R%d (type=%d)", temp_reg_start + i, vm_get_register_safe(temp_reg_start + i).type);
                                 if (vm_get_register_safe(temp_reg_start + i).type == VALUE_I32) {
                                     DEBUG_VM_PRINT("  value = %d\n", AS_I32(vm_get_register_safe(temp_reg_start + i)));
                                 }
@@ -1773,11 +1769,9 @@ InterpretResult vm_run_dispatch(void) {
                             vm_set_register_safe(FRAME_REG_START + i, frame->savedRegisters[i]);
                             // Debug: Print restored values for first few registers
                             if (i < 8) {
-                                DEBUG_VM_PRINT("RESTORE R%d (type=%d)
-", FRAME_REG_START + i, frame->savedRegisters[i].type);
+                                DEBUG_VM_PRINT("RESTORE R%d (type=%d)", FRAME_REG_START + i, frame->savedRegisters[i].type);
                                 if (frame->savedRegisters[i].type == VALUE_I32) {
-                                    DEBUG_VM_PRINT("  value = %d
-", AS_I32(vm_get_register_safe(FRAME_REG_START + i)));
+                                    DEBUG_VM_PRINT("  value = %d", AS_I32(vm_get_register_safe(FRAME_REG_START + i)));
                                 }
                             }
                         }
@@ -1804,11 +1798,9 @@ InterpretResult vm_run_dispatch(void) {
                             vm_set_register_safe(FRAME_REG_START + i, frame->savedRegisters[i]);
                             // Debug: Print restored values for first few registers
                             if (i < 8) {
-                                DEBUG_VM_PRINT("RESTORE R%d (type=%d)
-", FRAME_REG_START + i, frame->savedRegisters[i].type);
+                                DEBUG_VM_PRINT("RESTORE R%d (type=%d)", FRAME_REG_START + i, frame->savedRegisters[i].type);
                                 if (frame->savedRegisters[i].type == VALUE_I32) {
-                                    DEBUG_VM_PRINT("  value = %d
-", AS_I32(vm_get_register_safe(FRAME_REG_START + i)));
+                                    DEBUG_VM_PRINT("  value = %d", AS_I32(vm_get_register_safe(FRAME_REG_START + i)));
                                 }
                             }
                         }

--- a/src/vm/handlers/vm_control_flow_handlers.c
+++ b/src/vm/handlers/vm_control_flow_handlers.c
@@ -14,7 +14,7 @@
 #include "vm/vm_control_flow.h"
 
 // Ensure correct return type is known to the compiler
-extern Value vm_get_register_safe(uint8_t reg);
+extern Value vm_get_register_safe(uint16_t reg);
 
 // ====== Jump Operation Handlers ======
 

--- a/src/vm/profiling/vm_profiling.c
+++ b/src/vm/profiling/vm_profiling.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 199309L
 #include "vm/vm_profiling.h"
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Summary
- fix unterminated debug strings in switch-based VM dispatcher
- ensure control flow handlers use 16-bit register indices
- enable clock_gettime in profiling by defining `_POSIX_C_SOURCE`

## Testing
- `make test` *(fails: 76 failed, 38 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b77c563c8325b0283f5ab53e159c