### PR TITLE
Refine typed fast paths for arithmetic and move handlers

### DIFF
--- a/include/vm/vm_comparison.h
+++ b/include/vm/vm_comparison.h
@@ -306,34 +306,124 @@ static inline void vm_cache_bool_typed(uint16_t id, bool value) {
     }
 }
 
+static inline void store_i32_register(uint16_t id, int32_t value) {
+    if (vm_typed_reg_in_range(id)) {
+        vm.typed_regs.i32_regs[id] = value;
+        vm.typed_regs.reg_types[id] = REG_TYPE_I32;
+    }
+
+    vm_typed_iterator_invalidate(id);
+
+    Value boxed = I32_VAL(value);
+    if (id < 256) {
+        vm.registers[id] = boxed;
+    } else {
+        set_register(&vm.register_file, id, boxed);
+    }
+}
+
+static inline void store_i64_register(uint16_t id, int64_t value) {
+    if (vm_typed_reg_in_range(id)) {
+        vm.typed_regs.i64_regs[id] = value;
+        vm.typed_regs.reg_types[id] = REG_TYPE_I64;
+    }
+
+    vm_typed_iterator_invalidate(id);
+
+    Value boxed = I64_VAL(value);
+    if (id < 256) {
+        vm.registers[id] = boxed;
+    } else {
+        set_register(&vm.register_file, id, boxed);
+    }
+}
+
+static inline void store_u32_register(uint16_t id, uint32_t value) {
+    if (vm_typed_reg_in_range(id)) {
+        vm.typed_regs.u32_regs[id] = value;
+        vm.typed_regs.reg_types[id] = REG_TYPE_U32;
+    }
+
+    vm_typed_iterator_invalidate(id);
+
+    Value boxed = U32_VAL(value);
+    if (id < 256) {
+        vm.registers[id] = boxed;
+    } else {
+        set_register(&vm.register_file, id, boxed);
+    }
+}
+
+static inline void store_u64_register(uint16_t id, uint64_t value) {
+    if (vm_typed_reg_in_range(id)) {
+        vm.typed_regs.u64_regs[id] = value;
+        vm.typed_regs.reg_types[id] = REG_TYPE_U64;
+    }
+
+    vm_typed_iterator_invalidate(id);
+
+    Value boxed = U64_VAL(value);
+    if (id < 256) {
+        vm.registers[id] = boxed;
+    } else {
+        set_register(&vm.register_file, id, boxed);
+    }
+}
+
+static inline void store_f64_register(uint16_t id, double value) {
+    if (vm_typed_reg_in_range(id)) {
+        vm.typed_regs.f64_regs[id] = value;
+        vm.typed_regs.reg_types[id] = REG_TYPE_F64;
+    }
+
+    vm_typed_iterator_invalidate(id);
+
+    Value boxed = F64_VAL(value);
+    if (id < 256) {
+        vm.registers[id] = boxed;
+    } else {
+        set_register(&vm.register_file, id, boxed);
+    }
+}
+
+static inline void store_bool_register(uint16_t id, bool value) {
+    if (vm_typed_reg_in_range(id)) {
+        vm.typed_regs.bool_regs[id] = value;
+        vm.typed_regs.reg_types[id] = REG_TYPE_BOOL;
+    }
+
+    vm_typed_iterator_invalidate(id);
+
+    Value boxed = BOOL_VAL(value);
+    if (id < 256) {
+        vm.registers[id] = boxed;
+    } else {
+        set_register(&vm.register_file, id, boxed);
+    }
+}
+
 static inline void vm_store_i32_register(uint16_t id, int32_t value) {
-    vm_cache_i32_typed(id, value);
-    vm_set_register_safe(id, I32_VAL(value));
+    store_i32_register(id, value);
 }
 
 static inline void vm_store_i64_register(uint16_t id, int64_t value) {
-    vm_cache_i64_typed(id, value);
-    vm_set_register_safe(id, I64_VAL(value));
+    store_i64_register(id, value);
 }
 
 static inline void vm_store_u32_register(uint16_t id, uint32_t value) {
-    vm_cache_u32_typed(id, value);
-    vm_set_register_safe(id, U32_VAL(value));
+    store_u32_register(id, value);
 }
 
 static inline void vm_store_u64_register(uint16_t id, uint64_t value) {
-    vm_cache_u64_typed(id, value);
-    vm_set_register_safe(id, U64_VAL(value));
+    store_u64_register(id, value);
 }
 
 static inline void vm_store_f64_register(uint16_t id, double value) {
-    vm_cache_f64_typed(id, value);
-    vm_set_register_safe(id, F64_VAL(value));
+    store_f64_register(id, value);
 }
 
 static inline void vm_store_bool_register(uint16_t id, bool value) {
-    vm_cache_bool_typed(id, value);
-    vm_set_register_safe(id, BOOL_VAL(value));
+    store_bool_register(id, value);
 }
 
 // Equality comparisons

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -18,22 +18,6 @@
 #include <limits.h>
 #include <inttypes.h>
 
