### PR TITLE
Optimize monotonic fused loops

### DIFF
--- a/include/compiler/compiler.h
+++ b/include/compiler/compiler.h
@@ -54,6 +54,9 @@ typedef struct BytecodeBuffer {
     struct JumpPatch* patches; // Forward/backward jump patches
     int patch_count;
     int patch_capacity;
+
+    // Instruction metadata (per-byte flags)
+    uint8_t* monotonic_range_flags; // Marks fused range loops eligible for monotonic fastpath
 } BytecodeBuffer;
 
 typedef struct JumpPatch {
@@ -164,6 +167,7 @@ OpCode get_typed_opcode(const char* op, RegisterType type);
 OpCode get_standard_opcode(const char* op, RegisterType type);
 int emit_jump_placeholder(BytecodeBuffer* buffer, uint8_t jump_opcode);
 bool patch_jump(BytecodeBuffer* buffer, int patch_index, int target_offset);
+void bytecode_mark_monotonic_range(BytecodeBuffer* buffer, int offset);
 
 // Constant pool functions
 ConstantPool* init_constant_pool(void);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -166,6 +166,7 @@ typedef struct {
     int* lines;
     int* columns;
     const char** files;
+    uint8_t* monotonic_range_flags;
     struct {
         int count;
         int capacity;

--- a/include/vm/vm_loop_fastpaths.h
+++ b/include/vm/vm_loop_fastpaths.h
@@ -53,6 +53,7 @@ static inline bool vm_typed_iterator_bind_array(uint16_t reg, ObjArray* array) {
 bool vm_try_branch_bool_fast_hot(uint16_t reg, bool* out_value);
 VMBoolBranchResult vm_try_branch_bool_fast_cold(uint16_t reg, bool* out_value);
 bool vm_exec_inc_i32_checked(uint16_t reg);
+bool vm_exec_monotonic_inc_cmp_i32(uint16_t counter_reg, uint16_t limit_reg, bool* out_should_continue);
 bool vm_typed_iterator_next(uint16_t reg, Value* out_value);
 
 #ifdef __cplusplus

--- a/src/compiler/backend/codegen/codegen.c
+++ b/src/compiler/backend/codegen/codegen.c
@@ -4582,7 +4582,9 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
         }
 
         set_location_from_node(ctx, while_stmt);
+        int inc_cmp_offset = ctx->bytecode ? ctx->bytecode->count : 0;
         emit_byte_to_buffer(ctx->bytecode, OP_INC_CMP_JMP);
+        bytecode_mark_monotonic_range(ctx->bytecode, inc_cmp_offset);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_loop_reg);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)(fused_limit_temp_is_temp ? fused_limit_temp_reg : fused_limit_reg));
         int back_off = loop_start_fused - (ctx->bytecode->count + 2);
@@ -5025,7 +5027,9 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
         patch_continue_statements(ctx, continue_target);
 
         set_location_from_node(ctx, for_stmt);
+        int inc_cmp_offset = ctx->bytecode ? ctx->bytecode->count : 0;
         emit_byte_to_buffer(ctx->bytecode, OP_INC_CMP_JMP);
+        bytecode_mark_monotonic_range(ctx->bytecode, inc_cmp_offset);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_var_reg);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_reg_used);
         // back offset is relative to address after the 2-byte offset we emit now
