### PR TITLE
Fix array index inference for unconstrained parameters

### DIFF
--- a/src/type/type_inference.c
+++ b/src/type/type_inference.c
@@ -1201,6 +1201,28 @@ Type* algorithm_w(TypeEnv* env, ASTNode* node) {
             array_type = prune(array_type);
             index_type = prune(index_type);
 
+            if (array_type && array_type->kind == TYPE_VAR) {
+                Type* element_var = make_var_type(env);
+                if (!element_var) {
+                    set_type_error();
+                    return NULL;
+                }
+
+                Type* inferred_array = createArrayType(element_var);
+                if (!inferred_array) {
+                    set_type_error();
+                    return NULL;
+                }
+
+                if (!unify(array_type, inferred_array)) {
+                    report_type_mismatch(node->indexAccess.array->location, "array",
+                                         getTypeName(array_type->kind));
+                    set_type_error();
+                    return NULL;
+                }
+                array_type = prune(array_type);
+            }
+
             if (index_type && index_type->kind == TYPE_VAR) {
                 Type* assumed_index = getPrimitiveType(TYPE_I32);
                 if (assumed_index) {

--- a/tests/arrays/index_inference.orus
+++ b/tests/arrays/index_inference.orus
@@ -1,0 +1,8 @@
+// Regression test: ensure array indexing infers the array type even without
+// explicit annotations or external calls. Previously this would fail during
+// type inference because the parameter `values` started as an unconstrained
+// type variable and indexing required an `array` type.
+fn stabilize(values):
+    mut idx = 0
+    current = values[idx]
+    values[idx] = current


### PR DESCRIPTION
## Summary
- teach the type inference pass to treat unconstrained array operands as arrays by unifying them with a fresh element type when an index access occurs
- add a regression test that indexes into an array parameter without any external annotations to ensure the scenario compiles cleanly