### PR TITLE
Initialize bytecode buffer state before allocations

### DIFF
--- a/src/compiler/backend/compiler.c
+++ b/src/compiler/backend/compiler.c
@@ -25,9 +25,19 @@
 BytecodeBuffer* init_bytecode_buffer(void) {
     BytecodeBuffer* buffer = malloc(sizeof(BytecodeBuffer));
     if (!buffer) return NULL;
-    
-    buffer->capacity = 256;  // Initial capacity
+
+    // Ensure all fields are initialized before any allocation so cleanup paths
+    // can safely free partially constructed buffers.
+    buffer->instructions = NULL;
+    buffer->source_lines = NULL;
+    buffer->source_columns = NULL;
+    buffer->source_files = NULL;
+    buffer->patches = NULL;
     buffer->count = 0;
+    buffer->capacity = 256;  // Initial capacity
+    buffer->patch_count = 0;
+    buffer->patch_capacity = 0;
+
     buffer->instructions = malloc(buffer->capacity);
     buffer->source_lines = malloc(buffer->capacity * sizeof(int));
     buffer->source_columns = malloc(buffer->capacity * sizeof(int));
@@ -43,11 +53,6 @@ BytecodeBuffer* init_bytecode_buffer(void) {
     buffer->current_location.line = -1;
     buffer->current_location.column = -1;
     buffer->has_current_location = false;
-
-    // Initialize jump patching
-    buffer->patches = NULL;
-    buffer->patch_count = 0;
-    buffer->patch_capacity = 0;
 
     return buffer;
 }


### PR DESCRIPTION
## Summary
- initialize all BytecodeBuffer pointers and counters before allocating any backing storage
- ensure free_bytecode_buffer can safely clean up after partial initialization failures

## Testing
- make
- ./orus_debug tests/control_flow/test_4_level_with_breaks.orus

------
https://chatgpt.com/codex/tasks/task_e_68cac6222f5c8325832e60f27d4d5573