### PR TITLE
Add throw statement and VM exception unwinding

### DIFF
--- a/include/compiler/ast.h
+++ b/include/compiler/ast.h
@@ -56,6 +56,8 @@ typedef enum {
     NODE_WHILE,
     NODE_FOR_RANGE,
     NODE_FOR_ITER,
+    NODE_TRY,
+    NODE_THROW,
     NODE_BLOCK,
     NODE_TERNARY,
     NODE_UNARY,
@@ -174,6 +176,14 @@ struct ASTNode {
             ASTNode* body;
             char* label;
         } forIter;
+        struct {
+            ASTNode* tryBlock;
+            char* catchVar;
+            ASTNode* catchBlock;
+        } tryStmt;
+        struct {
+            ASTNode* value;
+        } throwStmt;
         struct {
             ASTNode** statements;
             int count;

--- a/include/compiler/codegen/codegen.h
+++ b/include/compiler/codegen/codegen.h
@@ -38,6 +38,8 @@ void compile_if_statement(CompilerContext* ctx, TypedASTNode* if_stmt);
 void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt);
 void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt);
 void compile_for_iter_statement(CompilerContext* ctx, TypedASTNode* for_stmt);
+void compile_try_statement(CompilerContext* ctx, TypedASTNode* try_stmt);
+void compile_throw_statement(CompilerContext* ctx, TypedASTNode* throw_stmt);
 void compile_break_statement(CompilerContext* ctx, TypedASTNode* break_stmt);
 void compile_continue_statement(CompilerContext* ctx, TypedASTNode* continue_stmt);
 