@@ -5614,6 +5618,8 @@ void finalize_functions_to_vm(CompilerContext* ctx) {
         chunk->lines = func_chunk->count > 0 ? malloc(sizeof(int) * func_chunk->count) : NULL;
         chunk->columns = func_chunk->count > 0 ? malloc(sizeof(int) * func_chunk->count) : NULL;
         chunk->files = func_chunk->count > 0 ? malloc(sizeof(const char*) * func_chunk->count) : NULL;
+        chunk->monotonic_range_flags =
+            func_chunk->count > 0 ? malloc(sizeof(uint8_t) * func_chunk->count) : NULL;
         if (chunk->lines && func_chunk->source_lines) {
             memcpy(chunk->lines, func_chunk->source_lines, sizeof(int) * func_chunk->count);
         }
@@ -5626,6 +5632,12 @@ void finalize_functions_to_vm(CompilerContext* ctx) {
             for (int j = 0; j < func_chunk->count; ++j) {
                 chunk->files[j] = NULL;
             }
+        }
+        if (chunk->monotonic_range_flags && func_chunk->monotonic_range_flags) {
+            memcpy(chunk->monotonic_range_flags, func_chunk->monotonic_range_flags,
+                   sizeof(uint8_t) * func_chunk->count);
+        } else if (chunk->monotonic_range_flags) {
+            memset(chunk->monotonic_range_flags, 0, sizeof(uint8_t) * func_chunk->count);
         }
 
         // Copy constants from main context

--- a/src/vm/core/vm_memory.c
+++ b/src/vm/core/vm_memory.c
@@ -460,6 +460,7 @@ void initChunk(Chunk* chunk) {
     chunk->lines = NULL;
     chunk->columns = NULL;
     chunk->files = NULL;
+    chunk->monotonic_range_flags = NULL;
     chunk->constants.count = 0;
     chunk->constants.capacity = 0;
     chunk->constants.values = NULL;
@@ -470,6 +471,7 @@ void freeChunk(Chunk* chunk) {
     FREE_ARRAY(int, chunk->lines, chunk->capacity);
     FREE_ARRAY(int, chunk->columns, chunk->capacity);
     free(chunk->files);
+    free(chunk->monotonic_range_flags);
     FREE_ARRAY(Value, chunk->constants.values, chunk->constants.capacity);
     initChunk(chunk);
 }
@@ -486,6 +488,12 @@ void writeChunk(Chunk* chunk, uint8_t byte, int line, int column, const char* fi
             GROW_ARRAY(int, chunk->columns, oldCapacity, chunk->capacity);
         chunk->files =
             GROW_ARRAY(const char*, chunk->files, oldCapacity, chunk->capacity);
+        chunk->monotonic_range_flags =
+            GROW_ARRAY(uint8_t, chunk->monotonic_range_flags, oldCapacity, chunk->capacity);
+        if (chunk->monotonic_range_flags) {
+            memset(chunk->monotonic_range_flags + oldCapacity, 0,
+                   (size_t)(chunk->capacity - oldCapacity) * sizeof(uint8_t));
+        }
     }
 
     chunk->code[chunk->count] = byte;
@@ -493,6 +501,9 @@ void writeChunk(Chunk* chunk, uint8_t byte, int line, int column, const char* fi
     chunk->columns[chunk->count] = column;
     if (chunk->files) {
         chunk->files[chunk->count] = file;
+    }
+    if (chunk->monotonic_range_flags) {
+        chunk->monotonic_range_flags[chunk->count] = 0;
     }
     chunk->count++;
 }

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -3345,33 +3345,62 @@ InterpretResult vm_run_dispatch(void) {
     }
 
     LABEL_OP_INC_CMP_JMP: {
+        bool has_chunk = vm.chunk && vm.chunk->code;
+        size_t opcode_offset = has_chunk ? (size_t)((vm.ip - vm.chunk->code) - 1) : 0;
         uint8_t reg = *vm.ip++;
         uint8_t limit_reg = *vm.ip++;
         int16_t offset = *(int16_t*)vm.ip;
         vm.ip += 2;
 
-        const uint16_t typed_limit =
-            (uint16_t)(sizeof(vm.typed_regs.i32_regs) / sizeof(vm.typed_regs.i32_regs[0]));
-        if (reg < typed_limit && limit_reg < typed_limit &&
+        bool monotonic_hint = false;
+        if (has_chunk && vm.chunk->monotonic_range_flags &&
+            opcode_offset < (size_t)vm.chunk->count) {
+            monotonic_hint = vm.chunk->monotonic_range_flags[opcode_offset] != 0;
+        }
+
+        if (monotonic_hint && vm_typed_reg_in_range(reg) &&
+            vm_typed_reg_in_range(limit_reg) &&
             vm.typed_regs.reg_types[reg] == REG_TYPE_I32 &&
             vm.typed_regs.reg_types[limit_reg] == REG_TYPE_I32) {
-            int32_t incremented = vm.typed_regs.i32_regs[reg] + 1;
-            store_i32_register(reg, incremented);
-            if (incremented < vm.typed_regs.i32_regs[limit_reg]) {
-                vm.ip += offset;
+            bool should_continue = false;
+            if (vm_exec_monotonic_inc_cmp_i32(reg, limit_reg, &should_continue)) {
+                if (should_continue) {
+                    vm.ip += offset;
+                }
+                DISPATCH_TYPED();
             }
-        } else {
-            Value counter = vm_get_register_safe(reg);
+        }
+
+        if (vm_exec_inc_i32_checked(reg)) {
+            if (vm_typed_reg_in_range(limit_reg) &&
+                vm.typed_regs.reg_types[limit_reg] == REG_TYPE_I32) {
+                if (vm.typed_regs.i32_regs[reg] < vm.typed_regs.i32_regs[limit_reg]) {
+                    vm.ip += offset;
+                }
+                DISPATCH_TYPED();
+            }
+
             Value limit = vm_get_register_safe(limit_reg);
-            if (!IS_I32(counter) || !IS_I32(limit)) {
+            if (!IS_I32(limit)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be i32");
             }
 
-            int32_t incremented = AS_I32(counter) + 1;
-            store_i32_register(reg, incremented);
-            if (incremented < AS_I32(limit)) {
+            if (vm.typed_regs.i32_regs[reg] < AS_I32(limit)) {
                 vm.ip += offset;
             }
+            DISPATCH_TYPED();
+        }
+
+        Value counter = vm_get_register_safe(reg);
+        Value limit = vm_get_register_safe(limit_reg);
+        if (!IS_I32(counter) || !IS_I32(limit)) {
+            VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be i32");
+        }
+
+        int32_t incremented = AS_I32(counter) + 1;
+        store_i32_register(reg, incremented);
+        if (incremented < AS_I32(limit)) {
+            vm.ip += offset;
         }
 
         DISPATCH_TYPED();

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -2898,34 +2898,66 @@ InterpretResult vm_run_dispatch(void) {
                 }
 
                 case OP_INC_CMP_JMP: {
+                    bool has_chunk = vm.chunk && vm.chunk->code;
+                    size_t opcode_offset =
+                        has_chunk ? (size_t)((vm.ip - vm.chunk->code) - 1) : 0;
                     uint8_t reg = READ_BYTE();
                     uint8_t limit_reg = READ_BYTE();
                     int16_t offset = READ_SHORT();
 
-                    const uint16_t typed_limit =
-                        (uint16_t)(sizeof(vm.typed_regs.i32_regs) /
-                                   sizeof(vm.typed_regs.i32_regs[0]));
-                    if (reg < typed_limit && limit_reg < typed_limit &&
+                    bool monotonic_hint = false;
+                    if (has_chunk && vm.chunk->monotonic_range_flags &&
+                        opcode_offset < (size_t)vm.chunk->count) {
+                        monotonic_hint =
+                            vm.chunk->monotonic_range_flags[opcode_offset] != 0;
+                    }
+
+                    if (monotonic_hint && vm_typed_reg_in_range(reg) &&
+                        vm_typed_reg_in_range(limit_reg) &&
                         vm.typed_regs.reg_types[reg] == REG_TYPE_I32 &&
                         vm.typed_regs.reg_types[limit_reg] == REG_TYPE_I32) {
-                        int32_t incremented = vm.typed_regs.i32_regs[reg] + 1;
-                        store_i32_register(reg, incremented);
-                        if (incremented < vm.typed_regs.i32_regs[limit_reg]) {
-                            vm.ip += offset;
+                        bool should_continue = false;
+                        if (vm_exec_monotonic_inc_cmp_i32(reg, limit_reg,
+                                                          &should_continue)) {
+                            if (should_continue) {
+                                vm.ip += offset;
+                            }
+                            break;
                         }
-                    } else {
-                        Value counter = vm_get_register_safe(reg);
+                    }
+
+                    if (vm_exec_inc_i32_checked(reg)) {
+                        if (vm_typed_reg_in_range(limit_reg) &&
+                            vm.typed_regs.reg_types[limit_reg] == REG_TYPE_I32) {
+                            if (vm.typed_regs.i32_regs[reg] < vm.typed_regs.i32_regs[limit_reg]) {
+                                vm.ip += offset;
+                            }
+                            break;
+                        }
+
                         Value limit = vm_get_register_safe(limit_reg);
-                        if (!IS_I32(counter) || !IS_I32(limit)) {
+                        if (!IS_I32(limit)) {
                             VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(),
                                             "Operands must be i32");
                         }
 
-                        int32_t incremented = AS_I32(counter) + 1;
-                        store_i32_register(reg, incremented);
-                        if (incremented < AS_I32(limit)) {
+                        if (vm.typed_regs.i32_regs[reg] < AS_I32(limit)) {
                             vm.ip += offset;
                         }
+                        break;
+                    }
+
+                    Value counter = vm_get_register_safe(reg);
+                    Value limit = vm_get_register_safe(limit_reg);
+                    if (!IS_I32(counter) || !IS_I32(limit)) {
+                        VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(),
+                                        "Operands must be i32");
+                    }
+
+                    int32_t incremented = AS_I32(counter) + 1;
+                    store_i32_register(reg, incremented);
+                    if (incremented < AS_I32(limit)) {
+                        vm.ip += offset;
                     }
                     break;
                 }

--- a/src/vm/runtime/vm_loop_fastpaths.c
+++ b/src/vm/runtime/vm_loop_fastpaths.c
@@ -1,6 +1,8 @@
 #include "vm/vm_loop_fastpaths.h"
 #include "vm/vm_comparison.h"
 
+#include <limits.h>
+
 bool vm_try_branch_bool_fast_hot(uint16_t reg, bool* out_value) {
     if (!out_value) {
         return false;
@@ -80,6 +82,49 @@ bool vm_exec_inc_i32_checked(uint16_t reg) {
     }
 
     store_i32_register(reg, next_value);
+    vm_trace_loop_event(LOOP_TRACE_TYPED_HIT);
+    return true;
+}
+
+bool vm_exec_monotonic_inc_cmp_i32(uint16_t counter_reg, uint16_t limit_reg,
+                                   bool* out_should_continue) {
+    if (vm.config.disable_inc_typed_fastpath) {
+        vm_trace_loop_event(LOOP_TRACE_TYPED_MISS);
+        return false;
+    }
+
+    if (!vm_typed_reg_in_range(counter_reg) || !vm_typed_reg_in_range(limit_reg)) {
+        vm_trace_loop_event(LOOP_TRACE_INC_TYPE_INSTABILITY);
+        vm_trace_loop_event(LOOP_TRACE_TYPED_MISS);
+        return false;
+    }
+
+    if (vm.typed_regs.reg_types[counter_reg] != REG_TYPE_I32 ||
+        vm.typed_regs.reg_types[limit_reg] != REG_TYPE_I32) {
+        if (vm.typed_regs.reg_types[counter_reg] != REG_TYPE_I32) {
+            vm.typed_regs.reg_types[counter_reg] = REG_TYPE_HEAP;
+            vm_trace_loop_event(LOOP_TRACE_INC_TYPE_INSTABILITY);
+        }
+        vm_trace_loop_event(LOOP_TRACE_TYPED_MISS);
+        return false;
+    }
+
+    int32_t current = vm.typed_regs.i32_regs[counter_reg];
+    if (current == INT32_MAX) {
+        vm.typed_regs.reg_types[counter_reg] = REG_TYPE_HEAP;
+        vm_trace_loop_event(LOOP_TRACE_INC_OVERFLOW_BAILOUT);
+        vm_trace_loop_event(LOOP_TRACE_TYPED_MISS);
+        return false;
+    }
+
+    int32_t next_value = current + 1;
+    store_i32_register(counter_reg, next_value);
+
+    int32_t limit_value = vm.typed_regs.i32_regs[limit_reg];
+    if (out_should_continue) {
+        *out_should_continue = next_value < limit_value;
+    }
+
     vm_trace_loop_event(LOOP_TRACE_TYPED_HIT);
     return true;
 }

--- a/tests/golden/loop_telemetry/loop_typed_fastpath_correctness.log
+++ b/tests/golden/loop_telemetry/loop_typed_fastpath_correctness.log
@@ -1,1 +1,1 @@
-[loop-trace] typed_hit=21 typed_miss=0 boxed_type_mismatch=0 boxed_overflow_guard=0 branch_fast_hits=21 branch_fast_misses=0 inc_overflow_bailouts=0 inc_type_instability=0 iter_alloc_saved=0 iter_fallbacks=0 licm_guard_fusions=0 licm_guard_demotions=0
+[loop-trace] typed_hit=28 typed_miss=0 boxed_type_mismatch=0 boxed_overflow_guard=0 branch_fast_hits=21 branch_fast_misses=0 inc_overflow_bailouts=0 inc_type_instability=0 iter_alloc_saved=0 iter_fallbacks=0 licm_guard_fusions=0 licm_guard_demotions=0


### PR DESCRIPTION
## Summary
- add BytecodeBuffer metadata to flag monotonic fused loops and propagate hints into chunk metadata
- annotate fused range loops and provide vm_exec_monotonic_inc_cmp_i32 for overflow-aware monotonic increments
- route fused loop dispatch handlers through the new helper and refresh the loop telemetry baseline