### PR TITLE
Make array slice end index inclusive

### DIFF
--- a/docs/COMPLETE_ORUS_TUTORIAL.md
+++ b/docs/COMPLETE_ORUS_TUTORIAL.md
@@ -130,7 +130,8 @@ for item in values:
 - `len(array)` returns an `i32` length.
 - `push(array, value)` appends and returns the array.
 - `pop(array)` removes and returns the last element.
-- Slices use `array[start..end]` with an exclusive end index.
+- Slices use `array[start..end]` with an inclusive end index. Passing the array length (or omitting the bound) includes the
+  final element.
 
 ```orus
 mut numbers = []
@@ -139,7 +140,7 @@ push(numbers, 2)
 push(numbers, 3)
 print("len", len(numbers))
 print("pop", pop(numbers))
-print("slice", numbers[0..len(numbers)])
+print("slice", numbers[0..1])
 ```
 
 ## 8. Functions and Higher-Order Code

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -82,7 +82,8 @@ print("Pi ~= @.2f", pi)
 
 ### Arrays
 - Array literals use brackets: `values = [1, 2, 3]`. Trailing commas are allowed.
-- Indexing uses `array[index]`. Slices create new arrays with `array[start..end]` (`end` is exclusive).
+- Indexing uses `array[index]`. Slices create new arrays with `array[start..end]` and treat `end` as inclusive. Passing the
+  array length as the end bound (or omitting it) includes the last element.
 - Built-ins:
   - `len(array)` returns an `i32` length.
   - `push(array, value)` appends in place and returns the array.
@@ -96,7 +97,7 @@ push(numbers, 3)
 print(len(numbers))        // 3
 last = pop(numbers)
 print("popped", last)
-window = numbers[0..len(numbers)]
+window = numbers[0..1]          // includes indices 0 and 1
 ```
 
 ### Control Flow

--- a/docs/MISSING copy.md
+++ b/docs/MISSING copy.md
@@ -502,8 +502,8 @@ nums: [i32; 3] = [1, 2, 3]
 // Array fill expression (value; length)
 zeros = [0; 5]           // [i32; 5]
 
-// Slicing (end-exclusive)
-slice = nums[0..2]       // elements 0 and 1
+// Slicing (end-inclusive)
+slice = nums[0..2]       // elements 0, 1, and 2
 
 // Dynamic array (no length annotation)
 dynamic: [i32] = []

--- a/docs/MISSING.md
+++ b/docs/MISSING.md
@@ -345,8 +345,8 @@ nums: [i32; 3] = [1, 2, 3]
 // Array fill expression (value; length)
 zeros = [0; 5]           // [i32; 5]
 
-// Slicing (end-exclusive)
-slice = nums[0..2]       // elements 0 and 1
+// Slicing (end-inclusive)
+slice = nums[0..2]       // elements 0, 1, and 2
 
 // Dynamic array (no length annotation)
 dynamic: [i32] = []

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -1878,17 +1878,31 @@ InterpretResult vm_run_dispatch(void) {
                     }
 
                     ObjArray* array = AS_ARRAY(array_value);
-                    if (start_index < 0 || start_index > array->length) {
+                    int array_length = array->length;
+                    if (start_index < 0 || start_index > array_length) {
                         VM_ERROR_RETURN(ERROR_INDEX, CURRENT_LOCATION(), "Array slice start out of bounds");
                     }
-                    if (end_index < start_index) {
+                    if (end_index < 0) {
                         VM_ERROR_RETURN(ERROR_INDEX, CURRENT_LOCATION(), "Array slice end before start");
                     }
-                    if (end_index > array->length) {
+                    if (end_index > array_length) {
                         VM_ERROR_RETURN(ERROR_INDEX, CURRENT_LOCATION(), "Array slice end out of bounds");
                     }
 
-                    int slice_length = end_index - start_index;
+                    int slice_length = 0;
+                    if (start_index == array_length) {
+                        if (end_index != array_length) {
+                            VM_ERROR_RETURN(ERROR_INDEX, CURRENT_LOCATION(), "Array slice end before start");
+                        }
+                        slice_length = 0;
+                    } else {
+                        int normalized_end = end_index == array_length ? array_length - 1 : end_index;
+                        if (normalized_end < start_index) {
+                            VM_ERROR_RETURN(ERROR_INDEX, CURRENT_LOCATION(), "Array slice end before start");
+                        }
+                        slice_length = normalized_end - start_index + 1;
+                    }
+
                     ObjArray* result = allocateArray(slice_length);
                     if (!result) {
                         VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(), "Failed to allocate array slice");

--- a/tests/arrays/push_pop.orus
+++ b/tests/arrays/push_pop.orus
@@ -23,8 +23,9 @@ push(numbers, 42)
 print("final state:", numbers)
 
 // Validate slice shorthand on a mutated array.  Omitting the start bound
-// should default to zero, and omitting the end bound should default to the
-// array length, matching Python semantics.
+// should default to zero, and omitting the end bound should include the
+// final element.  Explicit end indices are inclusive.
+print("slice[0..1]:", numbers[0..1])
 print("slice[..len]:", numbers[..len(numbers)])
 print("slice[..]:", numbers[..])
 print("slice[1..]:", numbers[1..])

--- a/tests/arrays/slicing.orus
+++ b/tests/arrays/slicing.orus
@@ -1,13 +1,13 @@
 // Array slicing smoke test validating `[start..end]` syntax.
-// Ensures slices respect end-exclusive semantics and preserve element order.
+// Ensures slices treat the end index as inclusive and preserve element order.
 
 print("-- array slicing --")
 values = [5, 6, 7, 8, 9]
 
-head = values[0..2]
+head = values[0..1]
 print("head:", head)
 
-mid = values[1..4]
+mid = values[1..3]
 print("mid:", mid)
 
 full = values[0..len(values)]
@@ -16,7 +16,7 @@ print("full:", full)
 upto_len = values[..len(values)]
 print("upto len:", upto_len)
 
-prefix = values[..3]
+prefix = values[..2]
 print("prefix:", prefix)
 
 suffix = values[2..]
@@ -25,5 +25,8 @@ print("suffix:", suffix)
 clone = values[..]
 print("clone:", clone)
 
-empty = values[3..3]
+single = values[3..3]
+print("single:", single)
+
+empty = values[len(values)..len(values)]
 print("empty:", empty)


### PR DESCRIPTION
## Summary
- treat array slice end indices as inclusive in both VM dispatch modes so slice expressions return the final element
- update array slicing smoke tests to cover inclusive bounds and empty-slice sentinels
- refresh array documentation examples to describe the inclusive semantics