### PR TITLE
Register struct types and add tests for impl blocks

### DIFF
--- a/docs/MISSING.md
+++ b/docs/MISSING.md
@@ -183,6 +183,12 @@ pass—without introducing additional intermediate representations.
    types, synthesize method receivers as the first parameter, and support
    namespaced lookup during codegen.
 
+   - ✅ Parser, typed AST, and Hindley–Milner registration hook struct
+     declarations into the global type registry and attach impl methods to the
+     struct metadata.
+   - 🚧 Remaining: bytecode generation for method bodies and runtime dispatch,
+     plus value construction and field access semantics.
+
    ```orus
    impl Point:
        fn magnitude(self):

--- a/docs/TEST_CATEGORIZATION.md
+++ b/docs/TEST_CATEGORIZATION.md
@@ -1,0 +1,8 @@
+# Test Categorization Update
+
+## Structs
+- `tests/structs/basic_struct.orus` – Positive coverage for struct defaults and impl registration.
+
+## Type Safety Fails
+- `tests/type_safety_fails/struct_field_type_mismatch.orus` – Ensures mismatched default triggers a type error.
+- `tests/type_safety_fails/impl_missing_struct.orus` – Verifies impl blocks require a previously-declared struct.

--- a/include/compiler/ast.h
+++ b/include/compiler/ast.h
@@ -15,6 +15,13 @@ typedef struct {
     ASTNode* typeAnnotation;  // Optional type annotation
 } FunctionParam;
 
+// Struct field representation
+typedef struct {
+    char* name;
+    ASTNode* typeAnnotation;  // Field type annotation (required)
+    ASTNode* defaultValue;    // Optional default value expression
+} StructField;
+
 // Different kinds of AST nodes supported in the minimal language
 typedef enum {
     NODE_PROGRAM,
@@ -42,7 +49,9 @@ typedef enum {
     NODE_FUNCTION,
     NODE_CALL,
     NODE_RETURN,
-    NODE_CAST        // Add cast node for 'as' operator
+    NODE_CAST,       // Add cast node for 'as' operator
+    NODE_STRUCT_DECL,
+    NODE_IMPL_BLOCK
 } NodeType;
 
 struct ASTNode {
@@ -169,6 +178,18 @@ struct ASTNode {
             ASTNode* targetType;           // Target type
             bool parenthesized;            // Whether the cast was explicitly parenthesized
         } cast;
+        struct {
+            char* name;                    // Struct name
+            bool isPublic;                 // Whether the struct is public
+            StructField* fields;           // Struct field definitions
+            int fieldCount;                // Number of fields
+        } structDecl;
+        struct {
+            char* structName;              // Name of struct being implemented
+            bool isPublic;                 // Whether the impl block is public
+            ASTNode** methods;             // Method definitions (function nodes)
+            int methodCount;               // Number of methods
+        } implBlock;
     };
 };
 

--- a/include/compiler/typed_ast.h
+++ b/include/compiler/typed_ast.h
@@ -7,6 +7,12 @@
 // Forward declarations
 typedef struct TypedASTNode TypedASTNode;
 
+typedef struct {
+    const char* name;
+    TypedASTNode* typeAnnotation;
+    TypedASTNode* defaultValue;
+} TypedStructField;
+
 // Typed AST node that contains the original AST plus resolved type information
 struct TypedASTNode {
     ASTNode* original;       // Original AST node from parser
@@ -117,6 +123,18 @@ struct TypedASTNode {
             TypedASTNode* start;
             TypedASTNode* end;
         } arraySlice;
+        struct {
+            const char* name;
+            bool isPublic;
+            TypedStructField* fields;
+            int fieldCount;
+        } structDecl;
+        struct {
+            const char* structName;
+            bool isPublic;
+            TypedASTNode** methods;
+            int methodCount;
+        } implBlock;
     } typed;
 };
 

--- a/makefile
+++ b/makefile
@@ -188,7 +188,7 @@ test: $(ORUS)
 	@echo "Running Comprehensive Test Suite..."
 	@echo "==================================="
 	@passed=0; failed=0; current_dir=""; \
-        SUBDIRS="arrays arithmetic benchmarks comments comprehensive control_flow edge_cases expressions formatting functions literals register_file scope_analysis strings type_safety_fails types/f64 types/i32 types/i64 variables"; \
+        SUBDIRS="arrays arithmetic benchmarks comments comprehensive control_flow edge_cases expressions formatting functions literals register_file scope_analysis strings structs type_safety_fails types/f64 types/i32 types/i64 variables"; \
 	for subdir in $$SUBDIRS; do \
 		for test_file in $$(find $(TESTDIR)/$$subdir -type f -name "*.orus" | sort); do \
 			if [ -f "$$test_file" ]; then \

--- a/src/compiler/backend/codegen/codegen.c
+++ b/src/compiler/backend/codegen/codegen.c
@@ -2052,7 +2052,11 @@ void compile_statement(CompilerContext* ctx, TypedASTNode* stmt) {
             // Compile function call as statement (void return type)
             compile_expression(ctx, stmt);
             break;
-            
+        case NODE_STRUCT_DECL:
+        case NODE_IMPL_BLOCK:
+            // No bytecode emitted for type or impl declarations
+            break;
+
         default:
             DEBUG_CODEGEN_PRINT("Warning: Unsupported statement type: %d\n", stmt->original->type);
             break;

--- a/tests/structs/basic_struct.orus
+++ b/tests/structs/basic_struct.orus
@@ -1,0 +1,10 @@
+// Ensures struct declarations, defaults, and impl blocks type-check
+pub struct Counter:
+    value: i32 = 0
+
+impl Counter:
+    fn increment(counter: Counter) -> Counter:
+        return counter
+
+fn main():
+    print(0)

--- a/tests/type_safety_fails/impl_missing_struct.orus
+++ b/tests/type_safety_fails/impl_missing_struct.orus
@@ -1,0 +1,4 @@
+// Expect undefined type error when impl targets missing struct
+impl Missing:
+    fn stub(x: Missing) -> Missing:
+        return x

--- a/tests/type_safety_fails/struct_field_type_mismatch.orus
+++ b/tests/type_safety_fails/struct_field_type_mismatch.orus
@@ -1,0 +1,3 @@
+// Expect type mismatch when struct default value disagrees with annotation
+struct Broken:
+    value: i32 = "oops"


### PR DESCRIPTION
## Summary
- register struct declarations with the global type registry and attach impl methods during type inference
- surface undefined type errors for unknown annotations, keeping struct metadata on typed AST nodes
- document the struct pipeline in the implementation guide, update the roadmap, and add new struct/impl tests to the suite

## Testing
- make
- ./orus_debug tests/structs/basic_struct.orus
- ./orus_debug tests/type_safety_fails/struct_field_type_mismatch.orus; echo $?
- ./orus_debug tests/type_safety_fails/impl_missing_struct.orus; echo $?


------
https://chatgpt.com/codex/tasks/task_e_68cb2bb0764c8325a35633088b6c7a13