### PR TITLE
Improve indentation error guidance

### DIFF
--- a/src/compiler/frontend/parser.c
+++ b/src/compiler/frontend/parser.c
@@ -1822,7 +1822,7 @@ static ASTNode* parseBlock(ParserContext* ctx) {
         if (t.type == TOKEN_INDENT) {
             SrcLocation location = {NULL, t.line, t.column};
             report_compile_error(E1008_INVALID_INDENTATION, location,
-                                 "Unexpected indentation. This line is indented but no block is currently open.");
+                                 "It looks like this line is indented, but there's no open block above it.");
             ctx->block_depth--;
             return NULL;
         }
@@ -3996,7 +3996,7 @@ ASTNode* parseSourceWithContext(ParserContext* ctx, const char* source) {
         if (t.type == TOKEN_INDENT) {
             SrcLocation location = {NULL, t.line, t.column};
             report_compile_error(E1008_INVALID_INDENTATION, location,
-                                 "Unexpected indentation. This line is indented but no block is currently open.");
+                                 "It looks like this line is indented, but there's no open block above it.");
             return NULL;
         }
         if (t.type == TOKEN_COMMA) {

--- a/src/errors/infrastructure/error_infrastructure.c
+++ b/src/errors/infrastructure/error_infrastructure.c
@@ -1032,6 +1032,8 @@ const char* get_error_help(ErrorCode code) {
             return "Add a closing ')' to match the opening parenthesis.";
         case E1007_SEMICOLON_NOT_ALLOWED:
             return "Remove the semicolon - Orus doesn't need them to end statements.";
+        case E1008_INVALID_INDENTATION:
+            return "If you meant to start a block, add a ':' on the previous line or remove this extra indentation.";
         case E1009_EXPRESSION_TOO_COMPLEX:
             return "Break this into smaller expressions using intermediate variables.";
         case E1010_UNDEFINED_VARIABLE:
@@ -1082,6 +1084,8 @@ const char* get_error_note(ErrorCode code) {
         // Syntax errors (E1xxx)
         case E1007_SEMICOLON_NOT_ALLOWED:
             return "Orus uses newlines instead of semicolons to separate statements.";
+        case E1008_INVALID_INDENTATION:
+            return "Blocks in Orus begin after lines ending with ':' and end when the indentation returns.";
         
         // Type errors (E2xxx) - handled by feature modules, return NULL to use feature notes
         case E2001_TYPE_MISMATCH:

--- a/tests/error_reporting/cases.json
+++ b/tests/error_reporting/cases.json
@@ -184,12 +184,16 @@
     "expected_diagnostics": [
       {
         "title": "Indentation looks off",
-        "message_contains": "Unexpected indentation. This line is indented but no block is currently open."
+        "message_contains": "It looks like this line is indented, but there's no open block above it.",
+        "help_contains": "If you meant to start a block",
+        "note_contains": "Blocks in Orus begin"
       }
     ],
     "expected": [
       "-- SYNTAX ERROR: Indentation looks off",
-      "Unexpected indentation. This line is indented but no block is currently open.",
+      "It looks like this line is indented, but there's no open block above it.",
+      "help: If you meant to start a block, add a ':' on the previous line or remove this extra indentation.",
+      "note: Blocks in Orus begin after lines ending with ':' and end when the indentation returns.",
       "Compilation failed for \"tests/error_reporting/unexpected_indent.orus\"."
     ]
   },


### PR DESCRIPTION
## Summary
- polish the unexpected indentation syntax error message to explain the situation in a friendly tone
- add tailored help and note guidance for indentation issues
- update the error reporting regression to expect the new help and note output