### PR TITLE
Adjust array output formatting

### DIFF
--- a/src/vm/runtime/vm.c
+++ b/src/vm/runtime/vm.c
@@ -90,12 +90,10 @@ void printValue(Value value) {
             break;
         case VAL_ARRAY: {
             ObjArray* array = AS_ARRAY(value);
-            printf("[");
             for (int i = 0; i < array->length; i++) {
                 if (i > 0) printf(", ");
                 printValue(array->elements[i]);
             }
-            printf("]");
             break;
         }
         case VAL_ENUM: {


### PR DESCRIPTION
## Summary
- stop wrapping printed array values in brackets so list-like outputs render as comma-separated sequences