### PR TITLE
Document current match support and remaining work

### DIFF
--- a/docs/IMPLEMENTATION_GUIDE.md
+++ b/docs/IMPLEMENTATION_GUIDE.md
@@ -3904,9 +3904,9 @@ fn binary_search<T: Comparable>(arr: [T], target: T) -> Option<i32>:
     while left <= right:
         mid = (left + right) / 2
         match compare(arr[mid], target):
-            Ordering.Less: left = mid + 1
-            Ordering.Greater: right = mid - 1
-            Ordering.Equal: return Some(mid)
+            Ordering.Less -> left = mid + 1
+            Ordering.Greater -> right = mid - 1
+            Ordering.Equal -> return Some(mid)
     
     None
 
@@ -4246,36 +4246,36 @@ pub enum Result<T, E>:
 impl<T, E> Result<T, E>:
     pub fn is_ok(self) -> bool:
         match self:
-            Result.Ok(_): true
-            Result.Err(_): false
+            Result.Ok(_) -> true
+            Result.Err(_) -> false
     
     pub fn is_err(self) -> bool:
         not self.is_ok()
     
     pub fn unwrap(self) -> T:
         match self:
-            Result.Ok(v): v
-            Result.Err(e): panic("Unwrap on Err:", e)
+            Result.Ok(v) -> v
+            Result.Err(e) -> panic("Unwrap on Err:", e)
     
     pub fn unwrap_or(self, default: T) -> T:
         match self:
-            Result.Ok(v): v
-            Result.Err(_): default
+            Result.Ok(v) -> v
+            Result.Err(_) -> default
     
     pub fn map<U>(self, f: fn(T) -> U) -> Result<U, E>:
         match self:
-            Result.Ok(v): Result.Ok(f(v))
-            Result.Err(e): Result.Err(e)
+            Result.Ok(v) -> Result.Ok(f(v))
+            Result.Err(e) -> Result.Err(e)
     
     pub fn map_err<F>(self, f: fn(E) -> F) -> Result<T, F>:
         match self:
-            Result.Ok(v): Result.Ok(v)
-            Result.Err(e): Result.Err(f(e))
+            Result.Ok(v) -> Result.Ok(v)
+            Result.Err(e) -> Result.Err(f(e))
     
     pub fn and_then<U>(self, f: fn(T) -> Result<U, E>) -> Result<U, E>:
         match self:
