### PR TITLE
Silence compiler warnings in debug and release builds

### DIFF
--- a/include/internal/logging.h
+++ b/include/internal/logging.h
@@ -6,6 +6,10 @@
 #ifndef ORUS_LOGGING_H
 #define ORUS_LOGGING_H
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/include/vm/vm_comparison.h
+++ b/include/vm/vm_comparison.h
@@ -2,10 +2,26 @@
 #define ORUS_VM_COMPARISON_H
 
 #include "../../src/vm/core/vm_internal.h"
+#include "vm/register_file.h"
 
-// Forward declarations for frame-aware register access
-extern inline Value vm_get_register_safe(uint16_t id);
-extern inline void vm_set_register_safe(uint16_t id, Value value);
+// Frame-aware register access helpers shared across dispatch implementations
+static inline Value vm_get_register_safe(uint16_t id) {
+    if (id < 256) {
+        return vm.registers[id];
+    }
+
+    Value* reg_ptr = get_register(&vm.register_file, id);
+    return reg_ptr ? *reg_ptr : BOOL_VAL(false);
+}
+
+static inline void vm_set_register_safe(uint16_t id, Value value) {
+    if (id < 256) {
+        vm.registers[id] = value;
+        return;
+    }
+
+    set_register(&vm.register_file, id, value);
+}
 
 // Equality comparisons
 #define CMP_EQ(dst, a, b) \

--- a/include/vm/vm_control_flow.h
+++ b/include/vm/vm_control_flow.h
@@ -1,13 +1,7 @@
 #ifndef ORUS_VM_CONTROL_FLOW_H
 #define ORUS_VM_CONTROL_FLOW_H
 
