### PR TITLE
Prepare type system for aggregate and generic features

### DIFF
--- a/include/type/type.h
+++ b/include/type/type.h
@@ -37,6 +37,10 @@ typedef struct TypeExtension {
     // Extended union data for new type kinds
     union {
         struct {
+            int length;
+            bool has_length;
+        } array;
+        struct {
             ObjString* name;
             FieldInfo* fields;
             int fieldCount;
@@ -64,6 +68,7 @@ Type* createSizedArrayType(Type* elementType, int length);
 Type* createFunctionType(Type* returnType, Type** paramTypes, int paramCount);
 Type* createStructType(ObjString* name, FieldInfo* fields, int fieldCount,
                        ObjString** generics, int genericCount);
+Type* createEnumType(ObjString* name, Variant* variants, int variant_count);
 Type* createGenericType(ObjString* name);
 Type* findStructType(const char* name);
 void freeType(Type* type);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -198,6 +198,8 @@ typedef enum {
     TYPE_VOID,
     TYPE_ARRAY,
     TYPE_FUNCTION,
+    TYPE_STRUCT,
+    TYPE_ENUM,
     TYPE_ANY,
     TYPE_VAR,
     TYPE_GENERIC,


### PR DESCRIPTION
## Summary
- extend the type metadata layer with array length tracking plus struct and enum registries/constructors to support upcoming aggregate features
- add substitution and instantiation helpers so generics can compose with arrays, structs, and enums during future compiler work
- update type inference and presentation utilities to recognize the new kinds and release associated registries during teardown