### PR TITLE
Add typed branch opcode for fused loop guards

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -553,6 +553,7 @@ typedef enum {
     OP_JUMP,
     OP_JUMP_IF_R,      // condition_reg, offset
     OP_JUMP_IF_NOT_R,  // condition_reg, offset
+    OP_JUMP_IF_NOT_I32_TYPED, // left_reg, right_reg, offset
     OP_LOOP,
     OP_GET_ITER_R,     // dst_iter, iterable_reg
     OP_ITER_NEXT_R,    // dst_value, iter_reg, has_value_reg

--- a/src/compiler/backend/codegen/codegen.c
+++ b/src/compiler/backend/codegen/codegen.c
@@ -4458,7 +4458,6 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
     bool fused_limit_temp_is_temp = false;
     int fused_limit_reg = -1;
     int fused_limit_temp_reg = -1;
-    int fused_condition_reg = -1;
 
     if (use_fused_inc) {
         fused_symbol = resolve_symbol(ctx->symbols, fused_index_name);
@@ -4511,25 +4510,12 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
             emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 24) & 0xFF));
         }
 
-        fused_condition_reg = mp_allocate_temp_register(ctx->allocator);
-        if (fused_condition_reg == -1) {
-            DEBUG_CODEGEN_PRINT("Error: Failed to allocate condition register for fused while");
-            ctx->has_compilation_errors = true;
-            if (fused_limit_temp_is_temp) {
-                mp_free_temp_register(ctx->allocator, fused_limit_temp_reg);
-            }
-            if (fused_limit_is_temp) {
-                mp_free_temp_register(ctx->allocator, fused_limit_reg);
-            }
-            return;
-        }
         int loop_start_fused = ctx->bytecode->count;
         ScopeFrame* loop_frame_fused = enter_loop_context(ctx, loop_start_fused);
         int loop_frame_index = loop_frame_fused ? loop_frame_fused->lexical_depth : -1;
         if (!loop_frame_fused) {
             DEBUG_CODEGEN_PRINT("Error: Failed to enter loop context");
             ctx->has_compilation_errors = true;
-            mp_free_temp_register(ctx->allocator, fused_condition_reg);
             if (fused_limit_temp_is_temp) {
                 mp_free_temp_register(ctx->allocator, fused_limit_temp_reg);
             }
@@ -4542,20 +4528,14 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
         DEBUG_CODEGEN_PRINT("While loop start at offset %d\n", loop_start_fused);
 
         set_location_from_node(ctx, while_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_LT_I32_TYPED);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_condition_reg);
+        emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_loop_reg);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)(fused_limit_temp_is_temp ? fused_limit_temp_reg : fused_limit_reg));
-
-        set_location_from_node(ctx, while_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_R);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_condition_reg);
-        int end_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_R);
+        int end_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
         if (end_patch < 0) {
             DEBUG_CODEGEN_PRINT("Error: Failed to allocate while-loop end placeholder\n");
             ctx->has_compilation_errors = true;
             leave_loop_context(ctx, loop_frame_fused, ctx->bytecode->count);
-            mp_free_temp_register(ctx->allocator, fused_condition_reg);
             if (fused_limit_temp_is_temp) {
                 mp_free_temp_register(ctx->allocator, fused_limit_temp_reg);
             }
@@ -4564,8 +4544,6 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
             }
             return;
         }
-        mp_free_temp_register(ctx->allocator, fused_condition_reg);
-
         if (fused_body_is_block && fused_block_count > 0) {
             for (int i = 0; i < fused_block_count - 1; i++) {
                 TypedASTNode* stmt = while_body->typed.block.statements[i];
@@ -4927,19 +4905,27 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
         typed_hint_limit_reg = limit_reg_used;
     }
 
+    int guard_patch = -1;
     set_location_from_node(ctx, for_stmt);
     if (can_fuse_inc_cmp) {
-        emit_byte_to_buffer(ctx->bytecode, OP_LT_I32_TYPED);
+        emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_var_reg);
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_reg_used);
+        guard_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+        if (guard_patch < 0) {
+            ctx->has_compilation_errors = true;
+            goto cleanup;
+        }
     } else {
         if (for_stmt->typed.forRange.inclusive) {
             emit_byte_to_buffer(ctx->bytecode, OP_LE_I32_TYPED);
         } else {
             emit_byte_to_buffer(ctx->bytecode, OP_LT_I32_TYPED);
         }
+        emit_byte_to_buffer(ctx->bytecode, condition_reg);
+        emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)end_reg);
     }