-static inline void store_i32_register(uint16_t id, int32_t value) {
-    if (id < REGISTER_COUNT) {
-        vm.registers[id].type = VAL_I32;
-        vm.registers[id].as.i32 = value;
-
-        const uint16_t typed_limit =
-            (uint16_t)(sizeof(vm.typed_regs.i32_regs) / sizeof(vm.typed_regs.i32_regs[0]));
-        if (id < typed_limit) {
-            vm.typed_regs.i32_regs[id] = value;
-            vm.typed_regs.reg_types[id] = REG_TYPE_I32;
-        }
-    } else {
-        set_register(&vm.register_file, id, I32_VAL(value));
-    }
-}
-
 static inline bool value_to_index(Value value, int* out_index) {
     if (IS_I32(value)) {
         int32_t idx = AS_I32(value);

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -15,24 +15,6 @@
 #include <math.h>
 #include <limits.h>
 
-// Frame-aware register access functions are declared in vm_comparison.h
-
-static inline void store_i32_register(uint16_t id, int32_t value) {
-    if (id < REGISTER_COUNT) {
-        vm.registers[id].type = VAL_I32;
-        vm.registers[id].as.i32 = value;
-
-        const uint16_t typed_limit =
-            (uint16_t)(sizeof(vm.typed_regs.i32_regs) / sizeof(vm.typed_regs.i32_regs[0]));
-        if (id < typed_limit) {
-            vm.typed_regs.i32_regs[id] = value;
-            vm.typed_regs.reg_types[id] = REG_TYPE_I32;
-        }
-    } else {
-        set_register(&vm.register_file, id, I32_VAL(value));
-    }
-}
-
 // Only needed for the switch-dispatch backend
 #if !USE_COMPUTED_GOTO
 static inline bool value_to_index(Value value, int* out_index) {

--- a/src/vm/handlers/vm_arithmetic_handlers.c
+++ b/src/vm/handlers/vm_arithmetic_handlers.c
@@ -14,6 +14,92 @@
 #include "vm/vm_comparison.h"
 #include <math.h>
 
+static inline bool read_i32_operand(uint16_t reg, int32_t* out, bool* typed_out) {
+    if (vm_try_read_i32_typed(reg, out)) {
+        if (typed_out) {
+            *typed_out = true;
+        }
+        return true;
+    }
+
+    Value boxed = vm_get_register_safe(reg);
+    if (!IS_I32(boxed)) {
+        return false;
+    }
+
+    int32_t value = AS_I32(boxed);
+    vm_cache_i32_typed(reg, value);
+    *out = value;
+    if (typed_out) {
+        *typed_out = false;
+    }
+    return true;
+}
+
+static inline bool read_i64_operand(uint16_t reg, int64_t* out) {
+    if (vm_try_read_i64_typed(reg, out)) {
+        return true;
+    }
+
+    Value boxed = vm_get_register_safe(reg);
+    if (!IS_I64(boxed)) {
+        return false;
+    }
+
+    int64_t value = AS_I64(boxed);
+    vm_cache_i64_typed(reg, value);
+    *out = value;
+    return true;
+}
+
+static inline bool read_u32_operand(uint16_t reg, uint32_t* out) {
+    if (vm_try_read_u32_typed(reg, out)) {
+        return true;
+    }
+
+    Value boxed = vm_get_register_safe(reg);
+    if (!IS_U32(boxed)) {
+        return false;
+    }
+
+    uint32_t value = AS_U32(boxed);
+    vm_cache_u32_typed(reg, value);
+    *out = value;
+    return true;
+}
+
+static inline bool read_u64_operand(uint16_t reg, uint64_t* out) {
+    if (vm_try_read_u64_typed(reg, out)) {
+        return true;
+    }
+
+    Value boxed = vm_get_register_safe(reg);
+    if (!IS_U64(boxed)) {
+        return false;
+    }
+
+    uint64_t value = AS_U64(boxed);
+    vm_cache_u64_typed(reg, value);
+    *out = value;
+    return true;
+}
+
+static inline bool read_f64_operand(uint16_t reg, double* out) {
+    if (vm_try_read_f64_typed(reg, out)) {
+        return true;
+    }
+
+    Value boxed = vm_get_register_safe(reg);
+    if (!IS_F64(boxed)) {
+        return false;
+    }
+
+    double value = AS_F64(boxed);
+    vm_cache_f64_typed(reg, value);
+    *out = value;
+    return true;
+}
+
 // ====== I32 Typed Arithmetic Handlers ======
 
 void handle_add_i32_typed(void) {
@@ -22,29 +108,19 @@ void handle_add_i32_typed(void) {
     uint8_t right = READ_BYTE();
 
     int32_t left_val;
-    bool left_typed = vm_try_read_i32_typed(left, &left_val);
-    if (!left_typed) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_I32(boxed)) {
-            vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-            return;
-        }
-        left_val = AS_I32(boxed);
-        vm_cache_i32_typed(left, left_val);
+    bool left_typed = false;
+    if (!read_i32_operand(left, &left_val, &left_typed)) {
+        vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
+        return;
     }
 
     int32_t right_val;
-    bool right_typed = vm_try_read_i32_typed(right, &right_val);
-    if (!right_typed) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_I32(boxed)) {
-            vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-            return;
-        }
-        right_val = AS_I32(boxed);
-        vm_cache_i32_typed(right, right_val);
+    bool right_typed = false;
+    if (!read_i32_operand(right, &right_val, &right_typed)) {
+        vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
+        return;
     }
 
     if (left_typed && right_typed) {
@@ -53,7 +129,7 @@ void handle_add_i32_typed(void) {
         vm_trace_loop_event(LOOP_TRACE_TYPED_MISS);
     }
 
-    vm_store_i32_register(dst, left_val + right_val);
+    store_i32_register(dst, left_val + right_val);
 }
 
 void handle_sub_i32_typed(void) {
@@ -62,29 +138,19 @@ void handle_sub_i32_typed(void) {
     uint8_t right = READ_BYTE();
 
     int32_t left_val;
-    bool left_typed = vm_try_read_i32_typed(left, &left_val);
-    if (!left_typed) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_I32(boxed)) {
-            vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-            return;
-        }
-        left_val = AS_I32(boxed);
-        vm_cache_i32_typed(left, left_val);
+    bool left_typed = false;
+    if (!read_i32_operand(left, &left_val, &left_typed)) {
+        vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
+        return;
     }
 
     int32_t right_val;
-    bool right_typed = vm_try_read_i32_typed(right, &right_val);
-    if (!right_typed) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_I32(boxed)) {
-            vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-            return;
-        }
-        right_val = AS_I32(boxed);
-        vm_cache_i32_typed(right, right_val);
+    bool right_typed = false;
+    if (!read_i32_operand(right, &right_val, &right_typed)) {
+        vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
+        return;
     }
 
     if (left_typed && right_typed) {
@@ -93,7 +159,7 @@ void handle_sub_i32_typed(void) {
         vm_trace_loop_event(LOOP_TRACE_TYPED_MISS);
     }
 
-    vm_store_i32_register(dst, left_val - right_val);
+    store_i32_register(dst, left_val - right_val);
 }
 
 void handle_mul_i32_typed(void) {
@@ -102,29 +168,19 @@ void handle_mul_i32_typed(void) {
     uint8_t right = READ_BYTE();
 
     int32_t left_val;
-    bool left_typed = vm_try_read_i32_typed(left, &left_val);
-    if (!left_typed) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_I32(boxed)) {
-            vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-            return;
-        }
-        left_val = AS_I32(boxed);
-        vm_cache_i32_typed(left, left_val);
+    bool left_typed = false;
+    if (!read_i32_operand(left, &left_val, &left_typed)) {
+        vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
+        return;
     }
 
     int32_t right_val;
-    bool right_typed = vm_try_read_i32_typed(right, &right_val);
-    if (!right_typed) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_I32(boxed)) {
-            vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-            return;
-        }
-        right_val = AS_I32(boxed);
-        vm_cache_i32_typed(right, right_val);
+    bool right_typed = false;
+    if (!read_i32_operand(right, &right_val, &right_typed)) {
+        vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
+        return;
     }
 
     if (left_typed && right_typed) {
@@ -133,7 +189,7 @@ void handle_mul_i32_typed(void) {
         vm_trace_loop_event(LOOP_TRACE_TYPED_MISS);
     }
 
-    vm_store_i32_register(dst, left_val * right_val);
+    store_i32_register(dst, left_val * right_val);
 }
 
 void handle_div_i32_typed(void) {
@@ -142,29 +198,19 @@ void handle_div_i32_typed(void) {
     uint8_t right = READ_BYTE();
 
     int32_t left_val;
-    bool left_typed = vm_try_read_i32_typed(left, &left_val);
-    if (!left_typed) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_I32(boxed)) {
-            vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-            return;
-        }
-        left_val = AS_I32(boxed);
-        vm_cache_i32_typed(left, left_val);
+    bool left_typed = false;
+    if (!read_i32_operand(left, &left_val, &left_typed)) {
+        vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
+        return;
     }
 
     int32_t right_val;
-    bool right_typed = vm_try_read_i32_typed(right, &right_val);
-    if (!right_typed) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_I32(boxed)) {
-            vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-            return;
-        }
-        right_val = AS_I32(boxed);
-        vm_cache_i32_typed(right, right_val);
+    bool right_typed = false;
+    if (!read_i32_operand(right, &right_val, &right_typed)) {
+        vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
+        return;
     }
 
     if (right_val == 0) {
@@ -178,7 +224,7 @@ void handle_div_i32_typed(void) {
         vm_trace_loop_event(LOOP_TRACE_TYPED_MISS);
     }
 
-    vm_store_i32_register(dst, left_val / right_val);
+    store_i32_register(dst, left_val / right_val);
 }
 
 void handle_mod_i32_typed(void) {
@@ -187,29 +233,19 @@ void handle_mod_i32_typed(void) {
     uint8_t right = READ_BYTE();
 
     int32_t left_val;
-    bool left_typed = vm_try_read_i32_typed(left, &left_val);
-    if (!left_typed) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_I32(boxed)) {
-            vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-            return;
-        }
-        left_val = AS_I32(boxed);
-        vm_cache_i32_typed(left, left_val);
+    bool left_typed = false;
+    if (!read_i32_operand(left, &left_val, &left_typed)) {
+        vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
+        return;
     }
 
     int32_t right_val;
-    bool right_typed = vm_try_read_i32_typed(right, &right_val);
-    if (!right_typed) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_I32(boxed)) {
-            vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-            return;
-        }
-        right_val = AS_I32(boxed);
-        vm_cache_i32_typed(right, right_val);
+    bool right_typed = false;
+    if (!read_i32_operand(right, &right_val, &right_typed)) {
+        vm_trace_loop_event(LOOP_TRACE_TYPE_MISMATCH);
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
+        return;
     }
 
     if (right_val == 0) {
@@ -223,7 +259,7 @@ void handle_mod_i32_typed(void) {
         vm_trace_loop_event(LOOP_TRACE_TYPED_MISS);
     }
 
-    vm_store_i32_register(dst, left_val % right_val);
+    store_i32_register(dst, left_val % right_val);
 }
 
 // ====== I64 Typed Arithmetic Handlers ======
@@ -234,28 +270,18 @@ void handle_add_i64_typed(void) {
     uint8_t right = READ_BYTE();
 
     int64_t left_val;
-    if (!vm_try_read_i64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_I64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-            return;
-        }
-        left_val = AS_I64(boxed);
-        vm_cache_i64_typed(left, left_val);
+    if (!read_i64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
+        return;
     }
 
     int64_t right_val;
-    if (!vm_try_read_i64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_I64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-            return;
-        }
-        right_val = AS_I64(boxed);
-        vm_cache_i64_typed(right, right_val);
+    if (!read_i64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
+        return;
     }
 
-    vm_store_i64_register(dst, left_val + right_val);
+    store_i64_register(dst, left_val + right_val);
 }
 
 void handle_sub_i64_typed(void) {
@@ -264,28 +290,18 @@ void handle_sub_i64_typed(void) {
     uint8_t right = READ_BYTE();
 
     int64_t left_val;
-    if (!vm_try_read_i64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_I64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-            return;
-        }
-        left_val = AS_I64(boxed);
-        vm_cache_i64_typed(left, left_val);
+    if (!read_i64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
+        return;
     }
 
     int64_t right_val;
-    if (!vm_try_read_i64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_I64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-            return;
-        }
-        right_val = AS_I64(boxed);
-        vm_cache_i64_typed(right, right_val);
+    if (!read_i64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
+        return;
     }
 
-    vm_store_i64_register(dst, left_val - right_val);
+    store_i64_register(dst, left_val - right_val);
 }
 
 void handle_mul_i64_typed(void) {
@@ -294,28 +310,18 @@ void handle_mul_i64_typed(void) {
     uint8_t right = READ_BYTE();
 
     int64_t left_val;
-    if (!vm_try_read_i64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_I64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-            return;
-        }
-        left_val = AS_I64(boxed);
-        vm_cache_i64_typed(left, left_val);
+    if (!read_i64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
+        return;
     }
 
     int64_t right_val;
-    if (!vm_try_read_i64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_I64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-            return;
-        }
-        right_val = AS_I64(boxed);
-        vm_cache_i64_typed(right, right_val);
+    if (!read_i64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
+        return;
     }
 
-    vm_store_i64_register(dst, left_val * right_val);
+    store_i64_register(dst, left_val * right_val);
 }
 
 void handle_div_i64_typed(void) {
@@ -324,25 +330,15 @@ void handle_div_i64_typed(void) {
     uint8_t right = READ_BYTE();
 
     int64_t left_val;
-    if (!vm_try_read_i64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_I64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-            return;
-        }
-        left_val = AS_I64(boxed);
-        vm_cache_i64_typed(left, left_val);
+    if (!read_i64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
+        return;
     }
 
     int64_t right_val;
-    if (!vm_try_read_i64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_I64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-            return;
-        }
-        right_val = AS_I64(boxed);
-        vm_cache_i64_typed(right, right_val);
+    if (!read_i64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
+        return;
     }
 
     if (right_val == 0) {
@@ -350,7 +346,7 @@ void handle_div_i64_typed(void) {
         return;
     }
 
-    vm_store_i64_register(dst, left_val / right_val);
+    store_i64_register(dst, left_val / right_val);
 }
 
 void handle_mod_i64_typed(void) {
@@ -359,25 +355,15 @@ void handle_mod_i64_typed(void) {
     uint8_t right = READ_BYTE();
 
     int64_t left_val;
-    if (!vm_try_read_i64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_I64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-            return;
-        }
-        left_val = AS_I64(boxed);
-        vm_cache_i64_typed(left, left_val);
+    if (!read_i64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
+        return;
     }
 
     int64_t right_val;
-    if (!vm_try_read_i64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_I64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-            return;
-        }
-        right_val = AS_I64(boxed);
-        vm_cache_i64_typed(right, right_val);
+    if (!read_i64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
+        return;
     }
 
     if (right_val == 0) {
@@ -385,7 +371,7 @@ void handle_mod_i64_typed(void) {
         return;
     }
 
-    vm_store_i64_register(dst, left_val % right_val);
+    store_i64_register(dst, left_val % right_val);
 }
 
 // ====== F64 Typed Arithmetic Handlers ======
@@ -396,28 +382,18 @@ void handle_add_f64_typed(void) {
     uint8_t right = READ_BYTE();
 
     double left_val;
-    if (!vm_try_read_f64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_F64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-            return;
-        }
-        left_val = AS_F64(boxed);
-        vm_cache_f64_typed(left, left_val);
+    if (!read_f64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
+        return;
     }
 
     double right_val;
-    if (!vm_try_read_f64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_F64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-            return;
-        }
-        right_val = AS_F64(boxed);
-        vm_cache_f64_typed(right, right_val);
+    if (!read_f64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
+        return;
     }
 
-    vm_store_f64_register(dst, left_val + right_val);
+    store_f64_register(dst, left_val + right_val);
 }
 
 void handle_sub_f64_typed(void) {
@@ -426,28 +402,18 @@ void handle_sub_f64_typed(void) {
     uint8_t right = READ_BYTE();
 
     double left_val;
-    if (!vm_try_read_f64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_F64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-            return;
-        }
-        left_val = AS_F64(boxed);
-        vm_cache_f64_typed(left, left_val);
+    if (!read_f64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
+        return;
     }
 
     double right_val;
-    if (!vm_try_read_f64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_F64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-            return;
-        }
-        right_val = AS_F64(boxed);
-        vm_cache_f64_typed(right, right_val);
+    if (!read_f64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
+        return;
     }
 
-    vm_store_f64_register(dst, left_val - right_val);
+    store_f64_register(dst, left_val - right_val);
 }
 
 void handle_mul_f64_typed(void) {
@@ -456,28 +422,18 @@ void handle_mul_f64_typed(void) {
     uint8_t right = READ_BYTE();
 
     double left_val;
-    if (!vm_try_read_f64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_F64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-            return;
-        }
-        left_val = AS_F64(boxed);
-        vm_cache_f64_typed(left, left_val);
+    if (!read_f64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
+        return;
     }
 
     double right_val;
-    if (!vm_try_read_f64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_F64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-            return;
-        }
-        right_val = AS_F64(boxed);
-        vm_cache_f64_typed(right, right_val);
+    if (!read_f64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
+        return;
     }
 
-    vm_store_f64_register(dst, left_val * right_val);
+    store_f64_register(dst, left_val * right_val);
 }
 
 void handle_div_f64_typed(void) {
@@ -486,25 +442,15 @@ void handle_div_f64_typed(void) {
     uint8_t right = READ_BYTE();
 
     double left_val;
-    if (!vm_try_read_f64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_F64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-            return;
-        }
-        left_val = AS_F64(boxed);
-        vm_cache_f64_typed(left, left_val);
+    if (!read_f64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
+        return;
     }
 
     double right_val;
-    if (!vm_try_read_f64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_F64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-            return;
-        }
-        right_val = AS_F64(boxed);
-        vm_cache_f64_typed(right, right_val);
+    if (!read_f64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
+        return;
     }
 
     if (right_val == 0.0) {
@@ -512,7 +458,7 @@ void handle_div_f64_typed(void) {
         return;
     }
 
-    vm_store_f64_register(dst, left_val / right_val);
+    store_f64_register(dst, left_val / right_val);
 }
 
 void handle_mod_f64_typed(void) {
@@ -521,25 +467,15 @@ void handle_mod_f64_typed(void) {
     uint8_t right = READ_BYTE();
 
     double left_val;
-    if (!vm_try_read_f64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_F64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-            return;
-        }
-        left_val = AS_F64(boxed);
-        vm_cache_f64_typed(left, left_val);
+    if (!read_f64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
+        return;
     }
 
     double right_val;
-    if (!vm_try_read_f64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_F64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-            return;
-        }
-        right_val = AS_F64(boxed);
-        vm_cache_f64_typed(right, right_val);
+    if (!read_f64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
+        return;
     }
 
     if (right_val == 0.0) {
@@ -547,7 +483,7 @@ void handle_mod_f64_typed(void) {
         return;
     }
 
-    vm_store_f64_register(dst, fmod(left_val, right_val));
+    store_f64_register(dst, fmod(left_val, right_val));
 }
 
 // ====== U32 Typed Arithmetic Handlers ======
@@ -558,28 +494,18 @@ void handle_add_u32_typed(void) {
     uint8_t right = READ_BYTE();
 
     uint32_t left_val;
-    if (!vm_try_read_u32_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_U32(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-            return;
-        }
-        left_val = AS_U32(boxed);
-        vm_cache_u32_typed(left, left_val);
+    if (!read_u32_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
+        return;
     }
 
     uint32_t right_val;
-    if (!vm_try_read_u32_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_U32(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-            return;
-        }
-        right_val = AS_U32(boxed);
-        vm_cache_u32_typed(right, right_val);
+    if (!read_u32_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
+        return;
     }
 
-    vm_store_u32_register(dst, left_val + right_val);
+    store_u32_register(dst, left_val + right_val);
 }
 
 void handle_sub_u32_typed(void) {
@@ -588,28 +514,18 @@ void handle_sub_u32_typed(void) {
     uint8_t right = READ_BYTE();
 
     uint32_t left_val;
-    if (!vm_try_read_u32_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_U32(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-            return;
-        }
-        left_val = AS_U32(boxed);
-        vm_cache_u32_typed(left, left_val);
+    if (!read_u32_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
+        return;
     }
 
     uint32_t right_val;
-    if (!vm_try_read_u32_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_U32(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-            return;
-        }
-        right_val = AS_U32(boxed);
-        vm_cache_u32_typed(right, right_val);
+    if (!read_u32_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
+        return;
     }
 
-    vm_store_u32_register(dst, left_val - right_val);
+    store_u32_register(dst, left_val - right_val);
 }
 
 void handle_mul_u32_typed(void) {
@@ -618,28 +534,18 @@ void handle_mul_u32_typed(void) {
     uint8_t right = READ_BYTE();
 
     uint32_t left_val;
-    if (!vm_try_read_u32_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_U32(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-            return;
-        }
-        left_val = AS_U32(boxed);
-        vm_cache_u32_typed(left, left_val);
+    if (!read_u32_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
+        return;
     }
 
     uint32_t right_val;
-    if (!vm_try_read_u32_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_U32(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-            return;
-        }
-        right_val = AS_U32(boxed);
-        vm_cache_u32_typed(right, right_val);
+    if (!read_u32_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
+        return;
     }
 
-    vm_store_u32_register(dst, left_val * right_val);
+    store_u32_register(dst, left_val * right_val);
 }
 
 void handle_div_u32_typed(void) {
@@ -648,25 +554,15 @@ void handle_div_u32_typed(void) {
     uint8_t right = READ_BYTE();
 
     uint32_t left_val;
-    if (!vm_try_read_u32_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_U32(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-            return;
-        }
-        left_val = AS_U32(boxed);
-        vm_cache_u32_typed(left, left_val);
+    if (!read_u32_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
+        return;
     }
 
     uint32_t right_val;
-    if (!vm_try_read_u32_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_U32(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-            return;
-        }
-        right_val = AS_U32(boxed);
-        vm_cache_u32_typed(right, right_val);
+    if (!read_u32_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
+        return;
     }
 
     if (right_val == 0) {
@@ -674,7 +570,7 @@ void handle_div_u32_typed(void) {
         return;
     }
 
-    vm_store_u32_register(dst, left_val / right_val);
+    store_u32_register(dst, left_val / right_val);
 }
 
 void handle_mod_u32_typed(void) {
@@ -683,25 +579,15 @@ void handle_mod_u32_typed(void) {
     uint8_t right = READ_BYTE();
 
     uint32_t left_val;
-    if (!vm_try_read_u32_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_U32(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-            return;
-        }
-        left_val = AS_U32(boxed);
-        vm_cache_u32_typed(left, left_val);
+    if (!read_u32_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
+        return;
     }
 
     uint32_t right_val;
-    if (!vm_try_read_u32_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_U32(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-            return;
-        }
-        right_val = AS_U32(boxed);
-        vm_cache_u32_typed(right, right_val);
+    if (!read_u32_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
+        return;
     }
 
     if (right_val == 0) {
@@ -709,7 +595,7 @@ void handle_mod_u32_typed(void) {
         return;
     }
 
-    vm_store_u32_register(dst, left_val % right_val);
+    store_u32_register(dst, left_val % right_val);
 }
 
 // ====== U64 Typed Arithmetic Handlers ======
@@ -720,28 +606,18 @@ void handle_add_u64_typed(void) {
     uint8_t right = READ_BYTE();
 
     uint64_t left_val;
-    if (!vm_try_read_u64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_U64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-            return;
-        }
-        left_val = AS_U64(boxed);
-        vm_cache_u64_typed(left, left_val);
+    if (!read_u64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
+        return;
     }
 
     uint64_t right_val;
-    if (!vm_try_read_u64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_U64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-            return;
-        }
-        right_val = AS_U64(boxed);
-        vm_cache_u64_typed(right, right_val);
+    if (!read_u64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
+        return;
     }
 
-    vm_store_u64_register(dst, left_val + right_val);
+    store_u64_register(dst, left_val + right_val);
 }
 
 void handle_sub_u64_typed(void) {
@@ -750,28 +626,18 @@ void handle_sub_u64_typed(void) {
     uint8_t right = READ_BYTE();
 
     uint64_t left_val;
-    if (!vm_try_read_u64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_U64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-            return;
-        }
-        left_val = AS_U64(boxed);
-        vm_cache_u64_typed(left, left_val);
+    if (!read_u64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
+        return;
     }
 
     uint64_t right_val;
-    if (!vm_try_read_u64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_U64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-            return;
-        }
-        right_val = AS_U64(boxed);
-        vm_cache_u64_typed(right, right_val);
+    if (!read_u64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
+        return;
     }
 
-    vm_store_u64_register(dst, left_val - right_val);
+    store_u64_register(dst, left_val - right_val);
 }
 
 void handle_mul_u64_typed(void) {
@@ -780,28 +646,18 @@ void handle_mul_u64_typed(void) {
     uint8_t right = READ_BYTE();
 
     uint64_t left_val;
-    if (!vm_try_read_u64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_U64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-            return;
-        }
-        left_val = AS_U64(boxed);
-        vm_cache_u64_typed(left, left_val);
+    if (!read_u64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
+        return;
     }
 
     uint64_t right_val;
-    if (!vm_try_read_u64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_U64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-            return;
-        }
-        right_val = AS_U64(boxed);
-        vm_cache_u64_typed(right, right_val);
+    if (!read_u64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
+        return;
     }
 
-    vm_store_u64_register(dst, left_val * right_val);
+    store_u64_register(dst, left_val * right_val);
 }
 
 void handle_div_u64_typed(void) {
@@ -810,25 +666,15 @@ void handle_div_u64_typed(void) {
     uint8_t right = READ_BYTE();
 
     uint64_t left_val;
-    if (!vm_try_read_u64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_U64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-            return;
-        }
-        left_val = AS_U64(boxed);
-        vm_cache_u64_typed(left, left_val);
+    if (!read_u64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
+        return;
     }
 
     uint64_t right_val;
-    if (!vm_try_read_u64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_U64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-            return;
-        }
-        right_val = AS_U64(boxed);
-        vm_cache_u64_typed(right, right_val);
+    if (!read_u64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
+        return;
     }
 
     if (right_val == 0) {
@@ -836,7 +682,7 @@ void handle_div_u64_typed(void) {
         return;
     }
 
-    vm_store_u64_register(dst, left_val / right_val);
+    store_u64_register(dst, left_val / right_val);
 }
 
 void handle_mod_u64_typed(void) {
@@ -845,25 +691,15 @@ void handle_mod_u64_typed(void) {
     uint8_t right = READ_BYTE();
 
     uint64_t left_val;
-    if (!vm_try_read_u64_typed(left, &left_val)) {
-        Value boxed = vm_get_register_safe(left);
-        if (!IS_U64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-            return;
-        }
-        left_val = AS_U64(boxed);
-        vm_cache_u64_typed(left, left_val);
+    if (!read_u64_operand(left, &left_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
+        return;
     }
 
     uint64_t right_val;
-    if (!vm_try_read_u64_typed(right, &right_val)) {
-        Value boxed = vm_get_register_safe(right);
-        if (!IS_U64(boxed)) {
-            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-            return;
-        }
-        right_val = AS_U64(boxed);
-        vm_cache_u64_typed(right, right_val);
+    if (!read_u64_operand(right, &right_val)) {
+        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
+        return;
     }
 
     if (right_val == 0) {
@@ -871,5 +707,5 @@ void handle_mod_u64_typed(void) {
         return;
     }
 
-    vm_store_u64_register(dst, left_val % right_val);
+    store_u64_register(dst, left_val % right_val);
 }

--- a/src/vm/handlers/vm_memory_handlers.c
+++ b/src/vm/handlers/vm_memory_handlers.c
@@ -64,32 +64,89 @@ void handle_move_reg(void) {
     uint8_t dst = READ_BYTE();
     uint8_t src = READ_BYTE();
 
+    if (vm_typed_reg_in_range(src)) {
+        switch (vm.typed_regs.reg_types[src]) {
+            case REG_TYPE_I32: {
+                int32_t cached;
+                if (vm_try_read_i32_typed(src, &cached)) {
+                    store_i32_register(dst, cached);
+                    return;
+                }
+                break;
+            }
+            case REG_TYPE_I64: {
+                int64_t cached;
+                if (vm_try_read_i64_typed(src, &cached)) {
+                    store_i64_register(dst, cached);
+                    return;
+                }
+                break;
+            }
+            case REG_TYPE_U32: {
+                uint32_t cached;
+                if (vm_try_read_u32_typed(src, &cached)) {
+                    store_u32_register(dst, cached);
+                    return;
+                }
+                break;
+            }
+            case REG_TYPE_U64: {
+                uint64_t cached;
+                if (vm_try_read_u64_typed(src, &cached)) {
+                    store_u64_register(dst, cached);
+                    return;
+                }
+                break;
+            }
+            case REG_TYPE_F64: {
+                double cached;
+                if (vm_try_read_f64_typed(src, &cached)) {
+                    store_f64_register(dst, cached);
+                    return;
+                }
+                break;
+            }
+            case REG_TYPE_BOOL: {
+                bool cached;
+                if (vm_try_read_bool_typed(src, &cached)) {
+                    store_bool_register(dst, cached);
+                    return;
+                }
+                break;
+            }
+            case REG_TYPE_HEAP:
+            case REG_TYPE_NONE:
+            default:
+                break;
+        }
+    }
+
     // Use frame-aware register access for proper local variable isolation
     Value value = vm_get_register_safe(src);
     switch (value.type) {
         case VAL_I32:
             vm_cache_i32_typed(src, AS_I32(value));
-            vm_store_i32_register(dst, AS_I32(value));
+            store_i32_register(dst, AS_I32(value));
             break;
         case VAL_I64:
             vm_cache_i64_typed(src, AS_I64(value));
-            vm_store_i64_register(dst, AS_I64(value));
+            store_i64_register(dst, AS_I64(value));
             break;
         case VAL_U32:
             vm_cache_u32_typed(src, AS_U32(value));
-            vm_store_u32_register(dst, AS_U32(value));
+            store_u32_register(dst, AS_U32(value));
             break;
         case VAL_U64:
             vm_cache_u64_typed(src, AS_U64(value));
-            vm_store_u64_register(dst, AS_U64(value));
+            store_u64_register(dst, AS_U64(value));
             break;
         case VAL_F64:
             vm_cache_f64_typed(src, AS_F64(value));
-            vm_store_f64_register(dst, AS_F64(value));
+            store_f64_register(dst, AS_F64(value));
             break;
         case VAL_BOOL:
             vm_cache_bool_typed(src, AS_BOOL(value));
-            vm_store_bool_register(dst, AS_BOOL(value));
+            store_bool_register(dst, AS_BOOL(value));
             break;
         default:
             vm_set_register_safe(dst, value);

--- a/src/vm/runtime/vm_loop_fastpaths.c
+++ b/src/vm/runtime/vm_loop_fastpaths.c
@@ -79,8 +79,7 @@ bool vm_exec_inc_i32_checked(uint16_t reg) {
         return false;
     }
 
-    vm.typed_regs.i32_regs[reg] = next_value;
-    vm_set_register_safe(reg, I32_VAL(next_value));
+    store_i32_register(reg, next_value);
     vm_trace_loop_event(LOOP_TRACE_TYPED_HIT);
     return true;
 }

--- a/tests/benchmarks/typed_fastpath_benchmark.orus
+++ b/tests/benchmarks/typed_fastpath_benchmark.orus
@@ -1,0 +1,30 @@
+// Focused microbenchmark for typed arithmetic and move fast paths
+// Measures the steady-state throughput of i32 add/inc loops and register moves
+// while validating that cached primitives produce the correct checksum.
+
+TRIALS: i32 = 5
+ITERATIONS: i32 = 2_000_000
+
+mut trial: i32 = 0
+mut checksum: i64 = 0
+
+while trial < TRIALS:
+    start: f64 = time_stamp()
+    mut i: i32 = 0
+    mut acc: i32 = trial
+    mut sink: i32 = 0
+
+    while i < ITERATIONS:
+        acc = acc + 1
+        sink = acc
+        i = i + 1
+
+    elapsed: f64 = time_stamp() - start
+    print("typed-fastpath elapsed:", elapsed)
+
+    checksum = checksum + (acc as i64) + (sink as i64)
+    trial = trial + 1
+
+print("checksum:", checksum)
+print("trials:", TRIALS)
+print("iterations:", ITERATIONS)


### PR DESCRIPTION
## Summary
- add lightweight typed store helpers and refactor typed arithmetic handlers to reuse cached primitives before falling back to boxed access
- update the increment fast path and register move handler to write through the new helpers without re-boxing, preserving existing type and overflow guards
- add a typed fast-path microbenchmark under tests/benchmarks to monitor throughput improvements