### PR TITLE
Add tagged union helpers and Result builtins

### DIFF
--- a/include/vm/vm_tagged_union.h
+++ b/include/vm/vm_tagged_union.h
@@ -1,0 +1,19 @@
+#ifndef ORUS_VM_TAGGED_UNION_H
+#define ORUS_VM_TAGGED_UNION_H
+
+#include "vm/vm.h"
+#include <stdbool.h>
+
+typedef struct {
+    const char* type_name;
+    const char* variant_name;
+    int variant_index;
+    const Value* payload;
+    int payload_count;
+} TaggedUnionSpec;
+
+bool vm_make_tagged_union(const TaggedUnionSpec* spec, Value* out_value);
+bool vm_result_ok(Value inner, Value* out_value);
+bool vm_result_err(Value error_value, Value* out_value);
+
+#endif // ORUS_VM_TAGGED_UNION_H

--- a/makefile
+++ b/makefile
@@ -117,7 +117,7 @@ COMPILER_BACKEND_SRCS = $(SRCDIR)/compiler/backend/typed_ast_visualizer.c $(SRCD
 
 # Combined simplified compiler sources  
 COMPILER_SRCS = $(COMPILER_FRONTEND_SRCS) $(COMPILER_BACKEND_SRCS) $(SRCDIR)/compiler/typed_ast.c $(SRCDIR)/debug/debug_config.c
-VM_SRCS = $(SRCDIR)/vm/core/vm_core.c $(SRCDIR)/vm/runtime/vm.c $(SRCDIR)/vm/runtime/vm_loop_fastpaths.c $(SRCDIR)/vm/core/vm_memory.c $(SRCDIR)/vm/utils/debug.c $(SRCDIR)/vm/runtime/builtins.c $(SRCDIR)/vm/operations/vm_arithmetic.c $(SRCDIR)/vm/operations/vm_control_flow.c $(SRCDIR)/vm/operations/vm_typed_ops.c $(SRCDIR)/vm/operations/vm_string_ops.c $(SRCDIR)/vm/operations/vm_comparison.c $(SRCDIR)/vm/dispatch/vm_dispatch_switch.c $(SRCDIR)/vm/dispatch/vm_dispatch_goto.c $(SRCDIR)/vm/core/vm_validation.c $(SRCDIR)/vm/register_file.c $(SRCDIR)/vm/spill_manager.c $(SRCDIR)/vm/module_manager.c $(SRCDIR)/vm/register_cache.c $(SRCDIR)/vm/profiling/vm_profiling.c $(SRCDIR)/vm/vm_config.c $(SRCDIR)/type/type_representation.c $(SRCDIR)/type/type_inference.c $(SRCDIR)/errors/infrastructure/error_infrastructure.c $(SRCDIR)/errors/core/error_base.c $(SRCDIR)/errors/features/type_errors.c $(SRCDIR)/errors/features/variable_errors.c $(SRCDIR)/errors/features/control_flow_errors.c $(SRCDIR)/config/config.c $(SRCDIR)/internal/logging.c
+VM_SRCS = $(SRCDIR)/vm/core/vm_core.c $(SRCDIR)/vm/core/vm_tagged_union.c $(SRCDIR)/vm/runtime/vm.c $(SRCDIR)/vm/runtime/vm_loop_fastpaths.c $(SRCDIR)/vm/core/vm_memory.c $(SRCDIR)/vm/utils/debug.c $(SRCDIR)/vm/runtime/builtins.c $(SRCDIR)/vm/operations/vm_arithmetic.c $(SRCDIR)/vm/operations/vm_control_flow.c $(SRCDIR)/vm/operations/vm_typed_ops.c $(SRCDIR)/vm/operations/vm_string_ops.c $(SRCDIR)/vm/operations/vm_comparison.c $(SRCDIR)/vm/dispatch/vm_dispatch_switch.c $(SRCDIR)/vm/dispatch/vm_dispatch_goto.c $(SRCDIR)/vm/core/vm_validation.c $(SRCDIR)/vm/register_file.c $(SRCDIR)/vm/spill_manager.c $(SRCDIR)/vm/module_manager.c $(SRCDIR)/vm/register_cache.c $(SRCDIR)/vm/profiling/vm_profiling.c $(SRCDIR)/vm/vm_config.c $(SRCDIR)/type/type_representation.c $(SRCDIR)/type/type_inference.c $(SRCDIR)/errors/infrastructure/error_infrastructure.c $(SRCDIR)/errors/core/error_base.c $(SRCDIR)/errors/features/type_errors.c $(SRCDIR)/errors/features/variable_errors.c $(SRCDIR)/errors/features/control_flow_errors.c $(SRCDIR)/config/config.c $(SRCDIR)/internal/logging.c
 REPL_SRC = $(SRCDIR)/repl.c
 MAIN_SRC = $(SRCDIR)/main.c
 
@@ -145,8 +145,9 @@ SOURCE_MAP_TEST_BIN = $(BUILDDIR)/tests/test_source_mapping
 SCOPE_TRACKING_TEST_BIN = $(BUILDDIR)/tests/test_scope_tracking
 PEEPHOLE_TEST_BIN = $(BUILDDIR)/tests/test_constant_propagation
 LICM_METADATA_TEST_BIN = $(BUILDDIR)/tests/test_licm_typed_metadata
+TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
 
-.PHONY: all clean test unit-test test-control-flow test-loop-telemetry benchmark help debug release profiling analyze install bytecode-jump-tests source-map-tests scope-tracking-tests peephole-tests cli-smoke-tests licm-metadata-tests test-optimizer
+.PHONY: all clean test unit-test test-control-flow test-loop-telemetry benchmark help debug release profiling analyze install bytecode-jump-tests source-map-tests scope-tracking-tests peephole-tests cli-smoke-tests licm-metadata-tests tagged-union-tests test-optimizer
 
 all: build-info $(ORUS)
 
@@ -253,6 +254,9 @@ test: $(ORUS)
 	@echo "\033[36m=== Peephole Constant Propagation Tests ===\033[0m"
 	@$(MAKE) peephole-tests
 	@echo ""
+	@echo "\033[36m=== Tagged Union Tests ===\033[0m"
+	@$(MAKE) tagged-union-tests
+	@echo ""
 	@echo "\033[36m=== CLI Smoke Tests ===\033[0m"
 	@python3 tests/comprehensive/run_cli_smoke_tests.py ./$(ORUS)
 
@@ -306,6 +310,15 @@ $(LICM_METADATA_TEST_BIN): tests/unit/test_licm_typed_metadata.c $(COMPILER_OBJS
 licm-metadata-tests: $(LICM_METADATA_TEST_BIN)
 	@echo "Running LICM typed metadata tests..."
 	@./$(LICM_METADATA_TEST_BIN)
+
+$(TAGGED_UNION_TEST_BIN): tests/unit/test_vm_tagged_union.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling tagged union tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+tagged-union-tests: $(TAGGED_UNION_TEST_BIN)
+	@echo "Running tagged union tests..."
+	@./$(TAGGED_UNION_TEST_BIN)
 
 cli-smoke-tests:
 	@python3 tests/comprehensive/run_cli_smoke_tests.py ./$(ORUS)

--- a/src/vm/core/vm_tagged_union.c
+++ b/src/vm/core/vm_tagged_union.c
@@ -1,0 +1,89 @@
+#include "vm_internal.h"
+#include "vm/vm_tagged_union.h"
+#include "runtime/memory.h"
+#include "vm/vm_string_ops.h"
+
+#include <string.h>
+
+static bool copy_payload_to_array(const TaggedUnionSpec* spec, ObjArray** out_array) {
+    if (!out_array) {
+        return false;
+    }
+
+    *out_array = NULL;
+
+    if (!spec || spec->payload_count <= 0) {
+        return true;
+    }
+
+    if (!spec->payload) {
+        return false;
+    }
+
+    ObjArray* array = allocateArray(spec->payload_count);
+    if (!array || !array->elements) {
+        return false;
+    }
+
+    for (int i = 0; i < spec->payload_count; i++) {
+        array->elements[i] = spec->payload[i];
+    }
+    array->length = spec->payload_count;
+
+    *out_array = array;
+    return true;
+}
+
+bool vm_make_tagged_union(const TaggedUnionSpec* spec, Value* out_value) {
+    if (!spec || !out_value || !spec->type_name) {
+        return false;
+    }
+
+    ObjString* type_name = intern_string(spec->type_name, (int)strlen(spec->type_name));
+    if (!type_name) {
+        return false;
+    }
+
+    ObjString* variant_name = NULL;
+    if (spec->variant_name && spec->variant_name[0] != '\0') {
+        variant_name = intern_string(spec->variant_name, (int)strlen(spec->variant_name));
+        if (!variant_name) {
+            return false;
+        }
+    }
+
+    ObjArray* payload = NULL;
+    if (!copy_payload_to_array(spec, &payload)) {
+        return false;
+    }
+
+    ObjEnumInstance* instance = allocateEnumInstance(type_name, variant_name, spec->variant_index, payload);
+    if (!instance) {
+        return false;
+    }
+
+    *out_value = ENUM_VAL(instance);
+    return true;
+}
+
+bool vm_result_ok(Value inner, Value* out_value) {
+    TaggedUnionSpec spec = {
+        .type_name = "Result",
+        .variant_name = "Ok",
+        .variant_index = 0,
+        .payload = &inner,
+        .payload_count = 1,
+    };
+    return vm_make_tagged_union(&spec, out_value);
+}
+
+bool vm_result_err(Value error_value, Value* out_value) {
+    TaggedUnionSpec spec = {
+        .type_name = "Result",
+        .variant_name = "Err",
+        .variant_index = 1,
+        .payload = &error_value,
+        .payload_count = 1,
+    };
+    return vm_make_tagged_union(&spec, out_value);
+}

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -4,6 +4,7 @@
 #include "runtime/memory.h"
 #include "vm/vm_constants.h"
 #include "vm/vm_string_ops.h"
+#include "vm/vm_tagged_union.h"
 #include "vm/vm_arithmetic.h"
 #include "vm/vm_control_flow.h"
 #include "vm/vm_comparison.h"
@@ -2141,25 +2142,33 @@ InterpretResult vm_run_dispatch(void) {
             variantName = AS_STRING(variantConst);
         }
 
-        ObjArray* payload = NULL;
+        Value payload_values[UINT8_MAX];
+        const Value* payload_ptr = NULL;
         if (payloadCount > 0) {
-            payload = allocateArray(payloadCount);
-            if (!payload) {
-                VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(), "Failed to allocate enum payload");
+            if ((int)payloadStart + payloadCount > REGISTER_COUNT) {
+                VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(),
+                                "Enum constructor payload exceeds register bounds");
             }
             for (uint8_t i = 0; i < payloadCount; i++) {
-                arrayEnsureCapacity(payload, i + 1);
-                payload->elements[i] = vm_get_register_safe(payloadStart + i);
+                payload_values[i] = vm_get_register_safe(payloadStart + i);
             }
-            payload->length = payloadCount;
+            payload_ptr = payload_values;
         }
 
-        ObjEnumInstance* instance = allocateEnumInstance(typeName, variantName, variantIndex, payload);
-        if (!instance) {
+        TaggedUnionSpec spec = {
+            .type_name = typeName->chars,
+            .variant_name = variantName ? variantName->chars : NULL,
+            .variant_index = variantIndex,
+            .payload = payload_ptr,
+            .payload_count = payloadCount,
+        };
+
+        Value enum_value;
+        if (!vm_make_tagged_union(&spec, &enum_value)) {
             VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(), "Failed to allocate enum instance");
         }
 
-        vm_set_register_safe(dst, ENUM_VAL(instance));
+        vm_set_register_safe(dst, enum_value);
         DISPATCH();
     }
 