-    emit_byte_to_buffer(ctx->bytecode, condition_reg);
-    emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
-    emit_byte_to_buffer(ctx->bytecode, (uint8_t) (can_fuse_inc_cmp ? limit_reg_used : end_reg));
 
     if (!step_known_positive) {
         condition_neg_reg = mp_allocate_temp_register(ctx->allocator);
@@ -5002,13 +4988,18 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
         }
     }
 
-    set_location_from_node(ctx, for_stmt);
-    emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_R);
-    emit_byte_to_buffer(ctx->bytecode, condition_reg);
-    int end_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_R);
-    if (end_patch < 0) {
-        ctx->has_compilation_errors = true;
-        goto cleanup;
+    int end_patch = -1;
+    if (can_fuse_inc_cmp) {
+        end_patch = guard_patch;
+    } else {
+        set_location_from_node(ctx, for_stmt);
+        emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_R);
+        emit_byte_to_buffer(ctx->bytecode, condition_reg);
+        end_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_R);
+        if (end_patch < 0) {
+            ctx->has_compilation_errors = true;
+            goto cleanup;
+        }
     }
 
     compile_block_with_scope(ctx, for_stmt->typed.forRange.body, true);

--- a/src/compiler/backend/compiler.c
+++ b/src/compiler/backend/compiler.c
@@ -234,6 +234,8 @@ void emit_instruction_to_buffer(BytecodeBuffer* buffer, uint8_t opcode, uint8_t 
 
 static inline int determine_prefix_size(uint8_t opcode) {
     switch (opcode) {
+        case OP_JUMP_IF_NOT_I32_TYPED:
+            return 3;  // opcode + left_reg + right_reg
         case OP_JUMP_IF_NOT_R:
         case OP_JUMP_IF_R:
         case OP_TRY_BEGIN:
@@ -317,6 +319,7 @@ bool patch_jump(BytecodeBuffer* buffer, int patch_index, int target_offset) {
         case OP_JUMP_IF_NOT_R:
         case OP_JUMP_IF_R:
         case OP_TRY_BEGIN:
+        case OP_JUMP_IF_NOT_I32_TYPED:
         {
             relative = target_offset - next_ip;
             if (relative < 0 || relative > 0xFFFF) {

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -305,6 +305,7 @@ InterpretResult vm_run_dispatch(void) {
         vm_dispatch_table[OP_THROW] = &&LABEL_OP_THROW;
         vm_dispatch_table[OP_JUMP] = &&LABEL_OP_JUMP;
         vm_dispatch_table[OP_JUMP_IF_NOT_R] = &&LABEL_OP_JUMP_IF_NOT_R;
+        vm_dispatch_table[OP_JUMP_IF_NOT_I32_TYPED] = &&LABEL_OP_JUMP_IF_NOT_I32_TYPED;
         vm_dispatch_table[OP_LOOP] = &&LABEL_OP_LOOP;
         vm_dispatch_table[OP_GET_ITER_R] = &&LABEL_OP_GET_ITER_R;
         vm_dispatch_table[OP_ITER_NEXT_R] = &&LABEL_OP_ITER_NEXT_R;
@@ -356,7 +357,8 @@ InterpretResult vm_run_dispatch(void) {
         global_dispatch_initialized = true;
         
         // Check for NULL entries in critical opcodes only
-        int critical_opcodes[] = {39, 41, 92, 126, 171, -1}; // OP_EQ_R, OP_LT_I32_R, OP_JUMP_IF_NOT_R, OP_ADD_I32_TYPED, etc.
+        int critical_opcodes[] = {OP_EQ_R, OP_LT_I32_R, OP_JUMP_IF_NOT_R,
+                                  OP_JUMP_IF_NOT_I32_TYPED, OP_ADD_I32_TYPED, -1};
         for (int i = 0; critical_opcodes[i] != -1; i++) {
             int opcode = critical_opcodes[i];
             if (opcode < VM_DISPATCH_TABLE_SIZE) {
@@ -2425,6 +2427,16 @@ InterpretResult vm_run_dispatch(void) {
             uint8_t reg = READ_BYTE();
             uint16_t offset = READ_SHORT();
             if (!CF_JUMP_IF_NOT(reg, offset)) {
+                RETURN(INTERPRET_RUNTIME_ERROR);
+            }
+            DISPATCH();
+        }
+
+    LABEL_OP_JUMP_IF_NOT_I32_TYPED: {
+            uint8_t left = READ_BYTE();
+            uint8_t right = READ_BYTE();
+            uint16_t offset = READ_SHORT();
+            if (!CF_JUMP_IF_NOT_I32_TYPED(left, right, offset)) {
                 RETURN(INTERPRET_RUNTIME_ERROR);
             }
             DISPATCH();

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -2110,6 +2110,16 @@ InterpretResult vm_run_dispatch(void) {
                     break;
                 }
 
+                case OP_JUMP_IF_NOT_I32_TYPED: {
+                    uint8_t left = READ_BYTE();
+                    uint8_t right = READ_BYTE();
+                    uint16_t offset = READ_SHORT();
+                    if (!CF_JUMP_IF_NOT_I32_TYPED(left, right, offset)) {
+                        return INTERPRET_RUNTIME_ERROR;
+                    }
+                    break;
+                }
+
                 case OP_LOOP: {
                     uint16_t offset = READ_SHORT();
                     if (!CF_LOOP(offset)) {

--- a/src/vm/utils/debug.c
+++ b/src/vm/utils/debug.c
@@ -386,6 +386,14 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return offset + 4;
         }
 
+        case OP_JUMP_IF_NOT_I32_TYPED: {
+            uint8_t left = chunk->code[offset + 1];
+            uint8_t right = chunk->code[offset + 2];
+            uint16_t jump = (uint16_t)((chunk->code[offset + 3] << 8) | chunk->code[offset + 4]);
+            printf("%-16s R%d, R%d, +%d\n", "JUMP_IF_NOT_I32_TYPED", left, right, jump);
+            return offset + 5;
+        }
+
         case OP_LOOP: {
             uint16_t jump = (uint16_t)((chunk->code[offset + 1] << 8) | chunk->code[offset + 2]);
             printf("%-16s -%d\n", "LOOP", jump);

--- a/tests/golden/loop_telemetry/loop_typed_fastpath_correctness.log
+++ b/tests/golden/loop_telemetry/loop_typed_fastpath_correctness.log
@@ -1,1 +1,1 @@
-[loop-trace] typed_hit=21 typed_miss=0 boxed_type_mismatch=0 boxed_overflow_guard=0 branch_fast_hits=21 branch_fast_misses=0 inc_overflow_bailouts=0 inc_type_instability=0 iter_alloc_saved=0 iter_fallbacks=0 licm_guard_fusions=0 licm_guard_demotions=0
+[loop-trace] typed_hit=28 typed_miss=0 boxed_type_mismatch=0 boxed_overflow_guard=0 branch_fast_hits=21 branch_fast_misses=0 inc_overflow_bailouts=0 inc_type_instability=0 iter_alloc_saved=0 iter_fallbacks=0 licm_guard_fusions=0 licm_guard_demotions=0


### PR DESCRIPTION
## Summary
- add CF_JUMP_IF_NOT_I32_TYPED and expose the OP_JUMP_IF_NOT_I32_TYPED opcode
- wire the new branch opcode through both dispatchers, patching, and disassembly
- emit the fused typed branch in while/for lowering and refresh the loop telemetry baseline