### PR TITLE
Improve variable diagnostics and friendly error coverage

### DIFF
--- a/include/compiler/symbol_table.h
+++ b/include/compiler/symbol_table.h
@@ -19,13 +19,18 @@ typedef struct Symbol {
     bool is_mutable;                // Can be reassigned (mut vs immutable)
     bool is_initialized;            // Has been assigned a value
     bool is_arithmetic_heavy;       // Used in arithmetic operations frequently
-    
+
     // Symbol table management
     struct Symbol* next;            // Hash table collision chain
-    
+
     // Optimization hints
     int usage_count;                // Number of times symbol is accessed
     bool is_loop_variable;          // Used as loop induction variable
+
+    // Lifecycle tracking
+    SrcLocation declaration_location;   // Where the symbol was declared
+    SrcLocation last_assignment_location;// Most recent assignment location
+    bool has_been_read;                 // Has the value been read from
 } Symbol;
 
 // Simple hash table symbol table
@@ -42,10 +47,12 @@ SymbolTable* create_symbol_table(SymbolTable* parent);
 void free_symbol_table(SymbolTable* table);
 
 // Symbol management - DUAL REGISTER SYSTEM
-Symbol* declare_symbol_with_allocation(SymbolTable* table, const char* name, Type* type, 
-                                      bool is_mutable, struct RegisterAllocation* reg_alloc);
-Symbol* declare_symbol_legacy(SymbolTable* table, const char* name, Type* type, 
-                             bool is_mutable, int register_id);  // Compatibility
+Symbol* declare_symbol_with_allocation(SymbolTable* table, const char* name, Type* type,
+                                      bool is_mutable, struct RegisterAllocation* reg_alloc,
+                                      SrcLocation location, bool is_initialized);
+Symbol* declare_symbol_legacy(SymbolTable* table, const char* name, Type* type,
+                             bool is_mutable, int register_id,
+                             SrcLocation location, bool is_initialized);  // Compatibility
 Symbol* resolve_symbol(SymbolTable* table, const char* name);
 Symbol* resolve_symbol_local_only(SymbolTable* table, const char* name);
 

--- a/tests/error_reporting/cases.json
+++ b/tests/error_reporting/cases.json
@@ -91,6 +91,49 @@
     ]
   },
   {
+    "name": "variable_redefinition",
+    "source": "variable_redefinition.orus",
+    "description": "Declaring the same variable twice in one scope should report a redefinition error.",
+    "expected_exit": 65,
+    "expected_diagnostic_count": 1,
+    "expected_diagnostics": [
+      {
+        "title": "This variable name is already taken",
+        "message_contains": "already defined on line",
+        "help_contains": "Choose a different name",
+        "note_contains": "Each variable can only be declared once"
+      }
+    ],
+    "expected": [
+      "-- SYNTAX ERROR: This variable name is already taken",
+      "Variable 'value' is already defined on line 2",
+      "help: Choose a different name for this variable, or use assignment to change the existing one.",
+      "note: Each variable can only be declared once in the same scope.",
+      "Compilation failed for \"tests/error_reporting/variable_redefinition.orus\"."
+    ]
+  },
+  {
+    "name": "variable_scope_violation",
+    "source": "variable_scope_violation.orus",
+    "description": "Referencing a block-local variable outside of its scope should surface an undefined-variable diagnostic.",
+    "expected_exit": 65,
+    "expected_diagnostic_count": 1,
+    "expected_diagnostics": [
+      {
+        "title": "Can't find this variable",
+        "message_contains": "Undefined variable 'temp'",
+        "help_contains": "Make sure you've declared the variable before using it"
+      }
+    ],
+    "expected": [
+      "-- SYNTAX ERROR: Can't find this variable",
+      "Undefined variable 'temp'. Variables must be declared before use.",
+      "help: Make sure you've declared the variable before using it, or check the spelling.",
+      "note: Variables must be declared before they can be used in Orus.",
+      "Compilation failed for \"tests/error_reporting/variable_scope_violation.orus\"."
+    ]
+  },
+  {
     "name": "function_argument_mismatch",
     "source": "function_argument_mismatch.orus",
     "description": "Calling a function with the wrong number of arguments should emit a type mismatch.",
@@ -135,19 +178,23 @@
   {
     "name": "closure_invalid_upvalue",
     "source": "closure_invalid_upvalue.orus",
-    "description": "Mutating a captured immutable variable inside a closure currently triggers a runtime panic.",
-    "expected_exit": 70,
+    "description": "Mutating a captured immutable variable inside a closure is now caught at compile time.",
+    "expected_exit": 65,
     "expected_diagnostic_count": 1,
     "expected_diagnostics": [
       {
-        "category": "RUNTIME PANIC",
-        "title": "This operation isn't allowed here",
-        "message_contains": "Invalid upvalue access"
+        "title": "This variable needs to be mutable",
+        "message_contains": "Cannot assign to immutable variable",
+        "help_contains": "Add 'mut' before the variable name",
+        "note_contains": "Variables are immutable by default"
       }
     ],
     "expected": [
-      "-- RUNTIME PANIC: This operation isn't allowed here",
-      "Invalid upvalue access"
+      "-- SYNTAX ERROR: This variable needs to be mutable",
+      "Cannot assign to immutable variable 'value'. Add 'mut' when declaring it.",
+      "help: Add 'mut' before the variable name when declaring it: 'mut variable_name = value'",
+      "note: Variables are immutable by default in Orus for safety and predictability.",
+      "Compilation failed for \"tests/error_reporting/closure_invalid_upvalue.orus\"."
     ]
   },
   {

--- a/tests/error_reporting/variable_redefinition.orus
+++ b/tests/error_reporting/variable_redefinition.orus
@@ -1,0 +1,3 @@
+// Declaring the same variable twice in one scope should trigger a redefinition diagnostic
+mut value = 1
+mut value = 2

--- a/tests/error_reporting/variable_scope_violation.orus
+++ b/tests/error_reporting/variable_scope_violation.orus
@@ -1,0 +1,7 @@
+// Using a variable outside of the block where it was declared should report a scope violation
+fn demo() -> i32:
+    if true:
+        mut temp = 10
+    return temp
+
+demo()


### PR DESCRIPTION
## Summary
- track symbol declaration, initialization, and reads in the symbol table so diagnostics know a variable's lifecycle
- emit friendly compile-time diagnostics for redefinitions, undefined uses, and immutable or uninitialized assignments across functions and closures
- treat if/else blocks as lexical scopes and expand error-reporting regression cases for redefinition, scope issues, and closure mutability