### PR TITLE
Enable built-in Result enum constructors

### DIFF
--- a/tests/comprehensive/result_builtin_runtime.orus
+++ b/tests/comprehensive/result_builtin_runtime.orus
@@ -1,0 +1,16 @@
+success = Result.Ok(42)
+failure = Result.Err("boom")
+
+match success:
+    Result.Ok(value) ->
+        print("ok", value)
+    Result.Err(reason) ->
+        print("error", reason)
+
+match failure:
+    Result.Ok(value) ->
+        print("unexpected", value)
+    Result.Err(reason) ->
+        print("handled", reason)
+
+print("built-in result runtime complete")


### PR DESCRIPTION
## Summary
- register the standard `Result` enum with `Ok`/`Err` variants when initializing the type environment
- ensure the interpreter can construct and match `Result` values without an explicit enum declaration
- add a regression test that exercises the built-in `Result` constructors and pattern matching at runtime