### PR TITLE
Report unexpected indentation with clear diagnostic

### DIFF
--- a/src/compiler/frontend/parser.c
+++ b/src/compiler/frontend/parser.c
@@ -1815,6 +1815,13 @@ static ASTNode* parseBlock(ParserContext* ctx) {
             nextToken(ctx);
             continue;
         }
+        if (t.type == TOKEN_INDENT) {
+            SrcLocation location = {NULL, t.line, t.column};
+            report_compile_error(E1008_INVALID_INDENTATION, location,
+                                 "Unexpected indentation. This line is indented but no block is currently open.");
+            ctx->block_depth--;
+            return NULL;
+        }
         if (t.type == TOKEN_SEMICOLON) {
             SrcLocation location = {NULL, t.line, t.column};
             report_compile_error(E1007_SEMICOLON_NOT_ALLOWED, location,
@@ -3981,6 +3988,12 @@ ASTNode* parseSourceWithContext(ParserContext* ctx, const char* source) {
         if (t.type == TOKEN_NEWLINE) {
             nextToken(ctx);
             continue;
+        }
+        if (t.type == TOKEN_INDENT) {
+            SrcLocation location = {NULL, t.line, t.column};
+            report_compile_error(E1008_INVALID_INDENTATION, location,
+                                 "Unexpected indentation. This line is indented but no block is currently open.");
+            return NULL;
         }
         if (t.type == TOKEN_COMMA) {
             // Skip commas between statements (for comma-separated variable declarations)

--- a/tests/error_reporting/cases.json
+++ b/tests/error_reporting/cases.json
@@ -176,6 +176,24 @@
     ]
   },
   {
+    "name": "unexpected_indent",
+    "source": "unexpected_indent.orus",
+    "description": "Indented statements without a surrounding block should clearly report the indentation error.",
+    "expected_exit": 65,
+    "expected_diagnostic_count": 1,
+    "expected_diagnostics": [
+      {
+        "title": "Indentation looks off",
+        "message_contains": "Unexpected indentation. This line is indented but no block is currently open."
+      }
+    ],
+    "expected": [
+      "-- SYNTAX ERROR: Indentation looks off",
+      "Unexpected indentation. This line is indented but no block is currently open.",
+      "Compilation failed for \"tests/error_reporting/unexpected_indent.orus\"."
+    ]
+  },
+  {
     "name": "closure_invalid_upvalue",
     "source": "closure_invalid_upvalue.orus",
     "description": "Mutating a captured immutable variable inside a closure is now caught at compile time.",

--- a/tests/error_reporting/unexpected_indent.orus
+++ b/tests/error_reporting/unexpected_indent.orus
@@ -1,0 +1,8 @@
+score = 10
+mut retries = 0
+threshold: f64 = 0.75
+x = 1, mut y = 2, label: string = "ready"
+
+ retries += 1
+
+print(retries)


### PR DESCRIPTION
## Summary
- detect stray indentation tokens at module scope and inside blocks
- emit a clear E1008 diagnostic explaining that no block is open for the indented line
- add an error reporting regression case covering unexpected indentation