### PR TITLE
Fix string concatenation opcode selection

### DIFF
--- a/tests/strings/multi_concatenation.orus
+++ b/tests/strings/multi_concatenation.orus
@@ -1,0 +1,15 @@
+// Ensure chained string concatenations preserve all segments
+part1 = "a"
+part2 = " :: "
+part3 = "b"
+part4 = " :: "
+part5 = "c"
+
+combined = part1 + part2 + part3 + part4 + part5
+expected = "a :: b :: c"
+
+if combined != expected:
+    print("Unexpected result: " + combined)
+    trigger = 1 / 0
+
+print(combined)


### PR DESCRIPTION
## Summary
- map string-typed binary operations to the boxed register opcode so chained concatenations use the VM's string slow path
- add a regression test covering multi-part string concatenation to guard against future regressions

## Testing
- `./orus_debug tests/strings/multi_concatenation.orus`


------
https://chatgpt.com/codex/tasks/task_e_68d32a2024dc83259ff5cd7479b0a778