### PR TITLE
Fix binary op codegen when type inference fails

### DIFF
--- a/tests/arrays/index_assignment_indirect.orus
+++ b/tests/arrays/index_assignment_indirect.orus
@@ -1,0 +1,19 @@
+// Indirect indexes can drive assignments and subsequent lookups without corrupting offsets.
+//
+// Ensures that mutating through an index derived from array contents preserves later reads.
+print("-- indirect index assignment --")
+
+mut digits = [0, 1, 2, 3, 4, 5]
+print("start:", digits[0], digits[1], digits[2], digits[3], digits[4], digits[5])
+
+mut target = digits[4] - 1  // 4 - 1 => 3
+print("target index:", target)
+
+digits[target] = 99
+print("after write:", digits[0], digits[1], digits[2], digits[3], digits[4], digits[5])
+
+target = digits[target] - 96  // 99 - 96 => 3
+print("recomputed target:", target)
+
+value = digits[target]
+print("final value:", value)

--- a/tests/arrays/index_chain.orus
+++ b/tests/arrays/index_chain.orus
@@ -1,0 +1,19 @@
+// Chained indexing should allow array elements to provide indexes for other lookups.
+//
+// Covers: value-from-array-as-index, arithmetic-derived indexes, and indirect lookups.
+print("-- chained array indexing --")
+
+numbers = [3, 1, 4, 1, 5]
+print("digits:", numbers[0], numbers[1], numbers[2], numbers[3], numbers[4])
+
+index_from_first = numbers[0]
+value_from_index = numbers[index_from_first]
+print("first chain:", index_from_first, value_from_index)
+
+second_index = numbers[2] - numbers[3]  // 4 - 1 => 3
+second_value = numbers[second_index]
+print("second chain:", second_index, second_value)
+
+third_index = numbers[second_value] - 1  // numbers[1] - 1 => 0
+print("third index:", third_index)
+print("third chain value:", numbers[third_index])


### PR DESCRIPTION
## Summary
- add fallback helpers to derive numeric type kinds when the typed AST is missing resolution
- allow compile_binary_op to use these fallbacks instead of aborting so operations still emit bytecode
- add regression coverage for chained and indirect array indexing so interpreter index math stays correct