### PR TITLE
Switch module imports to use keyword

### DIFF
--- a/docs/ERROR_FORMAT_REPORTING.md
+++ b/docs/ERROR_FORMAT_REPORTING.md
@@ -78,7 +78,7 @@ Whenever possible, error messages:
 | E0000–0999 | Runtime errors | Division by zero, null access   |
 | E1000–1999 | Syntax errors  | Missing colon, unexpected token |
 | E2000–2999 | Type errors    | Mismatched types                |
-| E3000–3999 | Module/import  | File not found, cyclic import   |
+| E3000–3999 | Module/use     | File not found, cyclic use      |
 | E9000–9999 | Internal bugs  | Internal panic, VM crash        |
 
 ---
@@ -98,7 +98,7 @@ Whenever possible, error messages:
 * Type mismatches with clear "found vs expected"
 * Syntax missing required colon or indent
 * Out-of-range indexing
-* Unused imports, unreachable code (optional warnings)
+* Unused `use` clauses, unreachable code (optional warnings)
 
 ---
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -35,6 +35,26 @@ commas. Semicolons are **not** allowed; use a newline to terminate statements.
 x = 1, y = 2, z = 3  # declares three variables
 ```
 
+### Global Variables and Module Exports
+
+Global storage is opt-in. Use the `global` keyword when a value must live for
+the duration of the program. Global identifiers **must** be written in
+`SCREAMING_SNAKE_CASE`; the parser enforces this convention. Globals are module
+private by default, mirroring functions, structs, and enums. Prepend `pub` to
+export a declaration from the current module. Both `global` and `pub`
+modifiers are only valid at module scope—using them inside a function, loop, or
+any nested block is rejected during parsing.
+
+```orus
+global mut CACHE_SIZE: i32 = 1024      // private module global
+pub global REGISTER_COUNT: i64 = 256   // exported global with explicit type
+pub global SEED = 42                   // exported global with inferred type
+```
+
+Global declarations always require an initializer. Optional type annotations can
+appear after the name and before the `=` sign. Mutability works the same as for
+locals via the `mut` keyword.
+
 ### Lexical Scoping
 
 Orus uses lexical scoping. A variable declared inside a block is visible only
@@ -154,6 +174,20 @@ print("Pi rounded:", pi)
 
 ```
 
+Module-level declarations are private unless marked `pub`. The `pub` modifier
+works with `fn`, `global`, `struct`, and `enum` definitions.
+
+```orus
+pub fn helper():
+    print("exported helper")
+
+pub struct Vec2:
+    x: f64
+    y: f64
+
+pub enum Axis: X, Y
+```
+
 ---
 
 ## 🪛 Structs and Methods
@@ -265,49 +299,45 @@ fn min<T: Comparable>(a: T, b: T) -> T:
 
 ## 📂 Modules
 
-Importing entire modules:
+Bringing an entire module into scope (all public globals/functions):
 
 ```orus
 use math
-use datetime as dt
+use datetime: *
 
-dt.now()
-math.pi
+print(datetime.now())
+print(math.PI)
 ```
 
-Wildcard import:
-
-```orus
-use math:*
-sin(0.5)
-cos(1.0)
-```
-
-Selective import:
+Selective use:
 
 ```orus
 use math: sin, cos, tan
 print(sin(0.5))
 ```
 
-Module aliases:
+Renaming imported symbols to avoid collisions:
 
 ```orus
-use utils.helpers as h
-h.do_something()
+use math: sin as sine, cos
+
+print(sine(0.5))
 ```
 
-Public function or struct in module:
+Public function or global in module:
 
 ```orus
 # utils.orus
 pub fn helper():
     print("from helper")
 
-# main.orus
-use utils
+pub global VERSION = 1
 
-utils.helper()
+# main.orus
+use utils: helper, VERSION
+
+helper()
+print("version", VERSION)
 ```
 
 ---

--- a/docs/MISSING.md
+++ b/docs/MISSING.md
@@ -30,6 +30,11 @@ still needs design work.
 - ⚠️ **Module system** – Runtime hooks exist (`interpret_module` and module
   loaders), yet the surface syntax and packaging workflow remain to be
   implemented and tested.
