### PR TITLE
Route redeclaration diagnostics through error reporter

### DIFF
--- a/include/compiler/error_reporter.h
+++ b/include/compiler/error_reporter.h
@@ -28,6 +28,11 @@ bool error_reporter_add(ErrorReporter* reporter,
                         const char* message,
                         const char* help,
                         const char* note);
+bool error_reporter_add_feature_error(ErrorReporter* reporter,
+                                      ErrorCode code,
+                                      SrcLocation location,
+                                      const char* format,
+                                      ...);
 bool error_reporter_add_formatted(ErrorReporter* reporter,
                                   ErrorCode code,
                                   ErrorSeverity severity,


### PR DESCRIPTION
## Summary
- add an error reporter helper that uses the feature error registry to populate diagnostics
- update codegen to enqueue variable redeclaration diagnostics through the helper while retaining the legacy fallback

## Testing
- make debug
- python3 tests/error_reporting/run_error_tests.py ./orus_debug

------
https://chatgpt.com/codex/tasks/task_e_68d30e5b08348325ae02b180cd67fcee