### PR TITLE
Implement VM array push/pop builtins

### DIFF
--- a/include/runtime/builtins.h
+++ b/include/runtime/builtins.h
@@ -26,6 +26,24 @@ void builtin_print(Value* args, int count, bool newline, const char* separator);
 void builtin_print_with_sep_value(Value* args, int count, bool newline, Value separator_value);
 
 /**
+ * Push a value onto an array, growing the backing store when needed.
+ *
+ * @param array_value Value containing the target array.
+ * @param element     Value to append.
+ * @return true when the value was appended successfully.
+ */
+bool builtin_array_push(Value array_value, Value element);
+
+/**
+ * Pop a value from the end of an array.
+ *
+ * @param array_value Value containing the target array.
+ * @param out_value   Receives the popped value on success.
+ * @return true when a value was popped successfully.
+ */
+bool builtin_array_pop(Value array_value, Value* out_value);
+
+/**
  * Obtain a monotonic timestamp in milliseconds.
  *
  * The epoch is unspecified but monotonically increasing for the

--- a/include/runtime/memory.h
+++ b/include/runtime/memory.h
@@ -1,6 +1,7 @@
 #ifndef ORUS_MEMORY_H
 #define ORUS_MEMORY_H
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #define GROW_CAPACITY(capacity) ((capacity) < 8 ? 8 : (capacity) * 2)
@@ -21,6 +22,11 @@ void resumeGC(void);
 
 ObjString* allocateString(const char* chars, int length);
 ObjArray* allocateArray(int capacity);
+void arrayEnsureCapacity(ObjArray* array, int minCapacity);
+bool arrayPush(ObjArray* array, Value value);
+bool arrayPop(ObjArray* array, Value* outValue);
+bool arrayGet(const ObjArray* array, int index, Value* outValue);
+bool arraySet(ObjArray* array, int index, Value value);
 ObjError* allocateError(ErrorType type, const char* message, SrcLocation location);
 ObjRangeIterator* allocateRangeIterator(int64_t start, int64_t end);
 ObjFunction* allocateFunction(void);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -491,6 +491,8 @@ typedef enum {
     OP_ARRAY_GET_R,   // dst, array_reg, index_reg
     OP_ARRAY_SET_R,   // array_reg, index_reg, value_reg
     OP_ARRAY_LEN_R,   // dst, array_reg
+    OP_ARRAY_PUSH_R,  // array_reg, value_reg
+    OP_ARRAY_POP_R,   // dst, array_reg
 
     // Control flow
     OP_JUMP,

--- a/src/vm/core/vm_memory.c
+++ b/src/vm/core/vm_memory.c
@@ -99,6 +99,84 @@ ObjArray* allocateArray(int capacity) {
     return array;
 }
 
+void arrayEnsureCapacity(ObjArray* array, int minCapacity) {
+    if (!array) {
+        return;
+    }
+
+    if (minCapacity <= array->capacity) {
+        return;
+    }
+
+    int newCapacity = array->capacity;
+    while (newCapacity < minCapacity) {
+        newCapacity = newCapacity < 8 ? 8 : newCapacity * 2;
+        if (newCapacity < 0) {
+            newCapacity = minCapacity;
+            break;
+        }
+    }
+
+    Value* newElements = (Value*)reallocate(
+        array->elements,
+        sizeof(Value) * array->capacity,
+        sizeof(Value) * newCapacity);
+    if (!newElements) {
+        return;
+    }
+
+    array->elements = newElements;
+    array->capacity = newCapacity;
+}
+
+bool arrayPush(ObjArray* array, Value value) {
+    if (!array) {
+        return false;
+    }
+
+    if (array->length >= array->capacity) {
+        arrayEnsureCapacity(array, array->length + 1);
+        if (array->length >= array->capacity) {
+            return false;
+        }
+    }
+
+    array->elements[array->length++] = value;
+    return true;
+}
+
+bool arrayPop(ObjArray* array, Value* outValue) {
+    if (!array || array->length == 0) {
+        return false;
+    }
+
+    array->length--;
+    if (outValue) {
+        *outValue = array->elements[array->length];
+    }
+    return true;
+}
+
+bool arrayGet(const ObjArray* array, int index, Value* outValue) {
+    if (!array || index < 0 || index >= array->length) {
+        return false;
+    }
+
+    if (outValue) {
+        *outValue = array->elements[index];
+    }
+    return true;
+}
+
+bool arraySet(ObjArray* array, int index, Value value) {
+    if (!array || index < 0 || index >= array->length) {
+        return false;
+    }
+
+    array->elements[index] = value;
+    return true;
+}
+
 ObjError* allocateError(ErrorType type, const char* message, SrcLocation location) {
     ObjError* error = (ObjError*)allocateObject(sizeof(ObjError), OBJ_ERROR);
     error->type = type;

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -1,6 +1,7 @@
 #include "vm/vm_dispatch.h"
 #include "vm/spill_manager.h"
 #include "runtime/builtins.h"
+#include "runtime/memory.h"
 #include "vm/vm_constants.h"
 #include "vm/vm_string_ops.h"
 #include "vm/vm_arithmetic.h"
@@ -13,6 +14,7 @@
 #include "debug/debug_config.h"
 
 #include <math.h>
+#include <limits.h>
 
 // Frame-aware register access functions for proper local variable isolation
 inline Value vm_get_register_safe(uint16_t id) {
@@ -44,6 +46,42 @@ inline void vm_set_register_safe(uint16_t id, Value value) {
         // Extended registers use register file
         set_register(&vm.register_file, id, value);
     }
+}
+
+static inline bool value_to_index(Value value, int* out_index) {
+    if (IS_I32(value)) {
+        int32_t idx = AS_I32(value);
+        if (idx < 0) {
+            return false;
+        }
+        *out_index = idx;
+        return true;
+    }
+    if (IS_I64(value)) {
+        int64_t idx = AS_I64(value);
+        if (idx < 0 || idx > INT_MAX) {
+            return false;
+        }
+        *out_index = (int)idx;
+        return true;
+    }
+    if (IS_U32(value)) {
+        uint32_t idx = AS_U32(value);
+        if (idx > (uint32_t)INT_MAX) {
+            return false;
+        }
+        *out_index = (int)idx;
+        return true;
+    }
+    if (IS_U64(value)) {
+        uint64_t idx = AS_U64(value);
+        if (idx > (uint64_t)INT_MAX) {
+            return false;
+        }
+        *out_index = (int)idx;
+        return true;
+    }
+    return false;
 }
 
 
@@ -240,6 +278,12 @@ InterpretResult vm_run_dispatch(void) {
         vm_dispatch_table[OP_OR_BOOL_R] = &&LABEL_OP_OR_BOOL_R;
         vm_dispatch_table[OP_NOT_BOOL_R] = &&LABEL_OP_NOT_BOOL_R;
         vm_dispatch_table[OP_CONCAT_R] = &&LABEL_OP_CONCAT_R;
+        vm_dispatch_table[OP_MAKE_ARRAY_R] = &&LABEL_OP_MAKE_ARRAY_R;
+        vm_dispatch_table[OP_ARRAY_GET_R] = &&LABEL_OP_ARRAY_GET_R;
+        vm_dispatch_table[OP_ARRAY_SET_R] = &&LABEL_OP_ARRAY_SET_R;
+        vm_dispatch_table[OP_ARRAY_LEN_R] = &&LABEL_OP_ARRAY_LEN_R;
+        vm_dispatch_table[OP_ARRAY_PUSH_R] = &&LABEL_OP_ARRAY_PUSH_R;
+        vm_dispatch_table[OP_ARRAY_POP_R] = &&LABEL_OP_ARRAY_POP_R;
         vm_dispatch_table[OP_TO_STRING_R] = &&LABEL_OP_TO_STRING_R;
         vm_dispatch_table[OP_JUMP] = &&LABEL_OP_JUMP;
         vm_dispatch_table[OP_JUMP_IF_NOT_R] = &&LABEL_OP_JUMP_IF_NOT_R;
@@ -2016,6 +2060,120 @@ InterpretResult vm_run_dispatch(void) {
         ObjString* res = allocateString(buf, newLen);
         free(buf);
         vm_set_register_safe(dst, STRING_VAL(res));
+        DISPATCH();
+    }
+
+    LABEL_OP_MAKE_ARRAY_R: {
+        uint8_t dst = READ_BYTE();
+        uint8_t first = READ_BYTE();
+        uint8_t count = READ_BYTE();
+
+        ObjArray* array = allocateArray(count);
+        if (!array) {
+            VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(), "Failed to allocate array");
+        }
+
+        for (uint8_t i = 0; i < count; i++) {
+            arrayEnsureCapacity(array, i + 1);
+            array->elements[i] = vm_get_register_safe(first + i);
+        }
+        array->length = count;
+        Value new_array = {.type = VAL_ARRAY, .as.obj = (Obj*)array};
+        vm_set_register_safe(dst, new_array);
+        DISPATCH();
+    }
+
+    LABEL_OP_ARRAY_GET_R: {
+        uint8_t dst = READ_BYTE();
+        uint8_t array_reg = READ_BYTE();
+        uint8_t index_reg = READ_BYTE();
+
+        Value array_value = vm_get_register_safe(array_reg);
+        if (!IS_ARRAY(array_value)) {
+            VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Value is not an array");
+        }
+
+        Value index_value = vm_get_register_safe(index_reg);
+        int index;
+        if (!value_to_index(index_value, &index)) {
+            VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Array index must be a non-negative integer");
+        }
+
+        Value element;
+        if (!arrayGet(AS_ARRAY(array_value), index, &element)) {
+            VM_ERROR_RETURN(ERROR_INDEX, CURRENT_LOCATION(), "Array index out of bounds");
+        }
+
+        vm_set_register_safe(dst, element);
+        DISPATCH();
+    }
+
+    LABEL_OP_ARRAY_SET_R: {
+        uint8_t array_reg = READ_BYTE();
+        uint8_t index_reg = READ_BYTE();
+        uint8_t value_reg = READ_BYTE();
+
+        Value array_value = vm_get_register_safe(array_reg);
+        if (!IS_ARRAY(array_value)) {
+            VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Value is not an array");
+        }
+
+        Value index_value = vm_get_register_safe(index_reg);
+        int index;
+        if (!value_to_index(index_value, &index)) {
+            VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Array index must be a non-negative integer");
+        }
+
+        Value value = vm_get_register_safe(value_reg);
+        if (!arraySet(AS_ARRAY(array_value), index, value)) {
+            VM_ERROR_RETURN(ERROR_INDEX, CURRENT_LOCATION(), "Array index out of bounds");
+        }
+
+        DISPATCH();
+    }
+
+    LABEL_OP_ARRAY_LEN_R: {
+        uint8_t dst = READ_BYTE();
+        uint8_t array_reg = READ_BYTE();
+
+        Value array_value = vm_get_register_safe(array_reg);
+        if (!IS_ARRAY(array_value)) {
+            VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Value is not an array");
+        }
+
+        ObjArray* array = AS_ARRAY(array_value);
+        vm_set_register_safe(dst, I32_VAL(array->length));
+        DISPATCH();
+    }
+
+    LABEL_OP_ARRAY_PUSH_R: {
+        uint8_t array_reg = READ_BYTE();
+        uint8_t value_reg = READ_BYTE();
+
+        Value array_value = vm_get_register_safe(array_reg);
+        if (!builtin_array_push(array_value, vm_get_register_safe(value_reg))) {
+            if (!IS_ARRAY(array_value)) {
+                VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Value is not an array");
+            }
+            VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(), "Failed to push value onto array");
+        }
+        DISPATCH();
+    }
+
+    LABEL_OP_ARRAY_POP_R: {
+        uint8_t dst = READ_BYTE();
+        uint8_t array_reg = READ_BYTE();
+
+        Value array_value = vm_get_register_safe(array_reg);
+        Value popped;
+        if (!builtin_array_pop(array_value, &popped)) {
+            if (!IS_ARRAY(array_value)) {
+                VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Value is not an array");
+            }
+            VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Cannot pop from an empty array");
+        }
+
+        vm_set_register_safe(dst, popped);
         DISPATCH();
     }
 

--- a/src/vm/runtime/builtins.c
+++ b/src/vm/runtime/builtins.c
@@ -1,5 +1,6 @@
 #define _POSIX_C_SOURCE 200809L
 #include "runtime/builtins.h"
+#include "runtime/memory.h"
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
@@ -204,14 +205,32 @@ void builtin_print(Value* args, int count, bool newline, const char* separator) 
 
 void builtin_print_with_sep_value(Value* args, int count, bool newline, Value separator_value) {
     const char* sep = " "; // default
-    
+
     // Extract separator string from Value
     if (IS_STRING(separator_value)) {
         ObjString* sepObj = AS_STRING(separator_value);
         sep = sepObj->chars;
     }
-    
+
     builtin_print(args, count, newline, sep);
+}
+
+bool builtin_array_push(Value array_value, Value element) {
+    if (!IS_ARRAY(array_value)) {
+        return false;
+    }
+
+    ObjArray* array = AS_ARRAY(array_value);
+    return arrayPush(array, element);
+}
+
+bool builtin_array_pop(Value array_value, Value* out_value) {
+    if (!IS_ARRAY(array_value)) {
+        return false;
+    }
+
+    ObjArray* array = AS_ARRAY(array_value);
+    return arrayPop(array, out_value);
 }
 
 // Cross-platform high-precision timestamp function

--- a/src/vm/utils/debug.c
+++ b/src/vm/utils/debug.c
@@ -187,6 +187,51 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return offset + 2;
         }
 
+        case OP_MAKE_ARRAY_R: {
+            uint8_t dst = chunk->code[offset + 1];
+            uint8_t first = chunk->code[offset + 2];
+            uint8_t count = chunk->code[offset + 3];
+            printf("%-16s R%d, R%d, count=%d\n", "MAKE_ARRAY", dst, first, count);
+            return offset + 4;
+        }
+
+        case OP_ARRAY_GET_R: {
+            uint8_t dst = chunk->code[offset + 1];
+            uint8_t array_reg = chunk->code[offset + 2];
+            uint8_t index_reg = chunk->code[offset + 3];
+            printf("%-16s R%d, R%d, R%d\n", "ARRAY_GET", dst, array_reg, index_reg);
+            return offset + 4;
+        }
+
+        case OP_ARRAY_SET_R: {
+            uint8_t array_reg = chunk->code[offset + 1];
+            uint8_t index_reg = chunk->code[offset + 2];
+            uint8_t value_reg = chunk->code[offset + 3];
+            printf("%-16s R%d, R%d, R%d\n", "ARRAY_SET", array_reg, index_reg, value_reg);
+            return offset + 4;
+        }
+
+        case OP_ARRAY_LEN_R: {
+            uint8_t dst = chunk->code[offset + 1];
+            uint8_t array_reg = chunk->code[offset + 2];
+            printf("%-16s R%d, R%d\n", "ARRAY_LEN", dst, array_reg);
+            return offset + 3;
+        }
+
+        case OP_ARRAY_PUSH_R: {
+            uint8_t array_reg = chunk->code[offset + 1];
+            uint8_t value_reg = chunk->code[offset + 2];
+            printf("%-16s R%d, R%d\n", "ARRAY_PUSH", array_reg, value_reg);
+            return offset + 3;
+        }
+
+        case OP_ARRAY_POP_R: {
+            uint8_t dst = chunk->code[offset + 1];
+            uint8_t array_reg = chunk->code[offset + 2];
+            printf("%-16s R%d, R%d\n", "ARRAY_POP", dst, array_reg);
+            return offset + 3;
+        }
+
         case OP_CALL_NATIVE_R: {
             uint8_t native_index = chunk->code[offset + 1];
             uint8_t first_arg = chunk->code[offset + 2];

--- a/tests/arrays/push_pop.orus
+++ b/tests/arrays/push_pop.orus
@@ -1,0 +1,23 @@
+// Array push/pop smoke test for the Orus VM runtime.
+//
+// This program exercises the built-in push/pop operations exposed by the VM.
+// It builds an array, pushes a series of values, then pops them back off while
+// printing the observed order and remaining length after each operation.
+
+print("-- array push/pop builtin smoke --")
+mut numbers = []
+
+// Push a few values
+push(numbers, 1)
+push(numbers, 2)
+push(numbers, 3)
+print("after pushes:", numbers)
+print("length:", len(numbers))
+
+last = pop(numbers)
+print("popped value:", last)
+print("after pop:", numbers)
+print("length:", len(numbers))
+
+push(numbers, 42)
+print("final state:", numbers)


### PR DESCRIPTION
## Summary
- expose `builtin_array_push` and `builtin_array_pop` wrappers on top of the VM array helpers
- wire new ARRAY_MAKE/GET/SET/LEN/PUSH/POP handlers into both dispatch loops with shared index validation
- extend the disassembler and add a smoke-test .orus script covering push/pop usage