+- ⚠️ **Module visibility** – Parser enforces uppercase `global` declarations,
+  tracks `pub` exports for globals, functions, structs, and enums, and the
+  runtime now registers those exports with the module loader. Modules can use
+  public globals and functions from sibling files via `use`, including
+  renaming support; pulling type declarations via `use` remains future work.
 - ✅ **Pattern matching** – `match` supports enums and literal values using the
   unified `pattern ->` arm syntax. Lowering reuses scoped temporaries and
   chained `if` statements, preserving payload destructuring, `_` wildcards, and
@@ -69,7 +74,7 @@ print(identity("orus"))
 
 ### Runtime & Tooling
 - 256-register VM with dedicated banks for globals, frames, temporaries, and
-  future module imports; dispatch tables ship in both `goto` and `switch`
+  future module uses; dispatch tables ship in both `goto` and `switch`
   variants.
 - Built-in printing, string interpolation, numeric formatting, and array
   helpers are available in the runtime (`src/vm/runtime/builtins.c`).
@@ -96,6 +101,7 @@ print("sum:", total)
 | Iterator-style `for item in collection` | Design | Parser/codegen support pending; VM array iterators are ready. |
 | Module packaging | Design | Module manager + loader stubs exist; surface syntax and tests still missing. |
 | Print formatting polish | Backlog | Finish escape handling and numeric formatting for the print APIs. |
+| Module use resolution | In progress | `use` loads sibling modules and binds their exported globals/functions with type metadata and aliasing; importing type declarations is still open. |
 
 ---
 
@@ -105,7 +111,7 @@ print("sum:", total)
    error reporters.
 3. Extend the parser/typechecker/codegen to support iterator-style `for` loops
    using array iterators.
-4. Define and implement module declarations/import syntax, backed by the
+4. Define and implement module declarations/`use` syntax, backed by the
    existing loader.
 5. Document and stabilize the printing APIs once formatting is finalized.
 
@@ -858,7 +864,7 @@ for i in 0..huge_array.length():
 
 ### 6.1 Module System & Advanced Optimization
 **Priority: 📋 Medium-High**
-- [ ] **TODO**: Add import/export functionality with module loading.
+- [ ] **TODO**: Add use/export functionality with module loading.
 - [ ] **NEW**: Implement cross-module optimization using type system knowledge
 - [ ] **NEW**: Add SIMD vectorization support for numerical loops
 - [ ] **NEW**: Implement advanced loop optimizations (fusion, parallelization)

--- a/docs/TEST_CATEGORIZATION.md
+++ b/docs/TEST_CATEGORIZATION.md
@@ -13,6 +13,14 @@
 - `tests/type_safety_fails/duplicate_literal_match_arm.orus` – Validates that duplicate literal arms in expression-form matches report diagnostics instead of compiling.
 - `tests/type_safety_fails/enum_match_payload_mismatch.orus` – Ensures destructuring patterns bind the exact payload arity before bodies execute.
 - `tests/type_safety_fails/enum_match_unknown_variant.orus` – Validates that referencing undeclared enum variants inside `match` arms reports errors.
+- `tests/type_safety_fails/global_lowercase_fail.orus` – Fails compilation when a `global` name violates the enforced uppercase convention.
+- `tests/type_safety_fails/pub_inside_block_fail.orus` – Confirms `'pub'` declarations trigger diagnostics if they appear outside of module scope.
+- `tests/type_safety_fails/import_missing_symbol_fail.orus` – Emits a compile error when a `use` clause references a symbol the target module does not export.
+- `tests/type_safety_fails/import_alias_type_mismatch_fail.orus` – Ensures aliased `use` clauses retain their function type information and reject mismatched argument types.
+
+## Modules
+- `tests/modules/module_imports.orus` – Demonstrates using public globals and functions from a sibling module.
+- `tests/modules/module_import_alias.orus` – Exercises selective `use` with aliases for globals and functions.
 
 ## Types
 - `tests/types/enum_declarations.orus` – Validates that enum declarations, payload annotations, and cross-type references resolve in the type system.

