### PR TITLE
Report missing return types in function arrows

### DIFF
--- a/src/compiler/frontend/parser.c
+++ b/src/compiler/frontend/parser.c
@@ -3037,12 +3037,19 @@ static ASTNode* parseFunctionExpression(ParserContext* ctx, Token fnToken) {
 
     ASTNode* returnType = NULL;
     if (peekToken(ctx).type == TOKEN_ARROW) {
-        nextToken(ctx);
+        Token arrowTok = nextToken(ctx);
         Token typeTok = peekToken(ctx);
         if (typeTok.type == TOKEN_FN) {
             returnType = parseFunctionType(ctx);
             if (!returnType) return NULL;
         } else {
+            if (!token_can_start_type(typeTok.type)) {
+                SrcLocation location = {NULL, arrowTok.line, arrowTok.column};
+                report_compile_error(E1006_INVALID_SYNTAX, location,
+                                     "Expected return type after '->' in function expression, but found %s",
+                                     token_type_to_string(typeTok.type));
+                return NULL;
+            }
             returnType = parseTypeAnnotation(ctx);
             if (!returnType) return NULL;
         }
@@ -3155,12 +3162,20 @@ static ASTNode* parseFunctionDefinition(ParserContext* ctx, bool isPublic) {
     // Optional return type annotation
     ASTNode* returnType = NULL;
     if (peekToken(ctx).type == TOKEN_ARROW) {
-        nextToken(ctx); // consume '->'
+        Token arrowTok = nextToken(ctx); // consume '->'
         Token typeTok = peekToken(ctx);
         if (typeTok.type == TOKEN_FN) {
             returnType = parseFunctionType(ctx);
             if (!returnType) return NULL;
         } else {
+            if (!token_can_start_type(typeTok.type)) {
+                SrcLocation location = {NULL, arrowTok.line, arrowTok.column};
+                report_compile_error(E1006_INVALID_SYNTAX, location,
+                                     "Expected return type after '->' in function '%s', but found %s",
+                                     functionName,
+                                     token_type_to_string(typeTok.type));
+                return NULL;
+            }
             returnType = parseTypeAnnotation(ctx);
             if (!returnType) return NULL;
         }
@@ -3927,11 +3942,18 @@ static ASTNode* parseFunctionType(ParserContext* ctx) {
     // Parse return type
     ASTNode* returnType = NULL;
     if (peekToken(ctx).type == TOKEN_ARROW) {
-        nextToken(ctx); // consume '->'
+        Token arrowTok = nextToken(ctx); // consume '->'
         Token typeTok = peekToken(ctx);
         if (typeTok.type == TOKEN_FN) {
             returnType = parseFunctionType(ctx);
         } else {
+            if (!token_can_start_type(typeTok.type)) {
+                SrcLocation location = {NULL, arrowTok.line, arrowTok.column};
+                report_compile_error(E1006_INVALID_SYNTAX, location,
+                                     "Expected return type after '->' in function type, but found %s",
+                                     token_type_to_string(typeTok.type));
+                return NULL;
+            }
             returnType = parseTypeAnnotation(ctx);
             if (!returnType) return NULL;
         }

--- a/tests/error_reporting/cases.json
+++ b/tests/error_reporting/cases.json
@@ -176,6 +176,24 @@
     ]
   },
   {
+    "name": "missing_function_return_type",
+    "source": "missing_function_return_type.orus",
+    "description": "Functions that use '->' must provide an explicit return type before the block colon.",
+    "expected_exit": 65,
+    "expected_diagnostic_count": 1,
+    "expected_diagnostics": [
+      {
+        "title": "This syntax isn't quite right",
+        "message_contains": "Expected return type after '->' in function 'add'"
+      }
+    ],
+    "expected": [
+      "-- SYNTAX ERROR: This syntax isn't quite right",
+      "Expected return type after '->' in function 'add', but found COLON",
+      "Compilation failed for \"tests/error_reporting/missing_function_return_type.orus\"."
+    ]
+  },
+  {
     "name": "unexpected_indent",
     "source": "unexpected_indent.orus",
     "description": "Indented statements without a surrounding block should clearly report the indentation error.",

--- a/tests/error_reporting/missing_function_return_type.orus
+++ b/tests/error_reporting/missing_function_return_type.orus
@@ -1,0 +1,8 @@
+fn add(a: i32, b: i32) -> :
+    return a + b
+
+square = fn(value: i32) -> i32:
+    return value * value
+
+print(add(5, 7))
+print(square(6))


### PR DESCRIPTION
## Summary
- emit a syntax diagnostic when `->` in function expressions, definitions, or function types is not followed by a valid type token
- add an error reporting regression case that covers missing function return types