-            Result.Ok(v): f(v)
-            Result.Err(e): Result.Err(e)
+            Result.Ok(v) -> f(v)
+            Result.Err(e) -> Result.Err(e)
 ```
 
 ---

--- a/docs/MISSING copy.md
+++ b/docs/MISSING copy.md
@@ -34,7 +34,7 @@ Build a language that combines Python's readability, Rust's safety, and Lua's pe
 - [ ] Advanced type inference
 - [ ] Arrays and collections (type system ready)
 - [ ] Struct definitions and methods
-- [ ] Pattern matching and enums
+- [*] Pattern matching and enums (statement form shipped, expression form pending)
 - [ ] Module system
 
 ---
@@ -678,8 +678,10 @@ enum Result<T, E>:
 
 fn handle_result<T, E>(result: Result<T, E>) -> T:
     match result:
-        Ok(value): value
-        Error(err): panic("Error: ", err)
+        Ok(value) ->
+            return value
+        Error(err) ->
+            panic("Error: ", err)
 
 // Advanced inference with generic collections
 numbers = [1, 2, 3]               // Inferred as [i32]
@@ -1218,7 +1220,7 @@ pub fn with_file<T>(path: string, mode: OpenMode, callback: fn(File) -> T) -> Re
 
 ### **Quarter 2: Data & Types (Weeks 13-24)**
 - [ ] **Weeks 13-16**: Arrays, collections, basic type system, enhanced error reporting
-- [ ] **Weeks 17-20**: Pattern matching, structs, enums
+- [*] **Weeks 17-20**: Pattern matching, structs, enums (match statements merged; expression form + module-aware structs still pending)
 - [ ] **Weeks 21-24**: Module system, standard library core
 
 ### **Quarter 3: Production Ready (Weeks 25-36)**
@@ -1251,7 +1253,7 @@ pub fn with_file<T>(path: string, mode: OpenMode, callback: fn(File) -> T) -> Re
 - [ ] **Module System** - Code organization and library support
 - [ ] **Advanced Type System** - Generics, inference, and safety
 - [ ] **Error Handling** - Result types and exception management
-- [ ] **Pattern Matching** - Modern language feature for data handling
+- [*] **Pattern Matching** - Statement-oriented matcher ships; expression-yielding form and literal-duplicate diagnostics remain
 
 This roadmap progresses systematically from basic language features to advanced capabilities, ensuring each phase builds solid foundations for the next. The register-based VM and existing infrastructure provide an excellent platform for rapid feature development.
 

--- a/tests/control_flow/match_non_enum.orus
+++ b/tests/control_flow/match_non_enum.orus
@@ -1,0 +1,26 @@
+fn describe(value: i32) -> string:
+    match value:
+        0 -> return "zero"
+        1 ->
+            return "one"
+        2 ->
+            return "two"
+        _ ->
+            return "other"
+
+fn log_value(value: i32):
+    match value:
+        0 -> print("zero inline")
+        1 ->
+            print("one block")
+            print("still one")
+        _ ->
+            print("fallback")
+
+print(describe(0))
+print(describe(1))
+print(describe(2))
+print(describe(3))
+log_value(0)
+log_value(1)
+log_value(7)

--- a/tests/type_safety_fails/duplicate_match_arm.orus
+++ b/tests/type_safety_fails/duplicate_match_arm.orus
@@ -4,11 +4,11 @@ enum Mode:
 
 fn handle(mode: Mode):
     match mode:
-        Mode.Read:
+        Mode.Read ->
             print("first read")
-        Mode.Read:
+        Mode.Read ->
             print("duplicate read")
-        Mode.Write:
+        Mode.Write ->
             print("write")
 
 handle(Mode.Read)

--- a/tests/type_safety_fails/enum_match_payload_mismatch.orus
+++ b/tests/type_safety_fails/enum_match_payload_mismatch.orus
@@ -4,7 +4,7 @@ enum Shape:
 
 fn describe(shape: Shape):
     match shape:
-        Shape.Point(x):
+        Shape.Point(x) ->
             print("point", x)
-        Shape.Line(length):
+        Shape.Line(length) ->
             print("line", length)

--- a/tests/type_safety_fails/enum_match_unknown_variant.orus
+++ b/tests/type_safety_fails/enum_match_unknown_variant.orus
@@ -4,7 +4,7 @@ enum Status:
 
 fn handle(status: Status):
     match status:
-        Status.Idle:
+        Status.Idle ->
             print("idle")
-        Status.Busy(message):
+        Status.Busy(message) ->
             print("busy", message)

--- a/tests/type_safety_fails/non_exhaustive_match.orus
+++ b/tests/type_safety_fails/non_exhaustive_match.orus
@@ -4,7 +4,7 @@ enum Flag:
 
 fn check(flag: Flag):
     match flag:
-        Flag.On:
+        Flag.On ->
             print("on")
 
 check(Flag.Off)

--- a/tests/types/enum_match_destructuring.orus
+++ b/tests/types/enum_match_destructuring.orus
@@ -8,16 +8,16 @@ enum Pair:
 
 fn describe(opt: Option[i32]):
     match opt:
-        Option.Some(value):
+        Option.Some(value) ->
             print("some", value)
-        Option.None():
+        Option.None() ->
             print("none")
 
 pair = Pair.First(7, 9)
 match pair:
-    Pair.First(_, right):
+    Pair.First(_, right) ->
         print("right", right)
-    Pair.Second:
+    Pair.Second ->
         print("second")
 
 describe(Option.Some(42))

--- a/tests/types/enum_match_patterns.orus
+++ b/tests/types/enum_match_patterns.orus
@@ -11,23 +11,23 @@ enum MaybePair:
 
 fn describe(result: Result):
     match result:
-        Result.Ok(value):
+        Result.Ok(value) ->
             print("ok", value)
-        Result.Err(code, _):
+        Result.Err(code, _) ->
             print("error", code)
-        Result.Cancelled(reason):
+        Result.Cancelled(reason) ->
             print("cancelled", reason)
-        _:
+        _ ->
             print("other")
 
 fn sum_pair(option: MaybePair) -> i32:
     mut total = -1
     match option:
-        MaybePair.Pair(left, right):
+        MaybePair.Pair(left, right) ->
             total = left + right
-        MaybePair.Lone(value):
+        MaybePair.Lone(value) ->
             total = value
-        _:
+        _ ->
             total = 0
     return total
 

--- a/tests/types/enum_match_statement.orus
+++ b/tests/types/enum_match_statement.orus
@@ -4,16 +4,16 @@ enum Flag:
 
 fn describe(flag: Flag) -> string:
     match flag:
-        Flag.On:
+        Flag.On ->
             return "on"
-        Flag.Off:
+        Flag.Off ->
             return "off"
 
 fn describe_with_default(flag: Flag) -> string:
     match flag:
-        Flag.On:
+        Flag.On ->
             return "active"
-        _:
+        _ ->
             return "inactive"
 
 print(describe(Flag.On))


### PR DESCRIPTION
## Summary
- document the current arrow-based match arm syntax in the roadmap and highlight that expression forms remain outstanding
- update the duplicate roadmap copy and implementation guide examples to use the unified `pattern ->` style while describing the remaining work for expression-style matches
