### PR TITLE
Bump Orus version to 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [0.5.2] - 2025-09-22
+
+### Changed
+- Bumped version to 0.5.2.
+
 ## [0.5.1] - 2025-09-21
 
 ### Changed
@@ -52,6 +57,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [0.2.2] - 2025-07-16
 - Introduced public `version.h` and initial 0.2.x series setup.
 
+[0.5.2]: https://github.com/jordyorel/orus-lang/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/jordyorel/orus-lang/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jordyorel/orus-lang/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jordyorel/orus-lang/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/jordyorel/orus-lang/compare/v0.2.4...v0.3.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orus Programming Language
 
-[![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.5.2-blue.svg)](CHANGELOG.md)
 
 Fast, elegant programming language with Python's readability and Rust's safety.
 

--- a/include/public/version.h
+++ b/include/public/version.h
@@ -3,7 +3,7 @@
 
 #define ORUS_VERSION_MAJOR 0
 #define ORUS_VERSION_MINOR 5
-#define ORUS_VERSION_PATCH 1
+#define ORUS_VERSION_PATCH 2
 
 // Helpers to stringify numeric macros
 #define ORUS_STR_HELPER(x) #x


### PR DESCRIPTION
## Summary
- update the public version macros to report 0.5.2
- refresh the README badge and changelog entry to reflect the new release number

## Testing
- make release
- ./orus --version

------
https://chatgpt.com/codex/tasks/task_e_68cef8fb4e18832593b819f61ab0e0b3