--- a/include/compiler/lexer.h
+++ b/include/compiler/lexer.h
@@ -64,6 +64,7 @@ typedef enum {
     TOKEN_CONST,
     TOKEN_WHILE,
     TOKEN_TRY,
+    TOKEN_THROW,
     TOKEN_CATCH,
     TOKEN_INT,
     TOKEN_I64,

--- a/include/compiler/typed_ast.h
+++ b/include/compiler/typed_ast.h
@@ -106,6 +106,14 @@ struct TypedASTNode {
             char* label;
         } forIter;
         struct {
+            TypedASTNode* tryBlock;
+            TypedASTNode* catchBlock;
+            char* catchVarName;
+        } tryStmt;
+        struct {
+            TypedASTNode* value;
+        } throwStmt;
+        struct {
             TypedASTNode** statements;
             int count;
         } block;

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -355,9 +355,11 @@ typedef struct RegisterMetadata {
 // Try frame
 typedef struct {
     uint8_t* handler;
-    uint8_t varIndex;
+    uint16_t catchRegister;
     int stackDepth;
 } TryFrame;
+
+#define TRY_CATCH_REGISTER_NONE 0xFFFF
 
 // Module system
 typedef struct {
@@ -520,6 +522,9 @@ typedef enum {
     OP_ARRAY_SLICE_R, // dst, array_reg, start_reg, end_reg
 
     // Control flow
+    OP_TRY_BEGIN,
+    OP_TRY_END,
+    OP_THROW,
     OP_JUMP,
     OP_JUMP_IF_R,      // condition_reg, offset
     OP_JUMP_IF_NOT_R,  // condition_reg, offset
@@ -1122,6 +1127,7 @@ void freeObjects(void);
 // Upvalue management
 ObjUpvalue* captureUpvalue(Value* local);
 void closeUpvalues(Value* last);
+void vm_unwind_to_stack_depth(int targetDepth);
 
 // Type system
 void initTypeSystem(void);

--- a/src/compiler/backend/compiler.c
+++ b/src/compiler/backend/compiler.c
@@ -209,6 +209,7 @@ static inline int determine_prefix_size(uint8_t opcode) {
     switch (opcode) {
         case OP_JUMP_IF_NOT_R:
         case OP_JUMP_IF_R:
+        case OP_TRY_BEGIN:
             return 2;  // opcode + condition register
         case OP_JUMP_IF_NOT_SHORT:
             return 2;  // opcode + condition register
@@ -224,6 +225,8 @@ static inline int determine_operand_size(uint8_t opcode) {
         case OP_JUMP_IF_NOT_SHORT:
         case OP_LOOP_SHORT:
             return 1;
+        case OP_TRY_BEGIN:
+            return 2;
         default:
             return 2;
     }
@@ -286,6 +289,7 @@ bool patch_jump(BytecodeBuffer* buffer, int patch_index, int target_offset) {
     switch (patch->opcode) {
         case OP_JUMP_IF_NOT_R:
         case OP_JUMP_IF_R:
+        case OP_TRY_BEGIN:
         {
             relative = target_offset - next_ip;
             if (relative < 0 || relative > 0xFFFF) {

--- a/src/compiler/backend/optimization/constantfold.c
+++ b/src/compiler/backend/optimization/constantfold.c
@@ -151,7 +151,16 @@ bool apply_constant_folding_recursive(TypedASTNode* ast) {
                 apply_constant_folding_recursive(ast->typed.ifStmt.elseBranch);
             }
             break;
-            
+
+        case NODE_TRY:
+            if (ast->typed.tryStmt.tryBlock) {
+                apply_constant_folding_recursive(ast->typed.tryStmt.tryBlock);
+            }
+            if (ast->typed.tryStmt.catchBlock) {
+                apply_constant_folding_recursive(ast->typed.tryStmt.catchBlock);
+            }
+            break;
+
         default:
             // No folding needed for other node types
             break;

--- a/src/compiler/backend/typed_ast_visualizer.c
+++ b/src/compiler/backend/typed_ast_visualizer.c
@@ -73,6 +73,8 @@ static const char* get_node_type_name(NodeType type) {
         case NODE_WHILE: return "While";
         case NODE_FOR_RANGE: return "ForRange";
         case NODE_FOR_ITER: return "ForIter";
+        case NODE_TRY: return "Try";
+        case NODE_THROW: return "Throw";
         case NODE_BLOCK: return "Block";
         case NODE_TERNARY: return "Ternary";
         case NODE_UNARY: return "Unary";
@@ -552,11 +554,25 @@ static void visualize_node_recursive(TypedASTNode* node, int depth, bool is_last
             break;
         case NODE_FOR_ITER:
             if (node->typed.forIter.iterable) {
-                visualize_node_recursive(node->typed.forIter.iterable, depth + 1, 
+                visualize_node_recursive(node->typed.forIter.iterable, depth + 1,
                                        !node->typed.forIter.body, config);
             }
             if (node->typed.forIter.body) {
                 visualize_node_recursive(node->typed.forIter.body, depth + 1, true, config);
+            }
+            break;
+        case NODE_TRY:
+            if (node->typed.tryStmt.tryBlock) {
+                visualize_node_recursive(node->typed.tryStmt.tryBlock, depth + 1,
+                                       !node->typed.tryStmt.catchBlock, config);
+            }
+            if (node->typed.tryStmt.catchBlock) {
+                visualize_node_recursive(node->typed.tryStmt.catchBlock, depth + 1, true, config);
+            }
+            break;
+        case NODE_THROW:
+            if (node->typed.throwStmt.value) {
+                visualize_node_recursive(node->typed.throwStmt.value, depth + 1, true, config);
             }
             break;
         case NODE_FUNCTION:

--- a/src/compiler/frontend/lexer.c
+++ b/src/compiler/frontend/lexer.c
@@ -306,6 +306,7 @@ static TokenType identifier_type(const char* start, int length) {
         case 't':
             if (length == 4 && memcmp(start, "true", 4) == 0) return TOKEN_TRUE;
             if (length == 3 && memcmp(start, "try", 3) == 0) return TOKEN_TRY;
+            if (length == 5 && memcmp(start, "throw", 5) == 0) return TOKEN_THROW;
             if (length == 10 && memcmp(start, "time_stamp", 10) == 0) return TOKEN_TIME_STAMP;
             break;
         case 'u':
@@ -961,6 +962,7 @@ const char* token_type_to_string(TokenType type) {
         case TOKEN_CONST: return "CONST";
         case TOKEN_WHILE: return "WHILE";
         case TOKEN_TRY: return "TRY";
+        case TOKEN_THROW: return "THROW";
         case TOKEN_CATCH: return "CATCH";
         case TOKEN_INT: return "INT";
         case TOKEN_I64: return "I64";

--- a/src/compiler/typed_ast.c
+++ b/src/compiler/typed_ast.c
@@ -78,6 +78,14 @@ TypedASTNode* create_typed_ast_node(ASTNode* original) {
             typed->typed.forIter.iterable = NULL;
             typed->typed.forIter.body = NULL;
             break;
+        case NODE_TRY:
+            typed->typed.tryStmt.tryBlock = NULL;
+            typed->typed.tryStmt.catchBlock = NULL;
+            typed->typed.tryStmt.catchVarName = NULL;
+            break;
+        case NODE_THROW:
+            typed->typed.throwStmt.value = NULL;
+            break;
         case NODE_BLOCK:
             typed->typed.block.statements = NULL;
             typed->typed.block.count = 0;
@@ -259,6 +267,16 @@ void free_typed_ast_node(TypedASTNode* node) {
         case NODE_FOR_ITER:
             free_typed_ast_node(node->typed.forIter.iterable);
             free_typed_ast_node(node->typed.forIter.body);
+            break;
+        case NODE_TRY:
+            free_typed_ast_node(node->typed.tryStmt.tryBlock);
+            free_typed_ast_node(node->typed.tryStmt.catchBlock);
+            if (node->typed.tryStmt.catchVarName) {
+                free(node->typed.tryStmt.catchVarName);
+            }
+            break;
+        case NODE_THROW:
+            free_typed_ast_node(node->typed.throwStmt.value);
             break;
         case NODE_BLOCK:
             if (node->typed.block.statements) {
@@ -580,6 +598,18 @@ bool validate_typed_ast(TypedASTNode* root) {
                 return false;
             }
             break;
+        case NODE_TRY:
+            if (root->typed.tryStmt.tryBlock &&
+                !validate_typed_ast(root->typed.tryStmt.tryBlock)) {
+                return false;
+            }
+            if (root->typed.tryStmt.catchBlock &&
+                !validate_typed_ast(root->typed.tryStmt.catchBlock)) {
+                return false;
+            }
+            break;
+        case NODE_THROW:
+            return validate_typed_ast(root->typed.throwStmt.value);
         default:
             // For leaf nodes, just check if type is resolved
             break;
@@ -691,6 +721,12 @@ void print_typed_ast(TypedASTNode* node, int indent) {
             break;
         case NODE_FOR_ITER:
             nodeTypeStr = "ForIter";
+            break;
+        case NODE_TRY:
+            nodeTypeStr = "Try";
+            break;
+        case NODE_THROW:
+            nodeTypeStr = "Throw";
             break;
         case NODE_BLOCK:
             nodeTypeStr = "Block";
@@ -860,6 +896,17 @@ void print_typed_ast(TypedASTNode* node, int indent) {
         case NODE_FOR_ITER:
             print_typed_ast(node->typed.forIter.iterable, indent + 1);
             print_typed_ast(node->typed.forIter.body, indent + 1);
+            break;
+        case NODE_TRY:
+            if (node->typed.tryStmt.tryBlock) {
+                print_typed_ast(node->typed.tryStmt.tryBlock, indent + 1);
+            }
+            if (node->typed.tryStmt.catchBlock) {
+                print_typed_ast(node->typed.tryStmt.catchBlock, indent + 1);
+            }
+            break;
+        case NODE_THROW:
+            print_typed_ast(node->typed.throwStmt.value, indent + 1);
             break;
         case NODE_BLOCK:
             if (node->typed.block.statements) {

--- a/src/vm/core/vm_internal.h
+++ b/src/vm/core/vm_internal.h
@@ -17,7 +17,7 @@ void runtimeError(ErrorType type, SrcLocation location, const char* format, ...)
 #define VM_ERROR_RETURN(type, loc, msg, ...) \
     do { \
         runtimeError(type, loc, msg, ##__VA_ARGS__); \
-        RETURN(INTERPRET_RUNTIME_ERROR); \
+        goto HANDLE_RUNTIME_ERROR; \
     } while (0)
 
 #define VM_TYPE_CHECK(cond, msg) \

--- a/src/vm/utils/debug.c
+++ b/src/vm/utils/debug.c
@@ -391,6 +391,27 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return offset + 3;
         }
 
+        case OP_TRY_BEGIN: {
+            uint8_t reg = chunk->code[offset + 1];
+            uint16_t jump = (uint16_t)((chunk->code[offset + 2] << 8) | chunk->code[offset + 3]);
+            if (reg == 0xFF) {
+                printf("%-16s catch=<none>, +%d\n", "TRY_BEGIN", jump);
+            } else {
+                printf("%-16s catch=R%u, +%d\n", "TRY_BEGIN", reg, jump);
+            }
+            return offset + 4;
+        }
+
+        case OP_TRY_END:
+            printf("%-16s\n", "TRY_END");
+            return offset + 1;
+
+        case OP_THROW: {
+            uint8_t reg = chunk->code[offset + 1];
+            printf("%-16s R%u\n", "THROW", reg);
+            return offset + 2;
+        }
+
         case OP_JUMP: {
             uint16_t jump = (uint16_t)((chunk->code[offset + 1] << 8) | chunk->code[offset + 2]);
             printf("%-16s +%d\n", "JUMP", jump);

--- a/tests/control_flow/try_catch.orus
+++ b/tests/control_flow/try_catch.orus
@@ -1,0 +1,51 @@
+fn fail_in_function():
+    value = 100 / 0
+
+// Basic try/catch execution paths
+print("== try/catch smoke test ==")
+
+print("-- success path --")
+try:
+    value = 6 / 3
+    print("computed", value)
+catch err:
+    print("unexpected", err)
+print("after success")
+
+print("-- failure with catch var --")
+try:
+    print("before failure")
+    failing = 1 / 0
+    print("unreachable")
+catch err:
+    print("caught runtime error")
+    print(err)
+print("after catch var")
+
+print("-- failure without catch var --")
+try:
+    print("before second failure")
+    another = 2 / 0
+catch:
+    print("caught without variable")
+print("after catch without var")
+
+print("-- propagation across function boundary --")
+try:
+    fail_in_function()
+catch err:
+    print("caught from function")
+    print(err)
+print("after function propagation")
+
+print("-- rethrow from catch --")
+try:
+    try:
+        temp = 5 / 0
+    catch err:
+        print("inner catch, rethrowing")
+        throw err
+catch outer:
+    print("outer caught rethrow")
+    print(outer)
+print("after rethrow")


### PR DESCRIPTION
## Summary
- add a throw statement to the front end, typed AST, and type inference so error values can be raised explicitly
- emit a new OP_THROW instruction and ensure code generation frees temporaries after throwing
- teach the VM to unwind call frames when handling errors, route VM_ERROR_RETURN through try/catch handlers, and expand the try/catch control-flow test to cover propagation and rethrowing