### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.5.1] - 2025-09-21
+
+### Changed
+- Bumped version to 0.5.1.
+
 ## [0.5.0] - 2025-09-20
 
 ### Changed

--- a/include/public/version.h
+++ b/include/public/version.h
@@ -3,7 +3,7 @@
 
 #define ORUS_VERSION_MAJOR 0
 #define ORUS_VERSION_MINOR 5
-#define ORUS_VERSION_PATCH 0
+#define ORUS_VERSION_PATCH 1
 
 // Helpers to stringify numeric macros
 #define ORUS_STR_HELPER(x) #x


### PR DESCRIPTION
## Summary
- update the public version header to 0.5.1
- document the new release in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdb51298288325859f44f88c334bf1