### PR TITLE
Expand struct regression test coverage

### DIFF
--- a/tests/structs/field_assignment.orus
+++ b/tests/structs/field_assignment.orus
@@ -1,0 +1,18 @@
+// Validates struct field mutation within iterative control flow.
+pub struct Accumulator:
+    total: i32
+    increment: i32
+
+impl Accumulator:
+    fn run(counter: Accumulator, steps: i32) -> Accumulator:
+        mut current = counter
+        mut remaining = steps
+        while remaining > 0:
+            current.total = current.total + current.increment
+            remaining = remaining - 1
+        return current
+
+start = Accumulator{ total: 5, increment: 2 }
+result = Accumulator.run(start, 4)
+print(result.total)
+print(result.increment)

--- a/tests/structs/range_methods.orus
+++ b/tests/structs/range_methods.orus
@@ -1,0 +1,26 @@
+// Covers boolean-returning instance methods and static helpers operating on structs.
+pub struct Range:
+    start: i32
+    end: i32
+
+impl Range:
+    fn contains(self, value: i32) -> bool:
+        if value < self.start:
+            return false
+        if value > self.end:
+            return false
+        return true
+
+    fn clamp(range: Range, value: i32) -> i32:
+        if value < range.start:
+            return range.start
+        if value > range.end:
+            return range.end
+        return value
+
+segment = Range{ start: 5, end: 12 }
+print(segment.contains(7))
+print(segment.contains(15))
+print(Range.clamp(segment, 2))
+print(Range.clamp(segment, 10))
+print(Range.clamp(segment, 20))

--- a/tests/structs/static_and_instance_methods.orus
+++ b/tests/structs/static_and_instance_methods.orus
@@ -1,0 +1,18 @@
+// Exercises static constructors returning structs and subsequent instance dispatch.
+pub struct Point:
+    x: i32
+    y: i32
+
+impl Point:
+    fn origin() -> Point:
+        return Point{ x: 0, y: 0 }
+
+    fn offset(self, dx: i32, dy: i32) -> Point:
+        return Point{ x: self.x + dx, y: self.y + dy }
+
+    fn manhattan(self) -> i32:
+        return self.x + self.y
+
+start = Point.origin()
+shifted = start.offset(4, 9)
+print(shifted.manhattan())


### PR DESCRIPTION
## Summary
- add an accumulator regression test that exercises mutating struct fields inside a loop
- add a range behavior test that mixes boolean-returning instance methods with static helpers
- add a point test that chains a static constructor with instance dispatch