--- a/include/compiler/ast.h
+++ b/include/compiler/ast.h
@@ -74,11 +74,17 @@ typedef enum {
     NODE_MEMBER_ACCESS,
     NODE_MEMBER_ASSIGN,
     NODE_ENUM_DECL,
+    NODE_IMPORT,
     NODE_ENUM_MATCH_TEST,
     NODE_ENUM_PAYLOAD,
     NODE_ENUM_MATCH_CHECK,
     NODE_MATCH_EXPRESSION
 } NodeType;
+
+typedef struct ImportSymbol {
+    char* name;
+    char* alias;
+} ImportSymbol;
 
 typedef struct MatchArm {
     bool isWildcard;
@@ -107,11 +113,19 @@ struct ASTNode {
         struct {
             char* name;
             bool isPublic;
+            bool isGlobal;
             ASTNode* initializer;
             ASTNode* typeAnnotation;
             bool isConst;
             bool isMutable;
         } varDecl;
+        struct {
+            char* moduleName;
+            char* moduleAlias;
+            ImportSymbol* symbols;
+            int symbolCount;
+            bool importAll;
+        } import;
         struct {
             char* name;
         } identifier;
@@ -213,6 +227,7 @@ struct ASTNode {
             int paramCount;                // Number of parameters
             ASTNode* returnType;           // Optional return type annotation
             ASTNode* body;                 // Function body (block)
+            bool isPublic;                 // Whether function is public
             bool isMethod;                 // Whether function is defined in impl block
             bool isInstanceMethod;         // Whether method has implicit self receiver
             char* methodStructName;        // Owning struct for methods

--- a/include/compiler/compiler.h
+++ b/include/compiler/compiler.h
@@ -131,6 +131,15 @@ typedef struct CompilerContext {
     UpvalueInfo* upvalues;             // Captured variables for current function
     int upvalue_count;                 // Number of captured upvalues
     int upvalue_capacity;              // Capacity of upvalues array
+
+    // Module export tracking
+    bool is_module;                    // Whether we're compiling a module
+    ModuleExportEntry* module_exports; // Collected exports
+    int module_export_count;           // Number of collected exports
+    int module_export_capacity;        // Allocated capacity for exports
+    ModuleImportEntry* module_imports; // Collected imports
+    int module_import_count;           // Number of collected imports
+    int module_import_capacity;        // Allocated capacity for imports
 } CompilerContext;
 
 // Bytecode emission functions

--- a/include/compiler/lexer.h
+++ b/include/compiler/lexer.h
@@ -74,11 +74,11 @@ typedef enum {
     TOKEN_ENUM,
     TOKEN_IMPL,
     TOKEN_IMPORT,
-    TOKEN_USE,
     TOKEN_AS,
     TOKEN_MATCH,
     TOKEN_MATCHES,
     TOKEN_PUB,
+    TOKEN_GLOBAL,
     TOKEN_STATIC,
 
     // Add type tokens

--- a/include/compiler/parser.h
+++ b/include/compiler/parser.h
@@ -31,6 +31,9 @@ typedef struct ParserContext {
     // Loop context tracking for break/continue validation
     int loop_depth;
 
+    // Track nested block depth so we can validate module-only constructs
+    int block_depth;
+
     // Token lookahead management
     Token peeked_token;
     bool has_peeked_token;

--- a/include/compiler/register_allocator.h
+++ b/include/compiler/register_allocator.h
@@ -43,7 +43,8 @@ void free_mp_register_allocator(MultiPassRegisterAllocator* allocator);
 
 // Register allocation by type
 int mp_allocate_global_register(MultiPassRegisterAllocator* allocator);
-int mp_allocate_frame_register(MultiPassRegisterAllocator* allocator);  
+int mp_allocate_frame_register(MultiPassRegisterAllocator* allocator);
+bool mp_reserve_global_register(MultiPassRegisterAllocator* allocator, int reg);
 
 void mp_reset_frame_registers(MultiPassRegisterAllocator* allocator);
 int mp_allocate_temp_register(MultiPassRegisterAllocator* allocator);

--- a/include/compiler/typed_ast.h
+++ b/include/compiler/typed_ast.h
@@ -40,6 +40,11 @@ typedef struct {
     SrcLocation location;
 } TypedMatchArm;
 
+typedef struct TypedImportSymbol {
+    const char* name;
+    const char* alias;
+} TypedImportSymbol;
+
 // Typed AST node that contains the original AST plus resolved type information
 struct TypedASTNode {
     ASTNode* original;       // Original AST node from parser
@@ -67,7 +72,16 @@ struct TypedASTNode {
         struct {
             TypedASTNode* initializer;
             TypedASTNode* typeAnnotation;
+            bool isGlobal;
+            bool isPublic;
         } varDecl;
+        struct {
+            const char* moduleName;
+            const char* moduleAlias;
+            TypedImportSymbol* symbols;
+            int symbolCount;
+            bool importAll;
+        } import;
         struct {
             TypedASTNode* left;
             TypedASTNode* right;
@@ -128,6 +142,7 @@ struct TypedASTNode {
         struct {
             TypedASTNode* returnType;
             TypedASTNode* body;
+            bool isPublic;
             bool isMethod;
             bool isInstanceMethod;
             const char* methodStructName;

--- a/include/vm/module_manager.h
+++ b/include/vm/module_manager.h
@@ -16,8 +16,10 @@ typedef struct RegisterModule {
     
     // Import/Export management
     struct {
-        char** exported_names;            // Names of exported variables
-        uint16_t* exported_registers;     // Register IDs of exports
+        char** exported_names;            // Names of exported symbols
+        uint16_t* exported_registers;     // Register IDs of exports (or MODULE_EXPORT_NO_REGISTER)
+        ModuleExportKind* exported_kinds; // Kind of each exported symbol
+        Type** exported_types;            // Type metadata for exports
         uint16_t export_count;            // Number of exports
     } exports;
     
@@ -65,9 +67,16 @@ uint16_t allocate_module_register(ModuleManager* manager, const char* module_nam
 bool free_module_register(ModuleManager* manager, const char* module_name, uint16_t reg_id);
 
 // Phase 3: Import/Export functionality
-bool export_variable(RegisterModule* module, const char* var_name, uint16_t reg_id);
+bool register_module_export(RegisterModule* module, const char* name, ModuleExportKind kind, int register_index,
+                            Type* type);
 bool import_variable(RegisterModule* dest_module, const char* var_name, RegisterModule* src_module);
 uint16_t resolve_import(ModuleManager* manager, const char* module_name, const char* var_name);
+bool module_manager_resolve_export(ModuleManager* manager, const char* module_name, const char* symbol_name,
+                                   ModuleExportKind* out_kind, uint16_t* out_register, Type** out_type);
+
+// Type metadata helpers for module exports
+Type* module_clone_export_type(const Type* source);
+void module_free_export_type(Type* type);
 
 // Phase 3: Module register access
 Value* get_module_register(ModuleManager* manager, uint8_t module_id, uint16_t reg_offset);

--- a/makefile
+++ b/makefile
@@ -203,7 +203,7 @@ test: $(ORUS)
 	@echo "Running Comprehensive Test Suite..."
 	@echo "==================================="
 	@passed=0; failed=0; current_dir=""; \
-        SUBDIRS="arrays arithmetic benchmarks comments comprehensive control_flow edge_cases expressions formatting functions literals register_file scope_analysis strings structs type_safety_fails types/f64 types/i32 types/i64 variables"; \
+        SUBDIRS="arrays arithmetic benchmarks comments comprehensive control_flow edge_cases expressions formatting functions literals modules register_file scope_analysis strings structs type_safety_fails types/f64 types/i32 types/i64 variables"; \
 	for subdir in $$SUBDIRS; do \
 		for test_file in $$(find $(TESTDIR)/$$subdir -type f -name "*.orus" | sort); do \
 			if [ -f "$$test_file" ]; then \

--- a/src/compiler/backend/register_allocator.c
+++ b/src/compiler/backend/register_allocator.c
@@ -45,7 +45,7 @@ void free_mp_register_allocator(MultiPassRegisterAllocator* allocator) {
 
 int mp_allocate_global_register(MultiPassRegisterAllocator* allocator) {
     if (!allocator) return -1;
-    
+
     // Find next free global register
     for (int i = 0; i < 64; i++) {
         if (!allocator->global_regs[i]) {
@@ -53,10 +53,24 @@ int mp_allocate_global_register(MultiPassRegisterAllocator* allocator) {
             return MP_GLOBAL_REG_START + i;
         }
     }
-    
+
     // No free global registers
     printf("[REGISTER_ALLOCATOR] Warning: No free global registers\n");
     return -1;
+}
+
+bool mp_reserve_global_register(MultiPassRegisterAllocator* allocator, int reg) {
+    if (!allocator) {
+        return false;
+    }
+
+    if (reg < MP_GLOBAL_REG_START || reg > MP_GLOBAL_REG_END) {
+        return false;
+    }
+
+    int index = reg - MP_GLOBAL_REG_START;
+    allocator->global_regs[index] = true;
+    return true;
 }
 
 int mp_allocate_frame_register(MultiPassRegisterAllocator* allocator) {

--- a/src/compiler/frontend/lexer.c
+++ b/src/compiler/frontend/lexer.c
@@ -260,14 +260,15 @@ static TokenType identifier_type(const char* start, int length) {
             if (length == 2 && start[1] == 'n') return TOKEN_FN;
             if (length == 3 && memcmp(start, "f64", 3) == 0) return TOKEN_F64;
             break;
+        case 'g':
+            if (length == 6 && memcmp(start, "global", 6) == 0) return TOKEN_GLOBAL;
+            break;
         case 'i':
             if (length == 2 && memcmp(start, "if", 2) == 0) return TOKEN_IF;
             if (length == 2 && memcmp(start, "in", 2) == 0) return TOKEN_IN;
             if (length == 3 && memcmp(start, "i32", 3) == 0) return TOKEN_INT;
             if (length == 3 && memcmp(start, "i64", 3) == 0) return TOKEN_I64;
             if (length == 4 && memcmp(start, "impl", 4) == 0) return TOKEN_IMPL;
-            if (length == 6 && memcmp(start, "import", 6) == 0)
-                return TOKEN_IMPORT;
             break;
         case 'l':
             break;
@@ -310,7 +311,7 @@ static TokenType identifier_type(const char* start, int length) {
             if (length == 10 && memcmp(start, "time_stamp", 10) == 0) return TOKEN_TIME_STAMP;
             break;
         case 'u':
-            if (length == 3 && memcmp(start, "use", 3) == 0) return TOKEN_USE;
+            if (length == 3 && memcmp(start, "use", 3) == 0) return TOKEN_IMPORT;
             if (length == 3 && memcmp(start, "u32", 3) == 0) return TOKEN_U32;
             if (length == 3 && memcmp(start, "u64", 3) == 0) return TOKEN_U64;
             break;
@@ -970,12 +971,12 @@ const char* token_type_to_string(TokenType type) {
         case TOKEN_BOOL: return "BOOL";
         case TOKEN_STRUCT: return "STRUCT";
         case TOKEN_IMPL: return "IMPL";
-        case TOKEN_IMPORT: return "IMPORT";
-        case TOKEN_USE: return "USE";
+        case TOKEN_IMPORT: return "USE";
         case TOKEN_AS: return "AS";
         case TOKEN_MATCH: return "MATCH";
         case TOKEN_MATCHES: return "MATCHES";
         case TOKEN_PUB: return "PUB";
+        case TOKEN_GLOBAL: return "GLOBAL";
         case TOKEN_STATIC: return "STATIC";
         case TOKEN_U32: return "U32";
         case TOKEN_U64: return "U64";

--- a/src/errors/infrastructure/error_infrastructure.c
+++ b/src/errors/infrastructure/error_infrastructure.c
@@ -987,9 +987,9 @@ const char* get_error_title(ErrorCode code) {
         
         // Module errors (E3xxx)
         case E3001_FILE_NOT_FOUND: return "Can't find the file you're looking for";
-        case E3002_CYCLIC_IMPORT: return "Modules are importing each other in a circle";
+        case E3002_CYCLIC_IMPORT: return "Modules are using each other in a circle";
         case E3003_MODULE_NOT_FOUND: return "Can't find this module";
-        case E3004_IMPORT_FAILED: return "Failed to import this module";
+        case E3004_IMPORT_FAILED: return "Failed to use this module";
         
         // Internal errors (E9xxx)
         case E9001_INTERNAL_PANIC: return "Internal compiler error (this is our bug!)";

--- a/src/vm/core/vm_core.c
+++ b/src/vm/core/vm_core.c
@@ -67,6 +67,10 @@ void initVM(void) {
     vm.currentLine = 0;
     vm.currentColumn = 1;
     vm.moduleCount = 0;
+    vm.loadingModuleCount = 0;
+    for (int i = 0; i < UINT8_COUNT; i++) {
+        vm.loadingModules[i] = NULL;
+    }
     vm.nativeFunctionCount = 0;
     vm.gcCount = 0;
     vm.lastExecutionTime = 0.0;

--- a/tests/modules/alias_provider.orus
+++ b/tests/modules/alias_provider.orus
@@ -1,0 +1,4 @@
+pub global OFFSET: i32 = 7
+
+pub fn add_offset(value: i32) -> i32:
+    value + OFFSET

--- a/tests/modules/math_module.orus
+++ b/tests/modules/math_module.orus
@@ -1,0 +1,10 @@
+pub global PI = 314
+
+pub fn double(value):
+    return value * 2
+
+global mut COUNTER = 0
+
+pub fn bump():
+    COUNTER = COUNTER + 1
+    return COUNTER

--- a/tests/modules/module_import_alias.orus
+++ b/tests/modules/module_import_alias.orus
@@ -1,0 +1,8 @@
+use alias_provider: OFFSET as START, add_offset as bump
+use math_module: double as twice
+
+bumped = bump(START)
+doubled = twice(bumped)
+print("start", START)
+print("bumped", bumped)
+print("doubled", doubled)

--- a/tests/modules/module_imports.orus
+++ b/tests/modules/module_imports.orus
@@ -1,0 +1,5 @@
+use math_module: PI, bump
+
+print("PI:", PI)
+print("First bump:", bump())
+print("Second bump:", bump())

--- a/tests/type_safety_fails/global_lowercase_fail.orus
+++ b/tests/type_safety_fails/global_lowercase_fail.orus
@@ -1,0 +1,4 @@
+// Lowercase global identifiers are rejected because module globals must use
+// SCREAMING_SNAKE_CASE naming.
+
+global counter = 1

--- a/tests/type_safety_fails/import_alias_type_mismatch_fail.orus
+++ b/tests/type_safety_fails/import_alias_type_mismatch_fail.orus
@@ -1,0 +1,4 @@
+use alias_provider: add_offset as bump
+
+// Passing a string should fail because bump expects i32
+bump("oops")

--- a/tests/type_safety_fails/import_missing_symbol_fail.orus
+++ b/tests/type_safety_fails/import_missing_symbol_fail.orus
@@ -1,0 +1,1 @@
+use import_missing_symbol_module: DOES_NOT_EXIST

--- a/tests/type_safety_fails/import_missing_symbol_module.orus
+++ b/tests/type_safety_fails/import_missing_symbol_module.orus
@@ -1,0 +1,2 @@
+pub fn helper():
+    return 42

--- a/tests/type_safety_fails/pub_inside_block_fail.orus
+++ b/tests/type_safety_fails/pub_inside_block_fail.orus
@@ -1,0 +1,5 @@
+// The `pub` modifier is limited to module scope. Using it inside any nested
+// block should surface a parse error.
+
+fn main():
+    pub global COUNTER = 1

--- a/tests/variables/global_keyword.orus
+++ b/tests/variables/global_keyword.orus
@@ -1,0 +1,16 @@
+// Explicit global keyword should allocate module-level storage
+// and allow public exports when combined with `pub`.
+
+pub global REGISTER = 256
+global mut COUNTER = 1
+
+fn bump():
+    COUNTER = COUNTER + 1
+    return COUNTER
+
+print("REGISTER:", REGISTER)
+print("Start:", COUNTER)
+print("First bump:", bump())
+print("Second bump:", bump())
+print("Final COUNTER:", COUNTER)
+


### PR DESCRIPTION
## Summary
- update the lexer, parser, and compiler/runtime diagnostics so module access uses the `use` keyword instead of `import`
- refresh language documentation, roadmap notes, and module test fixtures to demonstrate the new `use` syntax

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cdb9c8ed8c8325a37f6c2490bfd884