--- a/tests/comprehensive/result_builtins_cli.orus
+++ b/tests/comprehensive/result_builtins_cli.orus
@@ -1,0 +1,23 @@
+fn fail():
+    trigger = 1 / 0
+
+success = Result.Ok(99)
+failure = Result.Err("io error")
+
+match success:
+    Result.Ok(value) ->
+        if value != 99:
+            fail()
+    Result.Err(reason) ->
+        print("unexpected err", reason)
+        fail()
+
+match failure:
+    Result.Ok(value) ->
+        print("unexpected ok", value)
+        fail()
+    Result.Err(reason) ->
+        if reason != "io error":
+            fail()
+
+print("result builtins done")

--- a/tests/comprehensive/run_cli_smoke_tests.py
+++ b/tests/comprehensive/run_cli_smoke_tests.py
@@ -77,6 +77,11 @@ def load_tests(repo_root: Path) -> List[Tuple[Path, bool, Optional[str]]]:
         ),
         (repo_root / "tests" / "error_reporting" / "undefined_variable.orus", False, None),
         (
+            repo_root / "tests" / "comprehensive" / "result_builtins_cli.orus",
+            True,
+            "result builtins done\n",
+        ),
+        (
             repo_root / "tests" / "strings" / "string_equality_control_flow.orus",
             True,
             "ready\n",

--- a/tests/unit/test_vm_tagged_union.c
+++ b/tests/unit/test_vm_tagged_union.c
@@ -1,0 +1,182 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "vm/vm.h"
+#include "vm/vm_string_ops.h"
+#include "vm/vm_tagged_union.h"
+
+#define ASSERT_TRUE(cond, message)                                                         \
+    do {                                                                                   \
+        if (!(cond)) {                                                                     \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", message, __FILE__, __LINE__); \
+            return false;                                                                  \
+        }                                                                                  \
+    } while (0)
+
+static bool test_vm_result_ok_builds_enum(void) {
+    initVM();
+
+    Value inner = I32_VAL(123);
+    Value out = BOOL_VAL(false);
+
+    bool ok = vm_result_ok(inner, &out);
+    ASSERT_TRUE(ok, "Result.Ok should succeed");
+    ASSERT_TRUE(IS_ENUM(out), "Result.Ok should produce enum value");
+
+    ObjEnumInstance* instance = AS_ENUM(out);
+    ASSERT_TRUE(instance != NULL, "Result.Ok instance should be non-null");
+    ASSERT_TRUE(instance->typeName != NULL, "Result.Ok should set type name");
+    ASSERT_TRUE(strcmp(instance->typeName->chars, "Result") == 0,
+                "Result.Ok should intern the 'Result' type name");
+    ASSERT_TRUE(instance->variantName != NULL, "Result.Ok should set variant name");
+    ASSERT_TRUE(strcmp(instance->variantName->chars, "Ok") == 0,
+                "Result.Ok should intern the 'Ok' variant name");
+    ASSERT_TRUE(instance->variantIndex == 0, "Result.Ok should use variant index 0");
+    ASSERT_TRUE(instance->payload != NULL, "Result.Ok should allocate payload array");
+    ASSERT_TRUE(instance->payload->length == 1, "Result.Ok payload length should be 1");
+
+    Value stored = instance->payload->elements[0];
+    ASSERT_TRUE(IS_I32(stored), "Result.Ok payload should preserve value type");
+    ASSERT_TRUE(AS_I32(stored) == 123, "Result.Ok payload should preserve value contents");
+
+    freeVM();
+    return true;
+}
+
+static bool test_vm_result_err_builds_enum(void) {
+    initVM();
+
+    ObjString* message = intern_string("boom", 4);
+    ASSERT_TRUE(message != NULL, "String interning should succeed");
+    Value error = STRING_VAL(message);
+    Value out = BOOL_VAL(false);
+
+    bool ok = vm_result_err(error, &out);
+    ASSERT_TRUE(ok, "Result.Err should succeed");
+    ASSERT_TRUE(IS_ENUM(out), "Result.Err should produce enum value");
+
+    ObjEnumInstance* instance = AS_ENUM(out);
+    ASSERT_TRUE(instance != NULL, "Result.Err instance should be non-null");
+    ASSERT_TRUE(instance->typeName != NULL, "Result.Err should set type name");
+    ASSERT_TRUE(strcmp(instance->typeName->chars, "Result") == 0,
+                "Result.Err should intern the 'Result' type name");
+    ASSERT_TRUE(instance->variantName != NULL, "Result.Err should set variant name");
+    ASSERT_TRUE(strcmp(instance->variantName->chars, "Err") == 0,
+                "Result.Err should intern the 'Err' variant name");
+    ASSERT_TRUE(instance->variantIndex == 1, "Result.Err should use variant index 1");
+    ASSERT_TRUE(instance->payload != NULL, "Result.Err should allocate payload array");
+    ASSERT_TRUE(instance->payload->length == 1, "Result.Err payload length should be 1");
+
+    Value stored = instance->payload->elements[0];
+    ASSERT_TRUE(IS_STRING(stored), "Result.Err payload should preserve error type");
+    ASSERT_TRUE(AS_STRING(stored) == message, "Result.Err payload should reference provided error");
+
+    freeVM();
+    return true;
+}
+
+static bool test_vm_make_tagged_union_allows_empty_payload(void) {
+    initVM();
+
+    TaggedUnionSpec spec = {
+        .type_name = "Ping",
+        .variant_name = NULL,
+        .variant_index = 7,
+        .payload = NULL,
+        .payload_count = 0,
+    };
+
+    Value out = BOOL_VAL(true);
+    bool ok = vm_make_tagged_union(&spec, &out);
+    ASSERT_TRUE(ok, "Tagged union creation without payload should succeed");
+    ASSERT_TRUE(IS_ENUM(out), "Tagged union without payload should be enum value");
+
+    ObjEnumInstance* instance = AS_ENUM(out);
+    ASSERT_TRUE(instance != NULL, "Tagged union instance should be non-null");
+    ASSERT_TRUE(instance->typeName != NULL, "Tagged union should intern type name");
+    ASSERT_TRUE(strcmp(instance->typeName->chars, "Ping") == 0,
+                "Tagged union should preserve provided type name");
+    ASSERT_TRUE(instance->variantName == NULL, "Tagged union should allow missing variant name");
+    ASSERT_TRUE(instance->variantIndex == 7, "Tagged union should preserve variant index");
+    ASSERT_TRUE(instance->payload == NULL, "Tagged union without payload should not allocate array");
+
+    freeVM();
+    return true;
+}
+
+static bool test_vm_make_tagged_union_requires_payload_pointer(void) {
+    initVM();
+
+    TaggedUnionSpec spec = {
+        .type_name = "Result",
+        .variant_name = "Ok",
+        .variant_index = 0,
+        .payload = NULL,
+        .payload_count = 1,
+    };
+
+    Value sentinel = BOOL_VAL(true);
+    bool ok = vm_make_tagged_union(&spec, &sentinel);
+    ASSERT_TRUE(!ok, "Tagged union should fail when payload pointer is missing");
+    ASSERT_TRUE(IS_BOOL(sentinel) && AS_BOOL(sentinel),
+                "Tagged union failure should leave output value untouched");
+
+    freeVM();
+    return true;
+}
+
+static bool test_vm_make_tagged_union_requires_type_name(void) {
+    initVM();
+
+    TaggedUnionSpec spec = {
+        .type_name = NULL,
+        .variant_name = "Nothing",
+        .variant_index = 3,
+        .payload = NULL,
+        .payload_count = 0,
+    };
+
+    Value sentinel = BOOL_VAL(false);
+    bool ok = vm_make_tagged_union(&spec, &sentinel);
+    ASSERT_TRUE(!ok, "Tagged union should fail without a type name");
+    ASSERT_TRUE(IS_BOOL(sentinel) && !AS_BOOL(sentinel),
+                "Tagged union failure should keep sentinel value");
+
+    freeVM();
+    return true;
+}
+
+int main(void) {
+    bool (*tests[])(void) = {
+        test_vm_result_ok_builds_enum,
+        test_vm_result_err_builds_enum,
+        test_vm_make_tagged_union_allows_empty_payload,
+        test_vm_make_tagged_union_requires_payload_pointer,
+        test_vm_make_tagged_union_requires_type_name,
+    };
+
+    const char* names[] = {
+        "Result.Ok wraps payload",
+        "Result.Err wraps payload",
+        "Tagged union supports empty payload",
+        "Tagged union validates payload pointer",
+        "Tagged union validates type name",
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; i++) {
+        if (tests[i]()) {
+            printf("[PASS] %s\n", names[i]);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", names[i]);
+            return 1;
+        }
+    }
+
+    printf("%d/%d tagged union tests passed\n", passed, total);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a core tagged union helper that allocates enum instances and exposes Result.Ok/Err wrappers
- refactor enum construction dispatch code to route through the helper with register bounds checks
- wire the new helper into the build so it is compiled with the VM
- add targeted unit coverage for the tagged-union helpers and hook it into the `make test` umbrella target
- add a CLI smoke test program that exercises the Result.Ok/Err builtins end-to-end