### PR TITLE
Add array literal and array builtin support

### DIFF
--- a/include/compiler/ast.h
+++ b/include/compiler/ast.h
@@ -21,6 +21,7 @@ typedef enum {
     NODE_VAR_DECL,
     NODE_IDENTIFIER,
     NODE_LITERAL,
+    NODE_ARRAY_LITERAL,
     NODE_BINARY,
     NODE_ASSIGN,
     NODE_PRINT,
@@ -65,6 +66,10 @@ struct ASTNode {
             Value value;
             bool hasExplicitSuffix;
         } literal;
+        struct {
+            ASTNode** elements;
+            int count;
+        } arrayLiteral;
         struct {
             char* op;
             ASTNode* left;

--- a/include/compiler/typed_ast.h
+++ b/include/compiler/typed_ast.h
@@ -94,6 +94,10 @@ struct TypedASTNode {
             int argCount;
         } call;
         struct {
+            TypedASTNode** elements;
+            int count;
+        } arrayLiteral;
+        struct {
             TypedASTNode* value;
         } returnStmt;
         struct {

--- a/src/compiler/typed_ast.c
+++ b/src/compiler/typed_ast.c
@@ -99,6 +99,10 @@ TypedASTNode* create_typed_ast_node(ASTNode* original) {
             typed->typed.call.args = NULL;
             typed->typed.call.argCount = 0;
             break;
+        case NODE_ARRAY_LITERAL:
+            typed->typed.arrayLiteral.elements = NULL;
+            typed->typed.arrayLiteral.count = 0;
+            break;
         case NODE_RETURN:
             typed->typed.returnStmt.value = NULL;
             break;
@@ -203,6 +207,14 @@ void free_typed_ast_node(TypedASTNode* node) {
                     free_typed_ast_node(node->typed.call.args[i]);
                 }
                 free(node->typed.call.args);
+            }
+            break;
+        case NODE_ARRAY_LITERAL:
+            if (node->typed.arrayLiteral.elements) {
+                for (int i = 0; i < node->typed.arrayLiteral.count; i++) {
+                    free_typed_ast_node(node->typed.arrayLiteral.elements[i]);
+                }
+                free(node->typed.arrayLiteral.elements);
             }
             break;
         case NODE_RETURN:
@@ -370,6 +382,9 @@ void print_typed_ast(TypedASTNode* node, int indent) {
         case NODE_LITERAL:
             nodeTypeStr = "Literal";
             break;
+        case NODE_ARRAY_LITERAL:
+            nodeTypeStr = "ArrayLiteral";
+            break;
         case NODE_BINARY:
             nodeTypeStr = "Binary";
             break;
@@ -489,6 +504,13 @@ void print_typed_ast(TypedASTNode* node, int indent) {
             }
             if (node->typed.print.separator) {
                 print_typed_ast(node->typed.print.separator, indent + 1);
+            }
+            break;
+        case NODE_ARRAY_LITERAL:
+            if (node->typed.arrayLiteral.elements) {
+                for (int i = 0; i < node->typed.arrayLiteral.count; i++) {
+                    print_typed_ast(node->typed.arrayLiteral.elements[i], indent + 1);
+                }
             }
             break;
         case NODE_IF:


### PR DESCRIPTION
## Summary
- extend the AST, parser, and typed AST to understand array literals
- emit array literal bytecode and add VM builtin lowering for push, pop, and len calls
- register array builtins in the type environment and teach type inference/unification about arrays