### PR TITLE
Implement runtime enum constructors

### DIFF
--- a/docs/MISSING.md
+++ b/docs/MISSING.md
@@ -173,6 +173,18 @@ pass—without introducing additional intermediate representations.
    the VM, add pattern exhaustiveness checks, and reuse Hindley–Milner type
    inference to propagate variant data.
 
+   - ✅ Parser and typed AST generation understand enum declarations, including
+     tuple-style variant payloads.
+   - ✅ Hindley–Milner inference registers enum variants in the global type
+     registry and materializes `TYPE_ENUM` metadata for downstream compiler
+     phases.
+   - ✅ Enum metadata now preserves variant payload field names, enabling
+     upcoming pattern matching exhaustiveness and destructuring analysis.
+   - ✅ Wire up the standard `Result.Ok`/`Result.Err` constructors so they
+     allocate concrete tagged values once bytecode lowering is available.
+   - ✅ Lower enum constructors in the bytecode backend (variant pattern tests
+     remain to be implemented).
+
    ```orus
    enum Result[T]:
        Ok(value: T)

--- a/docs/TEST_CATEGORIZATION.md
+++ b/docs/TEST_CATEGORIZATION.md
@@ -8,3 +8,10 @@
 ## Type Safety Fails
 - `tests/type_safety_fails/struct_field_type_mismatch.orus` – Ensures mismatched default triggers a type error.
 - `tests/type_safety_fails/impl_missing_struct.orus` – Verifies impl blocks require a previously-declared struct.
+
+## Types
+- `tests/types/enum_declarations.orus` – Validates that enum declarations, payload annotations, and cross-type references resolve in the type system.
+- `tests/types/enum_constructors.orus` – Ensures enum variant constructors type-check for both payload-free and payload-carrying variants.
+
+## Comprehensive
+- `tests/comprehensive/enum_runtime.orus` – Confirms enum constructors lower to runtime values by constructing and reassigning variants before printing.

--- a/include/compiler/ast.h
+++ b/include/compiler/ast.h
@@ -27,6 +27,17 @@ typedef struct {
     ASTNode* value;
 } StructLiteralField;
 
+typedef struct {
+    char* name;
+    ASTNode* typeAnnotation;  // Payload type for the variant field (optional)
+} EnumVariantField;
+
+typedef struct {
+    char* name;
+    EnumVariantField* fields;
+    int fieldCount;
+} EnumVariant;
+
 // Different kinds of AST nodes supported in the minimal language
 typedef enum {
     NODE_PROGRAM,
@@ -59,7 +70,8 @@ typedef enum {
     NODE_IMPL_BLOCK,
     NODE_STRUCT_LITERAL,
     NODE_MEMBER_ACCESS,
-    NODE_MEMBER_ASSIGN
+    NODE_MEMBER_ASSIGN,
+    NODE_ENUM_DECL
 } NodeType;
 
 struct ASTNode {
@@ -211,11 +223,22 @@ struct ASTNode {
             char* member;                  // Member name
             bool isMethod;                 // True if member resolves to method
             bool isInstanceMethod;         // True if method expects implicit self
+            bool resolvesToEnum;           // True if the lookup hit an enum type/value
+            bool resolvesToEnumVariant;    // True if the member is an enum variant
+            int enumVariantIndex;          // Variant slot inside the enum definition
+            int enumVariantArity;          // Number of payload fields the variant expects
+            const char* enumTypeName;      // Cached enum type name for backend lowering
         } member;
         struct {
             ASTNode* target;               // Member access node
             ASTNode* value;                // Assigned value
         } memberAssign;
+        struct {
+            char* name;            // Enum name
+            bool isPublic;         // Whether the enum is public
+            EnumVariant* variants; // Declared variants
+            int variantCount;      // Number of variants
+        } enumDecl;
     };
 };
 

--- a/include/compiler/lexer.h
+++ b/include/compiler/lexer.h
@@ -70,6 +70,7 @@ typedef enum {
     TOKEN_IN,
     TOKEN_BOOL,
     TOKEN_STRUCT,
+    TOKEN_ENUM,
     TOKEN_IMPL,
     TOKEN_IMPORT,
     TOKEN_USE,

--- a/include/compiler/typed_ast.h
+++ b/include/compiler/typed_ast.h
@@ -13,6 +13,17 @@ typedef struct {
     TypedASTNode* defaultValue;
 } TypedStructField;
 
+typedef struct {
+    const char* name;
+    TypedASTNode* typeAnnotation;
+} TypedEnumVariantField;
+
+typedef struct {
+    const char* name;
+    TypedEnumVariantField* fields;
+    int fieldCount;
+} TypedEnumVariant;
+
 // Typed AST node that contains the original AST plus resolved type information
 struct TypedASTNode {
     ASTNode* original;       // Original AST node from parser
@@ -149,11 +160,22 @@ struct TypedASTNode {
             const char* member;
             bool isMethod;
             bool isInstanceMethod;
+            bool resolvesToEnum;
+            bool resolvesToEnumVariant;
+            int enumVariantIndex;
+            int enumVariantArity;
+            const char* enumTypeName;
         } member;
         struct {
             TypedASTNode* target;
             TypedASTNode* value;
         } memberAssign;
+        struct {
+            const char* name;
+            bool isPublic;
+            TypedEnumVariant* variants;
+            int variantCount;
+        } enumDecl;
     } typed;
 };
 

--- a/include/public/value.h
+++ b/include/public/value.h
@@ -12,6 +12,7 @@ typedef struct ObjIntArray ObjIntArray;
 typedef struct ObjError ObjError;
 typedef struct ObjRangeIterator ObjRangeIterator;
 typedef struct ObjArrayIterator ObjArrayIterator;
+typedef struct ObjEnumInstance ObjEnumInstance;
 typedef struct Value Value;
 
 // Base object type for the garbage collector
@@ -24,6 +25,7 @@ typedef enum {
     OBJ_ERROR,
     OBJ_RANGE_ITERATOR,
     OBJ_ARRAY_ITERATOR,
+    OBJ_ENUM_INSTANCE,
 } ObjType;
 
 struct Obj {
@@ -41,6 +43,7 @@ typedef enum {
     VAL_BOOL,
     VAL_STRING,
     VAL_ARRAY,
+    VAL_ENUM,
     VAL_ERROR,
     VAL_RANGE_ITERATOR,
     VAL_ARRAY_ITERATOR,
@@ -77,6 +80,14 @@ typedef struct ObjArrayIterator {
     int index;
 } ObjArrayIterator;
 
+typedef struct ObjEnumInstance {
+    Obj obj;
+    ObjString* typeName;
+    ObjString* variantName;
+    int variantIndex;
+    ObjArray* payload;
+} ObjEnumInstance;
+
 typedef ObjString String;
 typedef ObjArray Array;
 
@@ -107,10 +118,11 @@ typedef struct Value {
 #define BOOL_VAL(value)  ((Value){VAL_BOOL, {.boolean = value}})
 #define STRING_VAL(value) ((Value){VAL_STRING, {.string = value}})
 #define ARRAY_VAL(obj)   ((Value){VAL_ARRAY, {.array = obj}})
+#define ENUM_VAL(enumObj)    ((Value){VAL_ENUM, {.obj = (Obj*)enumObj}})
 #define ERROR_VAL(obj)   ((Value){VAL_ERROR, {.error = obj}})
 #define RANGE_ITERATOR_VAL(obj) ((Value){VAL_RANGE_ITERATOR, {.rangeIter = obj}})
 #ifndef ARRAY_ITERATOR_VAL
-#define ARRAY_ITERATOR_VAL(obj) ((Value){VAL_ARRAY_ITERATOR, {.obj = (Obj*)obj}})
+#define ARRAY_ITERATOR_VAL(iteratorObj) ((Value){VAL_ARRAY_ITERATOR, {.obj = (Obj*)iteratorObj}})
 #endif
 
 // Value checking macros
@@ -122,6 +134,7 @@ typedef struct Value {
 #define IS_BOOL(value)   ((value).type == VAL_BOOL)
 #define IS_STRING(value) ((value).type == VAL_STRING)
 #define IS_ARRAY(value)  ((value).type == VAL_ARRAY)
+#define IS_ENUM(value)   ((value).type == VAL_ENUM)
 #define IS_ERROR(value)  ((value).type == VAL_ERROR)
 #define IS_RANGE_ITERATOR(value) ((value).type == VAL_RANGE_ITERATOR)
 #ifndef IS_ARRAY_ITERATOR
@@ -137,6 +150,7 @@ typedef struct Value {
 #define AS_BOOL(value)   ((value).as.boolean)
 #define AS_STRING(value) ((value).as.string)
 #define AS_ARRAY(value)  ((value).as.array)
+#define AS_ENUM(value)   ((ObjEnumInstance*)(value).as.obj)
 #define AS_ERROR(value)  ((value).as.error)
 #define AS_RANGE_ITERATOR(value) ((value).as.rangeIter)
 #ifndef AS_ARRAY_ITERATOR

--- a/include/runtime/memory.h
+++ b/include/runtime/memory.h
@@ -32,6 +32,7 @@ ObjError* allocateError(ErrorType type, const char* message, SrcLocation locatio
 ObjRangeIterator* allocateRangeIterator(int64_t start, int64_t end);
 ObjFunction* allocateFunction(void);
 ObjClosure* allocateClosure(ObjFunction* function);
+ObjEnumInstance* allocateEnumInstance(ObjString* typeName, ObjString* variantName, int variantIndex, ObjArray* payload);
 char* copyString(const char* chars, int length);
 
 #endif

--- a/include/type/type.h
+++ b/include/type/type.h
@@ -20,6 +20,7 @@ typedef struct FieldInfo {
 // Extended type system structures (complement the existing Type in vm.h)
 typedef struct Variant {
     ObjString* name;
+    ObjString** field_names;
     struct Type** field_types;
     int field_count;
 } Variant;
@@ -73,6 +74,7 @@ Type* createStructType(ObjString* name, FieldInfo* fields, int fieldCount,
 Type* createEnumType(ObjString* name, Variant* variants, int variant_count);
 Type* createGenericType(ObjString* name);
 Type* findStructType(const char* name);
+Type* findEnumType(const char* name);
 void freeType(Type* type);
 bool typesEqual(Type* a, Type* b);
 bool equalsType(Type* a, Type* b);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -30,6 +30,7 @@ typedef enum {
     VAL_NUMBER,  // Generic number type for literals
     VAL_STRING,
     VAL_ARRAY,
+    VAL_ENUM,
     VAL_ERROR,
     VAL_RANGE_ITERATOR,
     VAL_ARRAY_ITERATOR,
@@ -43,6 +44,7 @@ typedef struct ObjArray ObjArray;
 typedef struct ObjError ObjError;
 typedef struct ObjRangeIterator ObjRangeIterator;
 typedef struct ObjArrayIterator ObjArrayIterator;
+typedef struct ObjEnumInstance ObjEnumInstance;
 typedef struct ObjFunction ObjFunction;
 typedef struct ObjClosure ObjClosure;
 typedef struct ObjUpvalue ObjUpvalue;
@@ -70,12 +72,13 @@ typedef enum {
     OBJ_ERROR,
     OBJ_RANGE_ITERATOR,
     OBJ_ARRAY_ITERATOR,
+    OBJ_ENUM_INSTANCE,
     OBJ_FUNCTION,
     OBJ_CLOSURE,
     OBJ_UPVALUE
 } ObjType;
 
-#define OBJ_TYPE_COUNT 8
+#define OBJ_TYPE_COUNT 9
 
 // Object header
 struct Obj {
@@ -106,6 +109,14 @@ struct ObjArrayIterator {
     Obj obj;
     ObjArray* array;
     int index;
+};
+
+struct ObjEnumInstance {
+    Obj obj;
+    ObjString* typeName;
+    ObjString* variantName;
+    int variantIndex;
+    ObjArray* payload;
 };
 
 // Error object
@@ -498,6 +509,7 @@ typedef enum {
 
     // Array operations
     OP_MAKE_ARRAY_R,  // dst, start_reg, count
+    OP_ENUM_NEW_R,    // dst, variant_idx, payload_count, payload_start, type_const
     OP_ARRAY_GET_R,   // dst, array_reg, index_reg
     OP_ARRAY_SET_R,   // array_reg, index_reg, value_reg
     OP_ARRAY_LEN_R,   // dst, array_reg
@@ -1024,8 +1036,9 @@ typedef enum {
 #define U64_VAL(value) ((Value){VAL_U64, {.u64 = value}})
 #define F64_VAL(value) ((Value){VAL_F64, {.f64 = value}})
 #define STRING_VAL(value) ((Value){VAL_STRING, {.obj = (Obj*)value}})
-#define ARRAY_VAL(obj) ((Value){VAL_ARRAY, {.obj = (Obj*)obj}})
-#define ARRAY_ITERATOR_VAL(obj) ((Value){VAL_ARRAY_ITERATOR, {.obj = (Obj*)obj}})
+#define ARRAY_VAL(arrayObj) ((Value){VAL_ARRAY, {.obj = (Obj*)arrayObj}})
+#define ENUM_VAL(enumObj) ((Value){VAL_ENUM, {.obj = (Obj*)enumObj}})
+#define ARRAY_ITERATOR_VAL(iteratorObj) ((Value){VAL_ARRAY_ITERATOR, {.obj = (Obj*)iteratorObj}})
 #define ERROR_VAL(object) ((Value){VAL_ERROR, {.obj = (Obj*)object}})
 #define FUNCTION_VAL(value) ((Value){VAL_FUNCTION, {.obj = (Obj*)value}})
 #define CLOSURE_VAL(value) ((Value){VAL_CLOSURE, {.obj = (Obj*)value}})
@@ -1039,6 +1052,7 @@ typedef enum {
 #define AS_OBJ(value) ((value).as.obj)
 #define AS_STRING(value) ((ObjString*)(value).as.obj)
 #define AS_ARRAY(value) ((ObjArray*)(value).as.obj)
+#define AS_ENUM(value) ((ObjEnumInstance*)(value).as.obj)
 #define AS_ERROR(value) ((ObjError*)(value).as.obj)
 #define AS_RANGE_ITERATOR(value) ((ObjRangeIterator*)(value).as.obj)
 #define AS_ARRAY_ITERATOR(value) ((ObjArrayIterator*)(value).as.obj)
@@ -1053,6 +1067,7 @@ typedef enum {
 #define IS_F64(value) ((value).type == VAL_F64)
 #define IS_STRING(value) ((value).type == VAL_STRING)
 #define IS_ARRAY(value) ((value).type == VAL_ARRAY)
+#define IS_ENUM(value) ((value).type == VAL_ENUM)
 #define IS_ERROR(value) ((value).type == VAL_ERROR)
 #define IS_RANGE_ITERATOR(value) ((value).type == VAL_RANGE_ITERATOR)
 #define IS_ARRAY_ITERATOR(value) ((value).type == VAL_ARRAY_ITERATOR)

--- a/src/compiler/frontend/lexer.c
+++ b/src/compiler/frontend/lexer.c
@@ -251,6 +251,7 @@ static TokenType identifier_type(const char* start, int length) {
         case 'e':
             if (length == 4 && memcmp(start, "else", 4) == 0) return TOKEN_ELSE;
             if (length == 4 && memcmp(start, "elif", 4) == 0) return TOKEN_ELIF;
+            if (length == 4 && memcmp(start, "enum", 4) == 0) return TOKEN_ENUM;
             break;
         case 'f':
             if (length == 5 && memcmp(start, "false", 5) == 0)

--- a/src/type/type_representation.c
+++ b/src/type/type_representation.c
@@ -525,6 +525,15 @@ bool equalsType(Type* a, Type* b) {
             }
             if (av->field_count != bv->field_count) return false;
             for (int j = 0; j < av->field_count; j++) {
+                ObjString* afn = (av->field_names && j < av->field_count) ? av->field_names[j] : NULL;
+                ObjString* bfn = (bv->field_names && j < bv->field_count) ? bv->field_names[j] : NULL;
+                if (afn || bfn) {
+                    if (!afn || !bfn) return false;
+                    if (afn != bfn) {
+                        if (afn->length != bfn->length) return false;
+                        if (strncmp(afn->chars, bfn->chars, afn->length) != 0) return false;
+                    }
+                }
                 if (!equalsType(av->field_types[j], bv->field_types[j])) return false;
             }
         }
@@ -915,6 +924,11 @@ Type* createGenericType(ObjString* name) {
 Type* findStructType(const char* name) {
     if (!name || !struct_type_registry) return NULL;
     return hashmap_get(struct_type_registry, name);
+}
+
+Type* findEnumType(const char* name) {
+    if (!name || !enum_type_registry) return NULL;
+    return hashmap_get(enum_type_registry, name);
 }
 
 void freeType(Type* type) {

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -1638,6 +1638,49 @@ InterpretResult vm_run_dispatch(void) {
                     break;
                 }
 
+                case OP_ENUM_NEW_R: {
+                    uint8_t dst = READ_BYTE();
+                    uint8_t variantIndex = READ_BYTE();
+                    uint8_t payloadCount = READ_BYTE();
+                    uint8_t payloadStart = READ_BYTE();
+                    uint16_t typeConstIndex = READ_SHORT();
+                    uint16_t variantConstIndex = READ_SHORT();
+
+                    Value typeConst = READ_CONSTANT(typeConstIndex);
+                    if (!IS_STRING(typeConst)) {
+                        VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(),
+                                        "Enum constructor requires string type name constant");
+                    }
+
+                    ObjString* typeName = AS_STRING(typeConst);
+                    ObjString* variantName = NULL;
+                    Value variantConst = READ_CONSTANT(variantConstIndex);
+                    if (IS_STRING(variantConst)) {
+                        variantName = AS_STRING(variantConst);
+                    }
+
+                    ObjArray* payload = NULL;
+                    if (payloadCount > 0) {
+                        payload = allocateArray(payloadCount);
+                        if (!payload) {
+                            VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(), "Failed to allocate enum payload");
+                        }
+                        for (uint8_t i = 0; i < payloadCount; i++) {
+                            arrayEnsureCapacity(payload, i + 1);
+                            payload->elements[i] = vm_get_register_safe(payloadStart + i);
+                        }
+                        payload->length = payloadCount;
+                    }
+
+                    ObjEnumInstance* instance = allocateEnumInstance(typeName, variantName, variantIndex, payload);
+                    if (!instance) {
+                        VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(), "Failed to allocate enum instance");
+                    }
+
+                    vm_set_register_safe(dst, ENUM_VAL(instance));
+                    break;
+                }
+
                 case OP_ARRAY_GET_R: {
                     uint8_t dst = READ_BYTE();
                     uint8_t array_reg = READ_BYTE();

--- a/src/vm/operations/vm_string_ops.c
+++ b/src/vm/operations/vm_string_ops.c
@@ -187,12 +187,15 @@ void free_string_table(StringInternTable* table) {
     if (!table || !table->interned) return;
     HashMapIterator it;
     hashmap_iterator_init(table->interned, &it);
+    bool skip_object_free = vm.isShuttingDown;
     while (hashmap_iterator_has_next(&it)) {
         ObjString* s = (ObjString*)hashmap_iterator_next_value(&it);
         if (s) {
-            if (s->rope) free_rope(s->rope);
-            free(s->chars);
-            free(s);
+            if (!skip_object_free) {
+                if (s->rope) free_rope(s->rope);
+                free(s->chars);
+                free(s);
+            }
         }
     }
     hashmap_free(table->interned);

--- a/src/vm/utils/debug.c
+++ b/src/vm/utils/debug.c
@@ -195,6 +195,18 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return offset + 4;
         }
 
+        case OP_ENUM_NEW_R: {
+            uint8_t dst = chunk->code[offset + 1];
+            uint8_t variant = chunk->code[offset + 2];
+            uint8_t payload = chunk->code[offset + 3];
+            uint8_t start = chunk->code[offset + 4];
+            uint16_t typeConst = (uint16_t)((chunk->code[offset + 5] << 8) | chunk->code[offset + 6]);
+            uint16_t variantConst = (uint16_t)((chunk->code[offset + 7] << 8) | chunk->code[offset + 8]);
+            printf("%-16s R%d, variant=%d, count=%d, start=R%d, typeConst=%d, variantConst=%d\n",
+                   "ENUM_NEW", dst, variant, payload, start, typeConst, variantConst);
+            return offset + 9;
+        }
+
         case OP_ARRAY_GET_R: {
             uint8_t dst = chunk->code[offset + 1];
             uint8_t array_reg = chunk->code[offset + 2];

--- a/tests/comprehensive/enum_runtime.orus
+++ b/tests/comprehensive/enum_runtime.orus
@@ -1,0 +1,25 @@
+enum Flag:
+    On
+    Off
+
+enum Result:
+    Ok(value: i32)
+    Err(message: string)
+
+fn flip(flag: Flag) -> Flag:
+    return Flag.Off if flag == Flag.On else Flag.On
+
+fn produce(value: i32) -> Result:
+    return Result.Ok(value)
+
+fn fail(text: string) -> Result:
+    return Result.Err(text)
+
+fn main():
+    mut status: Flag = Flag.On
+    status = flip(status)
+
+    mut outcome: Result = produce(7)
+    outcome = fail("boom")
+
+    print("enum runtime ok")

--- a/tests/types/enum_constructors.orus
+++ b/tests/types/enum_constructors.orus
@@ -1,0 +1,24 @@
+enum Flag:
+    On
+    Off
+
+enum Result:
+    Ok(value: i32)
+    Err(message: string)
+
+fn flip(flag: Flag) -> Flag:
+    return Flag.Off if flag == Flag.On else Flag.On
+
+fn make_ok(value: i32) -> Result:
+    return Result.Ok(value)
+
+fn make_err(text: string) -> Result:
+    return Result.Err(text)
+
+mut status: Flag = Flag.On
+status = flip(status)
+
+mut outcome: Result = make_ok(7)
+outcome = make_err("boom")
+
+print("enum constructors resolved")

--- a/tests/types/enum_declarations.orus
+++ b/tests/types/enum_declarations.orus
@@ -1,0 +1,19 @@
+enum Status:
+    Ok
+    Error(message: string)
+
+struct Response:
+    status: Status
+    retries: i32 = 0
+
+fn describe(status: Status):
+    print("inspecting status")
+
+enum Result:
+    Ok(value: i32)
+    Err(message: string)
+
+fn consume(result: Result):
+    print("result placeholder")
+
+print("enum declarations validated")


### PR DESCRIPTION
## Summary
- add an OP_ENUM_NEW_R opcode that lowers enum variant accesses and constructor calls to runtime allocations
- teach the VM to allocate, mark, print, compare, and disassemble ObjEnumInstance values while protecting the intern table from double frees during shutdown
- extend documentation and comprehensive tests with a runtime enum smoke test