### PR TITLE
Optimize fused loop increment for typed registers

### DIFF
--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -17,6 +17,22 @@
 #include <limits.h>
 #include <inttypes.h>
 
+static inline void store_i32_register(uint16_t id, int32_t value) {
+    if (id < REGISTER_COUNT) {
+        vm.registers[id].type = VAL_I32;
+        vm.registers[id].as.i32 = value;
+
+        const uint16_t typed_limit =
+            (uint16_t)(sizeof(vm.typed_regs.i32_regs) / sizeof(vm.typed_regs.i32_regs[0]));
+        if (id < typed_limit) {
+            vm.typed_regs.i32_regs[id] = value;
+            vm.typed_regs.reg_types[id] = REG_TYPE_I32;
+        }
+    } else {
+        set_register(&vm.register_file, id, I32_VAL(value));
+    }
+}
+
 static inline bool value_to_index(Value value, int* out_index) {
     if (IS_I32(value)) {
         int32_t idx = AS_I32(value);
@@ -3096,15 +3112,16 @@ InterpretResult vm_run_dispatch(void) {
         uint8_t src = *vm.ip++;
         int32_t imm = *(int32_t*)vm.ip;
         vm.ip += 4;
-        
+
         // Compiler ensures this is only emitted for i32 operations, so trust it
-        if (!IS_I32(vm.registers[src])) {
+        Value src_value = vm_get_register_safe(src);
+        if (!IS_I32(src_value)) {
             VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operand must be i32");
         }
-        
-        int32_t result = AS_I32(vm.registers[src]) + imm;
-        vm_set_register_safe(dst, I32_VAL(result));
-        
+
+        int32_t result = AS_I32(src_value) + imm;
+        store_i32_register(dst, result);
+
         DISPATCH_TYPED();
     }
 
@@ -3159,18 +3176,31 @@ InterpretResult vm_run_dispatch(void) {
         uint8_t limit_reg = *vm.ip++;
         int16_t offset = *(int16_t*)vm.ip;
         vm.ip += 2;
-        
-        // Compiler ensures this is only emitted for i32 operations, so trust it
-        if (!IS_I32(vm.registers[reg]) || !IS_I32(vm.registers[limit_reg])) {
-            VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be i32");
+
+        const uint16_t typed_limit =
+            (uint16_t)(sizeof(vm.typed_regs.i32_regs) / sizeof(vm.typed_regs.i32_regs[0]));
+        if (reg < typed_limit && limit_reg < typed_limit &&
+            vm.typed_regs.reg_types[reg] == REG_TYPE_I32 &&
+            vm.typed_regs.reg_types[limit_reg] == REG_TYPE_I32) {
+            int32_t incremented = vm.typed_regs.i32_regs[reg] + 1;
+            store_i32_register(reg, incremented);
+            if (incremented < vm.typed_regs.i32_regs[limit_reg]) {
+                vm.ip += offset;
+            }
+        } else {
+            Value counter = vm_get_register_safe(reg);
+            Value limit = vm_get_register_safe(limit_reg);
+            if (!IS_I32(counter) || !IS_I32(limit)) {
+                VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be i32");
+            }
+
+            int32_t incremented = AS_I32(counter) + 1;
+            store_i32_register(reg, incremented);
+            if (incremented < AS_I32(limit)) {
+                vm.ip += offset;
+            }
         }
-        
-        int32_t incremented = AS_I32(vm.registers[reg]) + 1;
-        vm_set_register_safe(reg, I32_VAL(incremented));
-        if (incremented < AS_I32(vm.registers[limit_reg])) {
-            vm.ip += offset;
-        }
-        
+
         DISPATCH_TYPED();
     }
 

--- a/tests/benchmarks/unified_benchmark.sh
+++ b/tests/benchmarks/unified_benchmark.sh
@@ -301,6 +301,7 @@ run_benchmark_category "Pure Arithmetic Performance" "arithmetic_benchmark.orus"
 # run_benchmark_category "Comprehensive Performance" "comprehensive_benchmark.orus"
 # run_benchmark_category "Extreme Performance" "extreme_benchmark.orus"
 run_benchmark_category "Control Flow Performance" "control_flow_benchmark.orus"
+run_benchmark_category "While Loop Performance" "while_loop_benchmark.orus"
 
 echo -e "${BLUE}=================================================================${NC}"
 echo -e "${GREEN}✨ Benchmark comparison complete!${NC}"

--- a/tests/benchmarks/while_loop_benchmark.orus
+++ b/tests/benchmarks/while_loop_benchmark.orus
@@ -1,0 +1,53 @@
+// Control Flow Benchmark: Compare while vs for loop performance
+print("=== Orus While vs For Loop Benchmark ===")
+
+TRIALS: i32 = 5
+LOOP_COUNT: i32 = 3_000_000
+
+mut trial: i32 = 0
+mut total_for_time: f64 = 0.0
+mut total_while_time: f64 = 0.0
+
+while trial < TRIALS:
+    print("\n--- Trial", trial, "---")
+
+    // Phase 1: for-loop summation
+    for_start: f64 = time_stamp()
+    mut for_sum: i64 = 0
+    for i in 0..=LOOP_COUNT:
+        for_sum = for_sum + (i as i64)
+    for_end: f64 = time_stamp()
+    for_elapsed: f64 = for_end - for_start
+    total_for_time = total_for_time + for_elapsed
+
+    print("For loop sum:", for_sum)
+    print("For loop elapsed:", for_elapsed)
+
+    // Phase 2: while-loop summation
+    while_start: f64 = time_stamp()
+    mut while_sum: i64 = 0
+    mut idx: i32 = 0
+    while idx <= LOOP_COUNT:
+        while_sum = while_sum + (idx as i64)
+        idx = idx + 1
+    while_end: f64 = time_stamp()
+    while_elapsed: f64 = while_end - while_start
+    total_while_time = total_while_time + while_elapsed
+
+    print("While loop sum:", while_sum)
+    print("While loop elapsed:", while_elapsed)
+
+    trial = trial + 1
+
+avg_for: f64 = total_for_time / (TRIALS as f64)
+avg_while: f64 = total_while_time / (TRIALS as f64)
+
+speed_ratio: f64 = avg_while / avg_for
+
+print("\n=== Benchmark Summary ===")
+print("Trials:", TRIALS)
+print("Iterations per loop:", LOOP_COUNT + 1)
+print("Average for-loop time:", avg_for)
+print("Average while-loop time:", avg_while)
+print("While vs for ratio:", speed_ratio)
+print("=== Benchmark Complete ===")


### PR DESCRIPTION
## Summary
- update the fused i32 store helper to keep the typed register cache in sync for both dispatchers
- accelerate OP_INC_CMP_JMP by using the cached i32 register bank when available and falling back to the safe path otherwise
https://chatgpt.com/codex/tasks/task_e_68cfe1306d8483259d6ff88005520d0e