### PR TITLE
feat: add closure capture and update roadmaps

### DIFF
--- a/docs/COMPILER_IMPLEMENTATION_PLAN.md
+++ b/docs/COMPILER_IMPLEMENTATION_PLAN.md
@@ -13,6 +13,7 @@ This document outlines the detailed implementation plan for building the Orus co
 - **TypedAST Visualization**: `src/compiler/backend/typed_ast_visualizer.c`
 - **VM Target**: 256-register VM with comprehensive instruction set
 - **Integration Points**: Pipeline hooks in `src/vm/runtime/vm.c`
+- **Closure Support**: Upvalue capture and closure creation for nested functions
 
 #### ✅ **What's Now Implemented**
 - **✅ Optimization Pass**: `src/compiler/backend/optimization/optimizer.c` + `constantfold.c`
@@ -32,7 +33,7 @@ This document outlines the detailed implementation plan for building the Orus co
 **CRITICAL LANGUAGE FEATURES (HIGH PRIORITY)**
 - **✅ Expression Types**: ✅ Binary ops (+,-,*,/,%), ✅ comparisons (<,>,<=,>=,==,!=), ✅ logical (and,or,not), unary ops (-,not,++) (COMPLETED)
 - **✅ Control Flow**: ✅ if/elif/else statements (COMPLETED), ✅ while loops with break/continue (COMPLETED), ❌ for loops, match statements
-- **Functions**: fn definitions, calls, parameters, return statements, recursion
+- **Functions**: fn definitions, calls, parameters, return statements, recursion, closures with upvalue capture
 - **✅ Data Types**: ✅ String literals, all numeric types (i32), ✅ booleans (COMPLETED)
 - **✅ Variable System**: ✅ Mutable/immutable declarations, ✅ proper scoping and identifier resolution (COMPLETED)
 

--- a/docs/MISSING.md
+++ b/docs/MISSING.md
@@ -406,7 +406,7 @@ fn greet(name: string):
 - [x] **COMPLETE**: Support for 250+ function parameters ✅
 - [x] **COMPLETE**: Function objects as first-class values ✅
 - [x] **COMPLETE**: Higher-order functions (functions as parameters/return values) ✅
-- [ ] **IN PROGRESS**: Closure capture and upvalues 🔧
+- [x] **COMPLETE**: Closure capture and upvalues ✅
 - [ ] **NEXT**: Lambda/anonymous function syntax
 - [ ] **NEXT**: Generic constraints for higher-order functions
 
@@ -456,7 +456,7 @@ fn applyTwice(func, value):
 addFunc = add
 result = addFunc(5, 3)
 
-// 🔧 IN PROGRESS: Closure capture
+// ✅ WORKING: Closure capture
 fn makeCounter(start):
     count = start
     

--- a/include/compiler/compiler.h
+++ b/include/compiler/compiler.h
@@ -56,6 +56,12 @@ typedef struct JumpPatch {
     int target_label;          // Label to patch to
 } JumpPatch;
 
+// Upvalue capture information for closures
+typedef struct {
+    bool isLocal;   // Captured variable comes from enclosing function's locals
+    uint8_t index;  // Register index or upvalue slot in enclosing function
+} UpvalueInfo;
+
 // Main compilation context for multi-pass compiler
 typedef struct CompilerContext {
     TypedASTNode* input_ast;           // Input from HM type inference
@@ -79,9 +85,10 @@ typedef struct CompilerContext {
     // Error handling (TODO: implement in Phase 2)
     ErrorReporter* errors;             // Compilation error tracking
     bool has_compilation_errors;       // Track if any compilation errors occurred
-    
+
     // Function compilation context
     bool compiling_function;           // Are we currently compiling inside a function?
+    int function_scope_depth;          // Scope depth of current function's root
     
     // Debugging
     bool enable_visualization;         // Show TypedAST between passes
@@ -107,6 +114,11 @@ typedef struct CompilerContext {
     int* function_arities;             // Arities for each function
     int function_count;                // Number of functions compiled
     int function_capacity;             // Capacity of function_chunks array
+
+    // Closure compilation context
+    UpvalueInfo* upvalues;             // Captured variables for current function
+    int upvalue_count;                 // Number of captured upvalues
+    int upvalue_capacity;              // Capacity of upvalues array
 } CompilerContext;
 
 // Bytecode emission functions

--- a/src/compiler/backend/compiler.c
+++ b/src/compiler/backend/compiler.c
@@ -206,10 +206,11 @@ CompilerContext* init_compiler_context(TypedASTNode* typed_ast) {
     ctx->symbols = create_symbol_table(NULL);  // Global scope
     
     // TODO: Initialize these in later phases
-    ctx->scopes = NULL;       // Will implement in Phase 2  
+    ctx->scopes = NULL;       // Will implement in Phase 2
     ctx->errors = NULL;       // Will implement in Phase 2
     ctx->has_compilation_errors = false;  // Initialize error tracking
     ctx->compiling_function = false;      // Initialize function compilation flag
+    ctx->function_scope_depth = ctx->symbols->scope_depth; // Track function root depth
     ctx->opt_ctx = NULL;      // Will implement in Phase 2
     
     // Initialize loop control context
@@ -229,6 +230,11 @@ CompilerContext* init_compiler_context(TypedASTNode* typed_ast) {
     ctx->function_arities = NULL;        // No function arities yet
     ctx->function_count = 0;
     ctx->function_capacity = 0;
+
+    // Initialize closure context
+    ctx->upvalues = NULL;
+    ctx->upvalue_count = 0;
+    ctx->upvalue_capacity = 0;
     
     if (!ctx->allocator || !ctx->dual_allocator || !ctx->bytecode || !ctx->constants || !ctx->symbols) {
         free_compiler_context(ctx);
@@ -443,6 +449,10 @@ void free_compiler_context(CompilerContext* ctx) {
     // Free function arities array
     if (ctx->function_arities) {
         free(ctx->function_arities);
+    }
+
+    if (ctx->upvalues) {
+        free(ctx->upvalues);
     }
     
     // Note: Don't free input_ast - it's owned by caller


### PR DESCRIPTION
## Summary
- track and resolve upvalues during compilation with new `UpvalueInfo` context
- generate closures and upvalue access bytecode for nested functions
- update project roadmaps to reflect completed closure support
- prevent block-local variables from being misclassified as upvalues