### PR TITLE
Add guidance for invalid syntax diagnostics

### DIFF
--- a/src/errors/infrastructure/error_infrastructure.c
+++ b/src/errors/infrastructure/error_infrastructure.c
@@ -1031,6 +1031,8 @@ const char* get_error_help(ErrorCode code) {
             return "Try adding a ':' at the end of this line.";
         case E1003_MISSING_PARENTHESIS:
             return "Add a closing ')' to match the opening parenthesis.";
+        case E1006_INVALID_SYNTAX:
+            return "Compare this syntax with a working example or check the docs to see what structure is expected here.";
         case E1007_SEMICOLON_NOT_ALLOWED:
             return "Remove the semicolon - Orus doesn't need them to end statements.";
         case E1008_INVALID_INDENTATION:
@@ -1087,6 +1089,8 @@ const char* get_error_note(ErrorCode code) {
         // Syntax errors (E1xxx)
         case E1007_SEMICOLON_NOT_ALLOWED:
             return "Orus uses newlines instead of semicolons to separate statements.";
+        case E1006_INVALID_SYNTAX:
+            return "Orus expected a different structure here. Re-read the surrounding code to find the mismatch.";
 
         case E1019_MISSING_PRINT_SEPARATOR:
             return "Commas help Orus understand where one print value ends and the next one begins.";

--- a/tests/error_reporting/cases.json
+++ b/tests/error_reporting/cases.json
@@ -190,6 +190,8 @@
     "expected": [
       "-- SYNTAX ERROR: This syntax isn't quite right",
       "Expected return type after '->' in function 'add', but found COLON",
+      "help: Compare this syntax with a working example or check the docs to see what structure is expected here.",
+      "note: Orus expected a different structure here. Re-read the surrounding code to find the mismatch.",
       "Compilation failed for \"tests/error_reporting/missing_function_return_type.orus\"."
     ]
   },


### PR DESCRIPTION
## Summary
- add contextual help and note strings for the generic E1006 invalid syntax diagnostic
- update the missing function return type error-reporting expectation to cover the new guidance text