### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.5.0] - 2025-09-20
+
+### Changed
+- Bumped version to 0.5.0.
+
 ## [0.4.0] - 2025-09-19
 
 ### Changed
@@ -42,6 +47,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.2.2] - 2025-07-16
 - Introduced public `version.h` and initial 0.2.x series setup.
 
+[0.5.0]: https://github.com/jordyorel/orus-lang/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jordyorel/orus-lang/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/jordyorel/orus-lang/compare/v0.2.4...v0.3.0
 [0.2.4]: https://github.com/jordyorel/orus-lang/compare/v0.2.3...v0.2.4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orus Programming Language
 
-[![Version](https://img.shields.io/badge/version-0.4.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)](CHANGELOG.md)
 
 Fast, elegant programming language with Python's readability and Rust's safety.
 

--- a/include/public/version.h
+++ b/include/public/version.h
@@ -2,7 +2,7 @@
 #define ORUS_VERSION_H
 
 #define ORUS_VERSION_MAJOR 0
-#define ORUS_VERSION_MINOR 4
+#define ORUS_VERSION_MINOR 5
 #define ORUS_VERSION_PATCH 0
 
 // Helpers to stringify numeric macros


### PR DESCRIPTION
## Summary
- bump the public version macros to 0.5.0
- refresh the README badge to show 0.5.0
- document the 0.5.0 release in the changelog