-#include "../../src/vm/core/vm_internal.h"
-
-// Forward declarations for safe register access helpers implemented in the
-// computed-goto dispatch unit. These provide bounds-checked access to the
-// unified register file without exposing the underlying representation here.
-Value vm_get_register_safe(uint16_t id);
-void vm_set_register_safe(uint16_t id, Value value);
+#include "vm/vm_comparison.h"
 
 static inline bool CF_JUMP(uint16_t offset) {
     // If VM is shutting down or chunk is invalid, ignore jump

--- a/include/vm/vm_opcode_handlers.h
+++ b/include/vm/vm_opcode_handlers.h
@@ -46,174 +46,37 @@ void handle_mod_f64_typed(void);
 // ====== Memory Operation Handlers ======
 
 // Constant loading operations
-static inline void handle_load_i32_const(void);
-static inline void handle_load_i64_const(void);
-static inline void handle_load_u32_const(void);
-static inline void handle_load_u64_const(void);
-static inline void handle_load_f64_const(void);
+void handle_load_i32_const(void);
+void handle_load_i64_const(void);
+void handle_load_u32_const(void);
+void handle_load_u64_const(void);
+void handle_load_f64_const(void);
+void handle_load_const_ext(void);
 
 // Register operations
-static inline void handle_move_reg(void);
-static inline void handle_load_const(void);
-static inline void handle_load_true(void);
-static inline void handle_load_false(void);
+void handle_move_reg(void);
+void handle_load_const(void);
+void handle_move_ext(void);
+void handle_load_true(void);
+void handle_load_false(void);
 
 // Global variable operations
-static inline void handle_load_global(void);
-static inline void handle_store_global(void);
+void handle_load_global(void);
+void handle_store_global(void);
 
 // Typed move operations
-static inline void handle_move_i32(void);
-static inline void handle_move_i64(void);
-static inline void handle_move_u32(void);
-static inline void handle_move_u64(void);
-static inline void handle_move_f64(void);
-
-// ====== Control Flow Operation Handlers ======
-
-// Jump operations
-static inline void handle_jump_short(void);
-static inline void handle_jump_back_short(void);
-static inline void handle_jump_if_not_short(void);
-static inline void handle_loop_short(void);
-
-// Long jump operations
-static inline void handle_jump_long(void);
-static inline void handle_jump_if_not_long(void);
-static inline void handle_loop_long(void);
-
-// Conditional operations
-static inline void handle_jump_if_false(void);
-static inline void handle_jump_if_true(void);
-
-// ====== Comparison Operation Handlers ======
-
-// I32 comparison operations
-static inline void handle_lt_i32_typed(void);
-static inline void handle_le_i32_typed(void);
-static inline void handle_gt_i32_typed(void);
-static inline void handle_ge_i32_typed(void);
-static inline void handle_eq_i32_typed(void);
-static inline void handle_ne_i32_typed(void);
-
-// I64 comparison operations
-static inline void handle_lt_i64_typed(void);
-static inline void handle_le_i64_typed(void);
-static inline void handle_gt_i64_typed(void);
-static inline void handle_ge_i64_typed(void);
-static inline void handle_eq_i64_typed(void);
-static inline void handle_ne_i64_typed(void);
-
-// U32 comparison operations
-static inline void handle_lt_u32_typed(void);
-static inline void handle_le_u32_typed(void);
-static inline void handle_gt_u32_typed(void);
-static inline void handle_ge_u32_typed(void);
-static inline void handle_eq_u32_typed(void);
-static inline void handle_ne_u32_typed(void);
-
-// U64 comparison operations
-static inline void handle_lt_u64_typed(void);
-static inline void handle_le_u64_typed(void);
-static inline void handle_gt_u64_typed(void);
-static inline void handle_ge_u64_typed(void);
-static inline void handle_eq_u64_typed(void);
-static inline void handle_ne_u64_typed(void);
-
-// F64 comparison operations
-static inline void handle_lt_f64_typed(void);
-static inline void handle_le_f64_typed(void);
-static inline void handle_gt_f64_typed(void);
-static inline void handle_ge_f64_typed(void);
-static inline void handle_eq_f64_typed(void);
-static inline void handle_ne_f64_typed(void);
-
-// ====== Type Conversion Operation Handlers ======
-
-// I32 conversions
-static inline void handle_i32_to_i64(void);
-static inline void handle_i32_to_u32(void);
-static inline void handle_i32_to_u64(void);
-static inline void handle_i32_to_f64(void);
-static inline void handle_i32_to_bool(void);
-static inline void handle_i32_to_string(void);
-
-// I64 conversions
-static inline void handle_i64_to_i32(void);
-static inline void handle_i64_to_u32(void);
-static inline void handle_i64_to_u64(void);
-static inline void handle_i64_to_f64(void);
-static inline void handle_i64_to_bool(void);
-static inline void handle_i64_to_string(void);
-
-// U32 conversions
-static inline void handle_u32_to_i32(void);
-static inline void handle_u32_to_i64(void);
-static inline void handle_u32_to_u64(void);
-static inline void handle_u32_to_f64(void);
-static inline void handle_u32_to_bool(void);
-static inline void handle_u32_to_string(void);
-
-// U64 conversions
-static inline void handle_u64_to_i32(void);
-static inline void handle_u64_to_i64(void);
-static inline void handle_u64_to_u32(void);
-static inline void handle_u64_to_f64(void);
-static inline void handle_u64_to_bool(void);
-static inline void handle_u64_to_string(void);
-
-// F64 conversions
-static inline void handle_f64_to_i32(void);
-static inline void handle_f64_to_i64(void);
-static inline void handle_f64_to_u32(void);
-static inline void handle_f64_to_u64(void);
-static inline void handle_f64_to_bool(void);
-static inline void handle_f64_to_string(void);
-
-// Bool conversions
-static inline void handle_bool_to_i32(void);
-static inline void handle_bool_to_i64(void);
-static inline void handle_bool_to_u32(void);
-static inline void handle_bool_to_u64(void);
-static inline void handle_bool_to_f64(void);
-static inline void handle_bool_to_string(void);
-
-// ====== String Operation Handlers ======
-
-// String operations
-static inline void handle_concat_string(void);
-static inline void handle_load_string_const(void);
-
-// ====== Utility Operation Handlers ======
+void handle_move_i32(void);
+void handle_move_i64(void);
+void handle_move_u32(void);
+void handle_move_u64(void);
+void handle_move_f64(void);
 
 // Print and debug operations
-static inline void handle_print(void);
-static inline void handle_print_multi(void);
-static inline void handle_print_no_nl(void);
-static inline void handle_halt(void);
-static inline void handle_time_stamp(void);
-
-// Increment/decrement operations
-static inline void handle_inc_i32(void);
-static inline void handle_dec_i32(void);
-static inline void handle_inc_i64(void);
-static inline void handle_dec_i64(void);
-
-// Unary operations
-static inline void handle_neg_i32(void);
-static inline void handle_neg_i64(void);
-static inline void handle_neg_f64(void);
-
-// Bitwise operations
-static inline void handle_and_i32(void);
-static inline void handle_or_i32(void);
-static inline void handle_xor_i32(void);
-static inline void handle_not_i32(void);
-static inline void handle_shl_i32(void);
-static inline void handle_shr_i32(void);
-
-// Performance note: All functions are marked static inline to ensure
-// the compiler inlines them directly into the dispatch loop, maintaining
-// the performance characteristics of the original monolithic implementation.
+void handle_print(void);
+void handle_print_multi(void);
+void handle_print_multi_sep(void);
+void handle_print_no_nl(void);
+void handle_halt(void);
+void handle_time_stamp(void);
 
 #endif // VM_OPCODE_HANDLERS_H

--- a/src/compiler/backend/codegen/peephole.c
+++ b/src/compiler/backend/codegen/peephole.c
@@ -128,14 +128,14 @@ static uint16_t read_u16(BytecodeBuffer* bytecode, int offset) {
 
 static bool can_eliminate_load(RegisterConstant* state, uint8_t reg,
                                uint8_t opcode, uint16_t constant_index) {
-    if (!state || (unsigned)reg >= VM_MAX_REGISTERS) return false;
+    if (!state) return false;
     return state[reg].known && state[reg].opcode == opcode &&
            state[reg].constant_index == constant_index;
 }
 
 static void remember_constant(RegisterConstant* state, uint8_t reg,
                               uint8_t opcode, uint16_t constant_index) {
-    if (!state || (unsigned)reg >= VM_MAX_REGISTERS) return;
+    if (!state) return;
     state[reg].known = true;
     state[reg].opcode = opcode;
     state[reg].constant_index = constant_index;

--- a/src/compiler/frontend/parser.c
+++ b/src/compiler/frontend/parser.c
@@ -473,23 +473,6 @@ static ASTNode* create_identifier_node(ParserContext* ctx, const char* name, Src
     return node;
 }
 
-static ASTNode* create_member_access(ParserContext* ctx, ASTNode* object, const char* member, SrcLocation location) {
-    ASTNode* memberNode = new_node(ctx);
-    memberNode->type = NODE_MEMBER_ACCESS;
-    memberNode->member.object = object;
-    memberNode->member.member = (char*)member;
-    memberNode->member.isMethod = false;
-    memberNode->member.isInstanceMethod = false;
-    memberNode->member.resolvesToEnum = false;
-    memberNode->member.resolvesToEnumVariant = false;
-    memberNode->member.enumVariantIndex = -1;
-    memberNode->member.enumVariantArity = 0;
-    memberNode->member.enumTypeName = NULL;
-    memberNode->location = location;
-    memberNode->dataType = NULL;
-    return memberNode;
-}
-
 static ASTNode* create_binary_equals(ParserContext* ctx, ASTNode* left, ASTNode* right, SrcLocation location) {
     ASTNode* node = new_node(ctx);
     node->type = NODE_BINARY;

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -434,7 +434,7 @@ bool config_validate(const OrusConfig* config) {
         return false;
     }
     
-    if (config->optimization_level < 0 || config->optimization_level > 2) {
+    if (config->optimization_level > 2) {
         return false;
     }
     
@@ -752,9 +752,18 @@ bool config_load_from_file(OrusConfig* config, const char* filename) {
         if (line[0] == '\0' || line[0] == '#') continue;
         
         // Check for section headers
-        if (line[0] == '[' && line[strlen(line)-1] == ']') {
-            strncpy(section, line + 1, sizeof(section) - 1);
-            section[strlen(section) - 1] = '\0'; // Remove closing ]
+        if (line[0] == '[') {
+            size_t len = strlen(line);
+            if (len > 1 && line[len - 1] == ']') {
+                size_t copy_len = len > 2 ? len - 2 : 0;
+                if (copy_len >= sizeof(section)) {
+                    copy_len = sizeof(section) - 1;
+                }
+                memcpy(section, line + 1, copy_len);
+                section[copy_len] = '\0';
+            } else {
+                section[0] = '\0';
+            }
             continue;
         }
         

--- a/src/internal/logging.c
+++ b/src/internal/logging.c
@@ -4,6 +4,7 @@
 // Description: Implementation of configurable logging system
 
 #include "internal/logging.h"
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>

--- a/src/repl.c
+++ b/src/repl.c
@@ -207,10 +207,11 @@ static bool process_command(const char* input){
     }
     if(strcmp(input,":clear")==0){
 #ifdef _WIN32
-        system("cls");
+        int clear_status = system("cls");
 #else
-        system("clear");
+        int clear_status = system("clear");
 #endif
+        (void)clear_status;
         return true;
     }
     if(strncmp(input,":timing ",COMMAND_TIMING_PREFIX_LEN)==0){

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -15,38 +15,7 @@
 
 #include <math.h>
 #include <limits.h>
-
-// Frame-aware register access functions for proper local variable isolation
-inline Value vm_get_register_safe(uint16_t id) {
-    // For now, use direct access for all registers < 256 
-    // Frame isolation handled by CALL/RETURN operations saving/restoring registers
-    if (id < 256) {
-        // Debug: track which registers are being accessed (disabled)
-        // if (id >= 60 && id <= 80) {
-        //     fprintf(stderr, "[REG_DEBUG] GET R%d = %d (type:%d)\n", id, IS_I32(vm.registers[id]) ? AS_I32(vm.registers[id]) : 0, vm.registers[id].type);
-        // }
-        return vm.registers[id];
-    } else {
-        // Extended registers use register file
-        Value* reg_ptr = get_register(&vm.register_file, id);
-        return reg_ptr ? *reg_ptr : BOOL_VAL(false);
-    }
-}
-
-inline void vm_set_register_safe(uint16_t id, Value value) {
-    // For now, use direct access for all registers < 256 
-    // Frame isolation handled by CALL/RETURN operations saving/restoring registers
-    if (id < 256) {
-        // Debug: track which registers are being set (disabled)
-        // if (id >= 60 && id <= 80) {
-        //     fprintf(stderr, "[REG_DEBUG] SET R%d = %d (type:%d)\n", id, IS_I32(value) ? AS_I32(value) : 0, value.type);
-        // }
-        vm.registers[id] = value;
-    } else {
-        // Extended registers use register file
-        set_register(&vm.register_file, id, value);
-    }
-}
+#include <inttypes.h>
 
 static inline bool value_to_index(Value value, int* out_index) {
     if (IS_I32(value)) {
@@ -525,11 +494,11 @@ InterpretResult vm_run_dispatch(void) {
                     if (IS_I32(left)) {
                         snprintf(buffer, sizeof(buffer), "%d", AS_I32(left));
                     } else if (IS_I64(left)) {
-                        snprintf(buffer, sizeof(buffer), "%lld", AS_I64(left));
+                        snprintf(buffer, sizeof(buffer), "%" PRId64, (int64_t)AS_I64(left));
                     } else if (IS_U32(left)) {
                         snprintf(buffer, sizeof(buffer), "%u", AS_U32(left));
                     } else if (IS_U64(left)) {
-                        snprintf(buffer, sizeof(buffer), "%llu", AS_U64(left));
+                        snprintf(buffer, sizeof(buffer), "%" PRIu64, (uint64_t)AS_U64(left));
                     } else if (IS_F64(left)) {
                         snprintf(buffer, sizeof(buffer), "%.6g", AS_F64(left));
                     } else if (IS_BOOL(left)) {
@@ -547,11 +516,11 @@ InterpretResult vm_run_dispatch(void) {
                     if (IS_I32(right)) {
                         snprintf(buffer, sizeof(buffer), "%d", AS_I32(right));
                     } else if (IS_I64(right)) {
-                        snprintf(buffer, sizeof(buffer), "%lld", AS_I64(right));
+                        snprintf(buffer, sizeof(buffer), "%" PRId64, (int64_t)AS_I64(right));
                     } else if (IS_U32(right)) {
                         snprintf(buffer, sizeof(buffer), "%u", AS_U32(right));
                     } else if (IS_U64(right)) {
-                        snprintf(buffer, sizeof(buffer), "%llu", AS_U64(right));
+                        snprintf(buffer, sizeof(buffer), "%" PRIu64, (uint64_t)AS_U64(right));
                     } else if (IS_F64(right)) {
                         snprintf(buffer, sizeof(buffer), "%.6g", AS_F64(right));
                     } else if (IS_BOOL(right)) {
@@ -1222,7 +1191,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_BOOL_TO_I32_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_BOOL(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be bool");
@@ -1234,7 +1203,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_BOOL_TO_I64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_BOOL(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be bool");
@@ -1246,7 +1215,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_BOOL_TO_U32_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_BOOL(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be bool");
@@ -1258,7 +1227,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_BOOL_TO_U64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_BOOL(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be bool");
@@ -1270,7 +1239,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_BOOL_TO_F64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_BOOL(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be bool");
@@ -1282,7 +1251,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_I32_TO_I64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_I32(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i32");
@@ -1294,7 +1263,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_I32_TO_U32_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_I32(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i32");
@@ -1306,7 +1275,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_I32_TO_BOOL_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_I32(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i32");
@@ -1319,7 +1288,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_U32_TO_I32_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_U32(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be u32");
@@ -1331,7 +1300,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_I64_TO_I32_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_I64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i64");
@@ -1343,7 +1312,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_I64_TO_BOOL_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_I64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i64");
@@ -1548,7 +1517,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_I32_TO_F64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_I32(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i32");
@@ -1560,7 +1529,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_I64_TO_F64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_I64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i64");
@@ -1572,7 +1541,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_F64_TO_I32_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_F64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be f64");
@@ -1584,7 +1553,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_F64_TO_I64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_F64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be f64");
@@ -1597,7 +1566,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_I32_TO_U64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_I32(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i32");
@@ -1613,7 +1582,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_I64_TO_U64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_I64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i64");
@@ -1629,7 +1598,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_U64_TO_I32_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_U64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be u64");
@@ -1645,7 +1614,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_U64_TO_I64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_U64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be u64");
@@ -1661,7 +1630,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_U32_TO_BOOL_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_U32(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be u32");
@@ -1673,7 +1642,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_U32_TO_U64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_U32(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be u32");
@@ -1685,7 +1654,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_U64_TO_U32_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_U64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be u64");
@@ -1701,7 +1670,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_F64_TO_U64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_F64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be f64");
@@ -1717,7 +1686,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_U64_TO_F64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_U64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be u64");
@@ -1729,7 +1698,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_U64_TO_BOOL_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_U64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be u64");
@@ -1741,7 +1710,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_F64_TO_BOOL_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_F64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be f64");
@@ -1753,7 +1722,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_U32_TO_F64_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_U32(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be u32");
@@ -1765,7 +1734,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_F64_TO_U32_R: {
             uint8_t dst = READ_BYTE();
             uint8_t src = READ_BYTE();
-            READ_BYTE(); // Skip third operand (unused)
+             (void)READ_BYTE(); // Skip third operand (unused)
             Value src_val = vm_get_register_safe(src);
             if (!IS_F64(src_val)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be f64");

--- a/src/vm/handlers/vm_control_flow_handlers.c
+++ b/src/vm/handlers/vm_control_flow_handlers.c
@@ -13,9 +13,6 @@
 #include "vm/vm_dispatch.h"
 #include "vm/vm_control_flow.h"
 
-// Ensure correct return type is known to the compiler
-extern Value vm_get_register_safe(uint16_t reg);
-
 // ====== Jump Operation Handlers ======
 
 static inline void handle_jump_short(void) {

--- a/src/vm/handlers/vm_memory_handlers.c
+++ b/src/vm/handlers/vm_memory_handlers.c
@@ -14,19 +14,17 @@
 #include "runtime/builtins.h"
 
 // Frame-aware register access functions for proper local variable isolation
-extern inline Value vm_get_register_safe(uint16_t id);
-extern inline void vm_set_register_safe(uint16_t id, Value value);
 
 // ====== Basic Load Operation Handlers ======
 
-static inline void handle_load_const(void) {
+void handle_load_const(void) {
     uint8_t reg = READ_BYTE();
     uint16_t constantIndex = READ_SHORT();
     vm_set_register_safe(reg, READ_CONSTANT(constantIndex));
 }
 
 // Extended constant loading for 16-bit register IDs (Phase 2.1)
-static inline void handle_load_const_ext(void) {
+void handle_load_const_ext(void) {
     uint16_t reg = READ_SHORT();      // 16-bit register ID
     uint16_t constantIndex = READ_SHORT(); // 16-bit constant index
     Value constant = READ_CONSTANT(constantIndex);
@@ -36,7 +34,7 @@ static inline void handle_load_const_ext(void) {
 }
 
 // Extended register move for 16-bit register IDs (Phase 2.2)
-static inline void handle_move_ext(void) {
+void handle_move_ext(void) {
     uint16_t dst_reg = READ_SHORT();  // 16-bit destination register
     uint16_t src_reg = READ_SHORT();  // 16-bit source register
     
@@ -49,19 +47,19 @@ static inline void handle_move_ext(void) {
 }
 
 
-static inline void handle_load_true(void) {
+void handle_load_true(void) {
     uint8_t reg = READ_BYTE();
     vm_set_register_safe(reg, BOOL_VAL(true));
 }
 
-static inline void handle_load_false(void) {
+void handle_load_false(void) {
     uint8_t reg = READ_BYTE();
     vm_set_register_safe(reg, BOOL_VAL(false));
 }
 
 // ====== Register Move Operation Handler ======
 
-static inline void handle_move_reg(void) {
+void handle_move_reg(void) {
     uint8_t dst = READ_BYTE();
     uint8_t src = READ_BYTE();
     
@@ -72,7 +70,7 @@ static inline void handle_move_reg(void) {
 
 // ====== Global Variable Operation Handlers ======
 
-static inline void handle_load_global(void) {
+void handle_load_global(void) {
     uint8_t reg = READ_BYTE();
     uint8_t globalIndex = READ_BYTE();
     if (globalIndex >= vm.variableCount || vm.globalTypes[globalIndex] == NULL) {
@@ -82,7 +80,7 @@ static inline void handle_load_global(void) {
     vm_set_register_safe(reg, vm.globals[globalIndex]);
 }
 
-static inline void handle_store_global(void) {
+void handle_store_global(void) {
     uint8_t globalIndex = READ_BYTE();
     uint8_t reg = READ_BYTE();
     
@@ -183,34 +181,34 @@ static inline void handle_store_global(void) {
 
 // ====== Typed Constant Load Handlers ======
 
-static inline void handle_load_i32_const(void) {
+void handle_load_i32_const(void) {
     uint8_t reg = READ_BYTE();
     uint16_t constantIndex = READ_SHORT();
     vm_set_register_safe(reg, READ_CONSTANT(constantIndex));
 }
 
-static inline void handle_load_i64_const(void) {
-    uint8_t reg = READ_BYTE();
-    uint16_t constantIndex = READ_SHORT();
-    // Store in the standard register system where comparison operations expect values
-    vm_set_register_safe(reg, READ_CONSTANT(constantIndex));
-}
-
-static inline void handle_load_u32_const(void) {
+void handle_load_i64_const(void) {
     uint8_t reg = READ_BYTE();
     uint16_t constantIndex = READ_SHORT();
     // Store in the standard register system where comparison operations expect values
     vm_set_register_safe(reg, READ_CONSTANT(constantIndex));
 }
 
-static inline void handle_load_u64_const(void) {
+void handle_load_u32_const(void) {
     uint8_t reg = READ_BYTE();
     uint16_t constantIndex = READ_SHORT();
     // Store in the standard register system where comparison operations expect values
     vm_set_register_safe(reg, READ_CONSTANT(constantIndex));
 }
 
-static inline void handle_load_f64_const(void) {
+void handle_load_u64_const(void) {
+    uint8_t reg = READ_BYTE();
+    uint16_t constantIndex = READ_SHORT();
+    // Store in the standard register system where comparison operations expect values
+    vm_set_register_safe(reg, READ_CONSTANT(constantIndex));
+}
+
+void handle_load_f64_const(void) {
     uint8_t reg = READ_BYTE();
     uint16_t constantIndex = READ_SHORT();
     // Store in the standard register system where comparison operations expect values
@@ -219,13 +217,13 @@ static inline void handle_load_f64_const(void) {
 
 // ====== Typed Move Operation Handlers ======
 
-static inline void handle_move_i32(void) {
+void handle_move_i32(void) {
     uint8_t dst = READ_BYTE();
     uint8_t src = READ_BYTE();
     vm_set_register_safe(dst, vm_get_register_safe(src));
 }
 
-static inline void handle_move_i64(void) {
+void handle_move_i64(void) {
     uint8_t dst = READ_BYTE();
     uint8_t src = READ_BYTE();
     // Read from the standard register system where OP_LOAD_CONST stores values
@@ -238,21 +236,21 @@ static inline void handle_move_i64(void) {
     vm_set_register_safe(dst, vm_get_register_safe(src));
 }
 
-static inline void handle_move_u32(void) {
+void handle_move_u32(void) {
     uint8_t dst = READ_BYTE();
     uint8_t src = READ_BYTE();
     vm.typed_regs.u32_regs[dst] = vm.typed_regs.u32_regs[src];
     vm.typed_regs.reg_types[dst] = REG_TYPE_U32;
 }
 
-static inline void handle_move_u64(void) {
+void handle_move_u64(void) {
     uint8_t dst = READ_BYTE();
     uint8_t src = READ_BYTE();
     vm.typed_regs.u64_regs[dst] = vm.typed_regs.u64_regs[src];
     vm.typed_regs.reg_types[dst] = REG_TYPE_U64;
 }
 
-static inline void handle_move_f64(void) {
+void handle_move_f64(void) {
     uint8_t dst = READ_BYTE();
     uint8_t src = READ_BYTE();
     // Read from the standard register system where OP_LOAD_CONST stores values
@@ -267,13 +265,13 @@ static inline void handle_move_f64(void) {
 
 // ====== Print Operation Handlers ======
 
-static inline void handle_print(void) {
+void handle_print(void) {
     uint8_t reg = READ_BYTE();
     Value temp_value = vm_get_register_safe(reg);
     builtin_print(&temp_value, 1, true, NULL);
 }
 
-static inline void handle_print_multi(void) {
+void handle_print_multi(void) {
     uint8_t first = READ_BYTE();
     uint8_t count = READ_BYTE();
     uint8_t nl = READ_BYTE();
@@ -294,7 +292,7 @@ static inline void handle_print_multi(void) {
     builtin_print(temp_values, count, nl != 0, NULL);
 }
 
-static inline void handle_print_multi_sep(void) {
+void handle_print_multi_sep(void) {
     uint8_t first = READ_BYTE();
     uint8_t count = READ_BYTE();
     uint8_t sep_reg = READ_BYTE();
@@ -309,7 +307,7 @@ static inline void handle_print_multi_sep(void) {
     builtin_print_with_sep_value(temp_values, count, nl != 0, sep_value);
 }
 
-static inline void handle_print_no_nl(void) {
+void handle_print_no_nl(void) {
     uint8_t reg = READ_BYTE();
     Value temp_value = vm_get_register_safe(reg);
     builtin_print(&temp_value, 1, false, NULL);
@@ -317,12 +315,12 @@ static inline void handle_print_no_nl(void) {
 
 // ====== Utility Operation Handlers ======
 
-static inline void handle_halt(void) {
+void handle_halt(void) {
     // Halt operation - handled by dispatch loop
     // This is a placeholder for consistency
 }
 
-static inline void handle_time_stamp(void) {
+void handle_time_stamp(void) {
     // Time stamp operation - implementation depends on VM requirements
     // This is a placeholder for consistency
 }

--- a/src/vm/register_cache.c
+++ b/src/vm/register_cache.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 // Forward declarations for register file internal functions
 Value* get_register_internal(RegisterFile* rf, uint16_t id);
@@ -320,19 +321,19 @@ void print_cache_stats(RegisterCache* cache) {
     if (!cache) return;
     
     printf("=== Register Cache Statistics ===\n");
-    printf("Total Accesses: %llu\n", cache->total_accesses);
-    printf("Cache Hits: %llu\n", cache->cache_hits);
-    printf("Cache Misses: %llu\n", cache->cache_misses);
-    printf("L1 Hits: %llu\n", cache->l1_hits);
-    printf("L1 Misses: %llu\n", cache->l1_misses);
-    printf("L2 Hits: %llu\n", cache->l2_hits);
-    printf("L2 Misses: %llu\n", cache->l2_misses);
-    printf("Prefetch Hits: %llu\n", cache->prefetch_hits);
-    printf("Writebacks: %llu\n", cache->writebacks);
+    printf("Total Accesses: %" PRIu64 "\n", cache->total_accesses);
+    printf("Cache Hits: %" PRIu64 "\n", cache->cache_hits);
+    printf("Cache Misses: %" PRIu64 "\n", cache->cache_misses);
+    printf("L1 Hits: %" PRIu64 "\n", cache->l1_hits);
+    printf("L1 Misses: %" PRIu64 "\n", cache->l1_misses);
+    printf("L2 Hits: %" PRIu64 "\n", cache->l2_hits);
+    printf("L2 Misses: %" PRIu64 "\n", cache->l2_misses);
+    printf("Prefetch Hits: %" PRIu64 "\n", cache->prefetch_hits);
+    printf("Writebacks: %" PRIu64 "\n", cache->writebacks);
     
     if (cache->total_accesses > 0) {
         uint64_t hit_rate = (cache->cache_hits * 100) / cache->total_accesses;
-        printf("Hit Rate: %llu%%\n", hit_rate);
+        printf("Hit Rate: %" PRIu64 "%%\n", hit_rate);
     }
 }
 

--- a/src/vm/register_file.c
+++ b/src/vm/register_file.c
@@ -252,7 +252,7 @@ uint16_t allocate_temp_register(RegisterFile* rf) {
 
 // Phase 1: Register type checking for debugging
 bool is_global_register(uint16_t id) {
-    return id >= GLOBAL_REG_START && id < FRAME_REG_START;
+    return id < FRAME_REG_START;
 }
 
 bool is_frame_register(uint16_t id) {


### PR DESCRIPTION
## Summary
- inline the safe VM register helpers and adjust opcode handler declarations so dispatch sources compile without unused static warnings
- clean up runtime code paths (dispatch, register cache/file, REPL) to use portable format specifiers and explicit result discards
- fix compiler and configuration helpers (codegen, peephole, logging, parser, config loader) to avoid unused or truncation diagnostics
