### PR TITLE
Fix array literal register allocation and typed register sync

### DIFF
--- a/include/compiler/register_allocator.h
+++ b/include/compiler/register_allocator.h
@@ -51,6 +51,7 @@ bool mp_reserve_global_register(MultiPassRegisterAllocator* allocator, int reg);
 
 void mp_reset_frame_registers(MultiPassRegisterAllocator* allocator);
 int mp_allocate_temp_register(MultiPassRegisterAllocator* allocator);
+int mp_allocate_consecutive_temp_registers(MultiPassRegisterAllocator* allocator, int count);
 int mp_allocate_module_register(MultiPassRegisterAllocator* allocator);
 
 // Scope-aware register allocation (NEW)


### PR DESCRIPTION
## Summary
- ensure typed registers are reset when storing heap values and keep boxed register values in sync for hot i32 stores
- add a register allocator helper for consecutive temp allocations and use it when compiling array literals so element registers are contiguous