### PR TITLE
Flatten Bellman-Ford phase1 edges

### DIFF
--- a/docs/ALGORITHM_STRESS_TEST_ROADMAP.md
+++ b/docs/ALGORITHM_STRESS_TEST_ROADMAP.md
@@ -68,3 +68,41 @@ three-argument call. The compiler now reserves contiguous temporary blocks for
 all call arguments, ensuring multi-argument helpers like `assert_sorted` keep
 their inputs intact during stress runs.
 
+
+## Phase 2 Kickoff – Graph Traversal & Shortest Paths
+
+The Phase 2 fixtures now live alongside the Phase 1 sort suite inside
+`tests/algorithms/phase1/` so that the harness can reuse the existing
+telemetry plumbing while we continue expanding coverage. The new graph
+programs focus on stressing recursion depth, queue pressure, and the
+compiler's ability to juggle dense numeric updates.
+
+- `depth_first_search.orus` introduces a recursive walker that counts
+  recursion depth, edge traversals, and order construction across
+  multi-component graphs. The tests exercise both a cyclic component and
+  a tree-shaped graph to drive the depth counter toward double digits.
+- `breadth_first_search.orus` mirrors those fixtures with a queue-backed
+  traversal that records enqueue/dequeue operations, edge checks, and the
+  high-water mark for queue occupancy. A layered graph fixture ensures we
+  observe steady growth in breadth levels.
+- `dijkstra.orus` uses an array-scanned priority selection so the VM's
+  register allocator sees repeated minimum searches and relaxation
+  updates. The script tracks how many nodes were settled and how many
+  times distances improved while covering connected and disconnected
+  graphs.
+- `bellman_ford.orus` adds negative edge handling with an explicit edge
+  list. The implementation logs total relaxation attempts and exposes the
+  early-out path when no updates occur before the full `V-1` passes.
+- `floyd_warshall.orus` stresses triple-nested loops and sentinel
+  `infinity` guards while counting how many matrix cells improved. A
+  follow-up fixture keeps unreachable nodes intact to confirm the guard
+  logic avoids overflow.
+- `topological_sort.orus` rounds out the phase with Kahn's algorithm,
+  capturing enqueue/dequeue counts, edge visits, and queue high-water
+  marks across DAGs with single roots, multiple roots, and wide fan-out.
+
+These additions give us depth-first, breadth-first, single-source, and
+all-pairs coverage along with DAG ordering. Combined with the Phase 1
+sorters we now touch recursion, queues, dense numeric loops, and
+conditional edge relaxations—enough variety to start capturing VM
+profiling snapshots for backend tuning.

--- a/tests/algorithms/phase1/bellman_ford.orus
+++ b/tests/algorithms/phase1/bellman_ford.orus
@@ -1,0 +1,146 @@
+// Phase 2 Bellman-Ford implementation for the algorithm stress-test suite.
+// Iterative relaxation across an explicit edge list to surface negative edge
+// handling and early-out behaviour when no updates occur.
+
+print("== Phase 2: Bellman-Ford Shortest Paths (Edge Relaxation) Smoke ==")
+
+global mut BELLMAN_RELAXATIONS = 0
+global mut BELLMAN_ITERATIONS = 0
+
+fn make_distance_array(count, value):
+    mut result = []
+    mut i = 0
+    while i < count:
+        push(result, value)
+        i = i + 1
+    return result
+
+fn bellman_ford(label, vertex_count, edges, start, infinity):
+    BELLMAN_RELAXATIONS = 0
+    BELLMAN_ITERATIONS = 0
+
+    distances = make_distance_array(vertex_count, infinity)
+    distances[start] = 0
+
+    mut iteration = 0
+    while iteration < vertex_count - 1:
+        changed = false
+        mut e = 0
+        while e < len(edges):
+            from = edges[e]
+            to = edges[e + 1]
+            weight = edges[e + 2]
+            if distances[from] != infinity:
+                candidate = distances[from] + weight
+                if candidate < distances[to]:
+                    distances[to] = candidate
+                    BELLMAN_RELAXATIONS = BELLMAN_RELAXATIONS + 1
+                    changed = true
+            e = e + 3
+        BELLMAN_ITERATIONS = BELLMAN_ITERATIONS + 1
+        if changed == false:
+            break
+        iteration = iteration + 1
+
+    print("bellman_ford", label, "iterations:", BELLMAN_ITERATIONS, "relaxations:", BELLMAN_RELAXATIONS)
+    return distances
+
+fn assert_distances(label, observed, expected):
+    if len(observed) != len(expected):
+        print("FAIL", label, "length mismatch", len(observed), "expected", len(expected))
+        return
+    mut i = 0
+    mut ok = true
+    while i < len(expected):
+        if observed[i] != expected[i]:
+            ok = false
+        i = i + 1
+    if ok:
+        print(label, "distances", observed)
+    else:
+        print("FAIL", label, "=>", observed, "expected", expected)
+
+// === Tests ===
+fn make_main_edges():
+    mut edges = []
+    push(edges, 0)
+    push(edges, 1)
+    push(edges, 6)
+    push(edges, 0)
+    push(edges, 2)
+    push(edges, 7)
+    push(edges, 1)
+    push(edges, 2)
+    push(edges, 8)
+    push(edges, 1)
+    push(edges, 3)
+    push(edges, 5)
+    push(edges, 1)
+    push(edges, 4)
+    push(edges, -4)
+    push(edges, 2)
+    push(edges, 3)
+    push(edges, -3)
+    push(edges, 2)
+    push(edges, 4)
+    push(edges, 9)
+    push(edges, 3)
+    push(edges, 1)
+    push(edges, -2)
+    push(edges, 4)
+    push(edges, 0)
+    push(edges, 2)
+    push(edges, 4)
+    push(edges, 3)
+    push(edges, 7)
+    return edges
+
+fn make_sparse_edges():
+    mut edges = []
+    push(edges, 0)
+    push(edges, 1)
+    push(edges, 5)
+    push(edges, 1)
+    push(edges, 2)
+    push(edges, 3)
+    return edges
+
+fn make_expected_from_zero():
+    mut expected = []
+    push(expected, 0)
+    push(expected, 2)
+    push(expected, 7)
+    push(expected, 4)
+    push(expected, -2)
+    return expected
+
+fn make_expected_from_four():
+    mut expected = []
+    push(expected, 2)
+    push(expected, 4)
+    push(expected, 9)
+    push(expected, 6)
+    push(expected, 0)
+    return expected
+
+fn make_expected_sparse(infinity):
+    mut expected = []
+    push(expected, 0)
+    push(expected, 5)
+    push(expected, 8)
+    push(expected, infinity)
+    return expected
+
+infinity = 999999
+vertex_count = 5
+
+edges = make_main_edges()
+expected_from_zero = make_expected_from_zero()
+assert_distances("from_zero", bellman_ford("from_zero", vertex_count, edges, 0, infinity), expected_from_zero)
+
+expected_from_four = make_expected_from_four()
+assert_distances("from_four", bellman_ford("from_four", vertex_count, edges, 4, infinity), expected_from_four)
+
+sparse_edges = make_sparse_edges()
+expected_sparse = make_expected_sparse(infinity)
+assert_distances("sparse", bellman_ford("sparse", 4, sparse_edges, 0, infinity), expected_sparse)

--- a/tests/algorithms/phase1/breadth_first_search.orus
+++ b/tests/algorithms/phase1/breadth_first_search.orus
@@ -1,0 +1,118 @@
+// Phase 2 breadth-first search implementation for the algorithm stress-test suite.
+// Queue-driven traversal that records enqueue/dequeue counts, explored edges,
+// and breadth levels to exercise queue pressure inside the VM.
+
+print("== Phase 2: Breadth-First Search (Iterative) Smoke ==")
+
+global mut BFS_ENQUEUES = 0
+global mut BFS_DEQUEUES = 0
+global mut BFS_EDGE_CHECKS = 0
+global mut BFS_MAX_DEPTH = 0
+global mut BFS_MAX_QUEUE = 0
+
+fn make_bool_array(count):
+    mut result = []
+    mut i = 0
+    while i < count:
+        push(result, false)
+        i = i + 1
+    return result
+
+fn breadth_first_search(label, graph, start):
+    BFS_ENQUEUES = 0
+    BFS_DEQUEUES = 0
+    BFS_EDGE_CHECKS = 0
+    BFS_MAX_DEPTH = 0
+    BFS_MAX_QUEUE = 0
+
+    visited = make_bool_array(len(graph))
+    queue = []
+    queue_depths = []
+    mut front = 0
+
+    push(queue, start)
+    push(queue_depths, 0)
+    BFS_ENQUEUES = 1
+    visited[start] = true
+    BFS_MAX_QUEUE = 1
+
+    order = []
+    while front < len(queue):
+        node = queue[front]
+        depth = queue_depths[front]
+        front = front + 1
+        BFS_DEQUEUES = BFS_DEQUEUES + 1
+        if depth > BFS_MAX_DEPTH:
+            BFS_MAX_DEPTH = depth
+        push(order, node)
+
+        neighbors = graph[node]
+        mut i = 0
+        while i < len(neighbors):
+            neighbor = neighbors[i]
+            BFS_EDGE_CHECKS = BFS_EDGE_CHECKS + 1
+            if visited[neighbor] == false:
+                visited[neighbor] = true
+                push(queue, neighbor)
+                push(queue_depths, depth + 1)
+                BFS_ENQUEUES = BFS_ENQUEUES + 1
+                queue_size = len(queue) - front
+                if queue_size > BFS_MAX_QUEUE:
+                    BFS_MAX_QUEUE = queue_size
+            i = i + 1
+
+    print("bfs", label, "enqueues:", BFS_ENQUEUES, "dequeues:", BFS_DEQUEUES, "edge_checks:", BFS_EDGE_CHECKS, "max_depth:", BFS_MAX_DEPTH, "max_queue:", BFS_MAX_QUEUE)
+    return order
+
+fn assert_sequence(label, observed, expected):
+    if len(observed) != len(expected):
+        print("FAIL", label, "length mismatch", len(observed), "expected", len(expected))
+        return
+    mut i = 0
+    mut ok = true
+    while i < len(expected):
+        if observed[i] != expected[i]:
+            ok = false
+        i = i + 1
+    if ok:
+        print(label, "order", observed)
+    else:
+        print("FAIL", label, "=>", observed, "expected", expected)
+
+fn make_base_graph():
+    mut graph = []
+    push(graph, [1, 2])
+    push(graph, [2, 4])
+    push(graph, [3])
+    push(graph, [1, 4])
+    push(graph, [])
+    push(graph, [2, 3])
+    return graph
+
+// === Tests ===
+base_graph = make_base_graph()
+
+expected_component_a = [0, 1, 2, 4, 3]
+assert_sequence("component_a", breadth_first_search("component_a", base_graph, 0), expected_component_a)
+
+expected_component_b = [5, 2, 3, 1, 4]
+assert_sequence("component_b", breadth_first_search("component_b", base_graph, 5), expected_component_b)
+
+fn make_layered_graph():
+    mut graph = []
+    push(graph, [1, 2, 3])
+    push(graph, [4, 5])
+    push(graph, [6])
+    push(graph, [7, 8])
+    push(graph, [])
+    push(graph, [])
+    push(graph, [9])
+    push(graph, [])
+    push(graph, [])
+    push(graph, [])
+    return graph
+
+layered_graph = make_layered_graph()
+
+expected_layered_order = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+assert_sequence("layered_levels", breadth_first_search("layered_levels", layered_graph, 0), expected_layered_order)

--- a/tests/algorithms/phase1/depth_first_search.orus
+++ b/tests/algorithms/phase1/depth_first_search.orus
@@ -1,0 +1,105 @@
+// Phase 2 depth-first search implementation for the algorithm stress-test suite.
+// Recursive traversal that measures recursion depth, edge exploration, and
+// overall visitation order for connected and disconnected graphs.
+
+print("== Phase 2: Depth-First Search (Recursive) Smoke ==")
+
+global mut DFS_RECURSIONS = 0
+global mut DFS_EDGES_EXPLORED = 0
+global mut DFS_MAX_DEPTH = 0
+
+fn make_bool_array(count):
+    mut result = []
+    mut i = 0
+    while i < count:
+        push(result, false)
+        i = i + 1
+    return result
+
+fn dfs_visit(graph, node, depth, visited, order):
+    visited[node] = true
+    DFS_RECURSIONS = DFS_RECURSIONS + 1
+    if depth > DFS_MAX_DEPTH:
+        DFS_MAX_DEPTH = depth
+    push(order, node)
+
+    neighbors = graph[node]
+    neighbor_count = len(neighbors)
+    mut snapshot = []
+    mut copy_index = 0
+    while copy_index < neighbor_count:
+        push(snapshot, neighbors[copy_index])
+        copy_index = copy_index + 1
+
+    mut i = 0
+    while i < neighbor_count:
+        next = snapshot[i]
+        DFS_EDGES_EXPLORED = DFS_EDGES_EXPLORED + 1
+        if visited[next] == false:
+            dfs_visit(graph, next, depth + 1, visited, order)
+        i = i + 1
+
+fn depth_first_search(label, graph, start):
+    DFS_RECURSIONS = 0
+    DFS_EDGES_EXPLORED = 0
+    DFS_MAX_DEPTH = 0
+
+    visited = make_bool_array(len(graph))
+    order = []
+    dfs_visit(graph, start, 1, visited, order)
+    print("dfs", label, "recursions:", DFS_RECURSIONS, "edges:", DFS_EDGES_EXPLORED, "max_depth:", DFS_MAX_DEPTH)
+    return order
+
+fn assert_sequence(label, observed, expected):
+    if len(observed) != len(expected):
+        print("FAIL", label, "length mismatch", len(observed), "expected", len(expected))
+        return
+    mut i = 0
+    mut ok = true
+    while i < len(expected):
+        if observed[i] != expected[i]:
+            ok = false
+        i = i + 1
+    if ok:
+        print(label, "order", observed)
+    else:
+        print("FAIL", label, "=>", observed, "expected", expected)
+
+fn make_base_graph():
+    mut graph = []
+    push(graph, [1, 2])      // 0 connects to two neighbours
+    push(graph, [2, 4])      // 1 has a shortcut back to 2 and a branch to 4
+    push(graph, [3])         // 2 leads deeper into the component
+    push(graph, [1, 4])      // 3 introduces a back-edge to 1 and forward edge to 4
+    push(graph, [])          // 4 terminates
+    push(graph, [2, 3])      // 5 forms a separate entry into the main component
+    return graph
+
+// === Tests ===
+base_graph = make_base_graph()
+
+expected_component_a = [0, 1, 2, 3, 4]
+assert_sequence("component_a", depth_first_search("component_a", base_graph, 0), expected_component_a)
+
+expected_component_b = [5, 2, 3, 1, 4]
+assert_sequence("component_b", depth_first_search("component_b", base_graph, 5), expected_component_b)
+
+// Stress a tree-shaped traversal to highlight depth growth.
+fn make_tree_graph():
+    mut graph = []
+    push(graph, [1, 2, 3])
+    push(graph, [4, 5])
+    push(graph, [6])
+    push(graph, [7, 8])
+    push(graph, [])
+    push(graph, [])
+    push(graph, [9])
+    push(graph, [])
+    push(graph, [])
+    push(graph, [])
+    return graph
+
+tree_graph = make_tree_graph()
+
+expected_tree_order = [0, 1, 4, 5, 2, 6, 9, 3, 7, 8]
+assert_sequence("tree_depth", depth_first_search("tree_depth", tree_graph, 0), expected_tree_order)

--- a/tests/algorithms/phase1/dijkstra.orus
+++ b/tests/algorithms/phase1/dijkstra.orus
@@ -1,0 +1,144 @@
+// Phase 2 Dijkstra shortest-path implementation for the algorithm stress-test suite.
+// Array-based priority scanning that captures relaxation counts and selection
+// pressure without relying on a heap so we can observe register allocation
+// patterns in the VM.
+
+print("== Phase 2: Dijkstra Shortest Paths (Array Priority) Smoke ==")
+
+global mut DIJKSTRA_RELAXATIONS = 0
+global mut DIJKSTRA_SELECTIONS = 0
+
+fn dijkstra(label, graph, start, infinity):
+    DIJKSTRA_RELAXATIONS = 0
+    DIJKSTRA_SELECTIONS = 0
+
+    count = len(graph)
+    distances = []
+    mut distance_index = 0
+    while distance_index < count:
+        push(distances, infinity)
+        distance_index = distance_index + 1
+
+    visited = []
+    mut visit_index = 0
+    while visit_index < count:
+        push(visited, false)
+        visit_index = visit_index + 1
+    distances[start] = 0
+
+    mut processed = 0
+    while processed < count:
+        best_index = -1
+        best_distance = infinity
+        mut i = 0
+        while i < count:
+            if visited[i] == false:
+                if distances[i] < best_distance:
+                    best_distance = distances[i]
+                    best_index = i
+            i = i + 1
+
+        if best_index == -1:
+            break
+
+        visited[best_index] = true
+        DIJKSTRA_SELECTIONS = DIJKSTRA_SELECTIONS + 1
+        neighbors = graph[best_index]
+        mut j = 0
+        while j < len(neighbors):
+            neighbor = neighbors[j]
+            weight = neighbors[j + 1]
+            if distances[best_index] != infinity:
+                candidate = distances[best_index] + weight
+                if candidate < distances[neighbor]:
+                    distances[neighbor] = candidate
+                    DIJKSTRA_RELAXATIONS = DIJKSTRA_RELAXATIONS + 1
+            j = j + 2
+
+        processed = processed + 1
+
+    print("dijkstra", label, "relaxations:", DIJKSTRA_RELAXATIONS, "selections:", DIJKSTRA_SELECTIONS)
+    return distances
+
+fn assert_distances(label, observed, expected):
+    if len(observed) != len(expected):
+        print("FAIL", label, "length mismatch", len(observed), "expected", len(expected))
+        return
+    mut i = 0
+    mut ok = true
+    while i < len(expected):
+        if observed[i] != expected[i]:
+            ok = false
+        i = i + 1
+    if ok:
+        print(label, "distances", observed)
+    else:
+        print("FAIL", label, "=>", observed, "expected", expected)
+
+// === Tests ===
+infinity = 999999
+fn make_weighted_graph():
+    mut graph = []
+
+    mut node0 = []
+    push(node0, 1)
+    push(node0, 4)
+    push(node0, 2)
+    push(node0, 1)
+    push(graph, node0)
+
+    mut node1 = []
+    push(node1, 3)
+    push(node1, 1)
+    push(graph, node1)
+
+    mut node2 = []
+    push(node2, 1)
+    push(node2, 2)
+    push(node2, 3)
+    push(node2, 5)
+    push(graph, node2)
+
+    mut node3 = []
+    push(node3, 4)
+    push(node3, 3)
+    push(graph, node3)
+
+    mut node4 = []
+    push(graph, node4)
+
+    return graph
+
+weighted_graph = make_weighted_graph()
+
+expected_from_zero = [0, 3, 1, 4, 7]
+assert_distances("from_zero", dijkstra("from_zero", weighted_graph, 0, infinity), expected_from_zero)
+
+expected_from_two = [999999, 2, 0, 3, 6]
+assert_distances("from_two", dijkstra("from_two", weighted_graph, 2, infinity), expected_from_two)
+
+fn make_disconnected_graph():
+    mut graph = []
+
+    mut node0 = []
+    push(node0, 1)
+    push(node0, 2)
+    push(graph, node0)
+
+    mut node1 = []
+    push(graph, node1)
+
+    mut node2 = []
+    push(node2, 3)
+    push(node2, 1)
+    push(graph, node2)
+
+    mut node3 = []
+    push(graph, node3)
+
+    return graph
+
+disconnected_graph = make_disconnected_graph()
+
+expected_disconnected = [0, 2, 999999, 999999]
+assert_distances("disconnected", dijkstra("disconnected", disconnected_graph, 0, infinity), expected_disconnected)

--- a/tests/algorithms/phase1/floyd_warshall.orus
+++ b/tests/algorithms/phase1/floyd_warshall.orus
@@ -1,0 +1,191 @@
+// Phase 2 Floyd-Warshall implementation for the algorithm stress-test suite.
+// Dense all-pairs shortest paths that stresses triple-nested loops and
+// conditional updates guarded by sentinel infinity values.
+
+print("== Phase 2: Floyd-Warshall All-Pairs Shortest Paths Smoke ==")
+
+global mut FLOYD_RELAXATIONS = 0
+
+fn clone_matrix(matrix, dimension):
+    mut result = []
+    mut i = 0
+    while i < dimension:
+        source_row = matrix[i]
+        mut copy = []
+        mut j = 0
+        while j < dimension:
+            push(copy, source_row[j])
+            j = j + 1
+        push(result, copy)
+        i = i + 1
+    return result
+
+fn floyd_warshall(label, matrix, dimension, infinity):
+    FLOYD_RELAXATIONS = 0
+    distances = clone_matrix(matrix, dimension)
+
+    mut k = 0
+    while k < dimension:
+        pivot_row = distances[k]
+        mut i = 0
+        while i < dimension:
+            current_row = distances[i]
+            mut j = 0
+            while j < dimension:
+                through_k = current_row[k]
+                via_k = pivot_row[j]
+                if through_k != infinity and via_k != infinity:
+                    candidate = through_k + via_k
+                    if candidate < current_row[j]:
+                        current_row[j] = candidate
+                        FLOYD_RELAXATIONS = FLOYD_RELAXATIONS + 1
+                j = j + 1
+            i = i + 1
+        k = k + 1
+
+    print("floyd_warshall", label, "relaxations:", FLOYD_RELAXATIONS)
+    return distances
+
+fn assert_matrix(label, observed, expected, dimension):
+    mut ok = true
+    mut i = 0
+    while i < dimension:
+        observed_row = observed[i]
+        expected_row = expected[i]
+        mut j = 0
+        while j < dimension:
+            if observed_row[j] != expected_row[j]:
+                ok = false
+            j = j + 1
+        i = i + 1
+    if ok:
+        print(label, "matrix", observed)
+    else:
+        print("FAIL", label, "=>", observed, "expected", expected)
+
+// === Tests ===
+infinity = 999999
+
+fn make_dense_matrix(infinity):
+    mut matrix = []
+
+    mut row0 = []
+    push(row0, 0)
+    push(row0, 3)
+    push(row0, infinity)
+    push(row0, 7)
+    push(matrix, row0)
+
+    mut row1 = []
+    push(row1, 8)
+    push(row1, 0)
+    push(row1, 2)
+    push(row1, infinity)
+    push(matrix, row1)
+
+    mut row2 = []
+    push(row2, 5)
+    push(row2, infinity)
+    push(row2, 0)
+    push(row2, 1)
+    push(matrix, row2)
+
+    mut row3 = []
+    push(row3, 2)
+    push(row3, infinity)
+    push(row3, infinity)
+    push(row3, 0)
+    push(matrix, row3)
+
+    return matrix
+
+fn make_dense_expected():
+    mut expected = []
+
+    mut row0 = []
+    push(row0, 0)
+    push(row0, 3)
+    push(row0, 5)
+    push(row0, 6)
+    push(expected, row0)
+
+    mut row1 = []
+    push(row1, 5)
+    push(row1, 0)
+    push(row1, 2)
+    push(row1, 3)
+    push(expected, row1)
+
+    mut row2 = []
+    push(row2, 3)
+    push(row2, 6)
+    push(row2, 0)
+    push(row2, 1)
+    push(expected, row2)
+
+    mut row3 = []
+    push(row3, 2)
+    push(row3, 5)
+    push(row3, 7)
+    push(row3, 0)
+    push(expected, row3)
+
+    return expected
+
+dense_dimension = 4
+dense_matrix = make_dense_matrix(infinity)
+dense_expected = make_dense_expected()
+
+assert_matrix("dense_fixture", floyd_warshall("dense_fixture", dense_matrix, dense_dimension, infinity), dense_expected, dense_dimension)
+
+fn make_disconnected_matrix(infinity):
+    mut matrix = []
+
+    mut row0 = []
+    push(row0, 0)
+    push(row0, infinity)
+    push(row0, infinity)
+    push(matrix, row0)
+
+    mut row1 = []
+    push(row1, infinity)
+    push(row1, 0)
+    push(row1, 4)
+    push(matrix, row1)
+
+    mut row2 = []
+    push(row2, infinity)
+    push(row2, infinity)
+    push(row2, 0)
+    push(matrix, row2)
+
+    return matrix
+
+fn make_disconnected_expected(infinity):
+    mut expected = []
+
+    mut row0 = []
+    push(row0, 0)
+    push(row0, infinity)
+    push(row0, infinity)
+    push(expected, row0)
+
+    mut row1 = []
+    push(row1, infinity)
+    push(row1, 0)
+    push(row1, 4)
+    push(expected, row1)
+
+    mut row2 = []
+    push(row2, infinity)
+    push(row2, infinity)
+    push(row2, 0)
+    push(expected, row2)
+
+    return expected
+
+disconnected_dimension = 3
+disconnected_matrix = make_disconnected_matrix(infinity)
+disconnected_expected = make_disconnected_expected(infinity)
+
+assert_matrix("disconnected", floyd_warshall("disconnected", disconnected_matrix, disconnected_dimension, infinity), disconnected_expected, disconnected_dimension)

--- a/tests/algorithms/phase1/topological_sort.orus
+++ b/tests/algorithms/phase1/topological_sort.orus
@@ -1,0 +1,202 @@
+// Phase 2 topological sort implementation for the algorithm stress-test suite.
+// Kahn's algorithm using explicit indegree accounting to stress repeated array
+// updates and queue pressure in DAG workloads.
+
+print("== Phase 2: Topological Sort (Kahn's Algorithm) Smoke ==")
+
+global mut TOPO_ENQUEUES = 0
+global mut TOPO_DEQUEUES = 0
+global mut TOPO_EDGE_VISITS = 0
+global mut TOPO_MAX_QUEUE = 0
+
+fn topological_sort(label, graph):
+    TOPO_ENQUEUES = 0
+    TOPO_DEQUEUES = 0
+    TOPO_EDGE_VISITS = 0
+    TOPO_MAX_QUEUE = 0
+
+    node_count = len(graph)
+    indegree = []
+    mut zero_index = 0
+    while zero_index < node_count:
+        push(indegree, 0)
+        zero_index = zero_index + 1
+
+    mut i = 0
+    while i < node_count:
+        neighbors = graph[i]
+        mut j = 0
+        neighbor_count = len(neighbors)
+        while j < neighbor_count:
+            indegree[neighbors[j]] = indegree[neighbors[j]] + 1
+            TOPO_EDGE_VISITS = TOPO_EDGE_VISITS + 1
+            j = j + 1
+        i = i + 1
+
+    queue = []
+    mut front = 0
+    mut node = 0
+    while node < node_count:
+        if indegree[node] == 0:
+            push(queue, node)
+            TOPO_ENQUEUES = TOPO_ENQUEUES + 1
+        node = node + 1
+    TOPO_MAX_QUEUE = len(queue) - front
+
+    order = []
+    while front < len(queue):
+        current = queue[front]
+        front = front + 1
+        TOPO_DEQUEUES = TOPO_DEQUEUES + 1
+        push(order, current)
+
+        neighbors = graph[current]
+        mut edge_index = 0
+        neighbor_count = len(neighbors)
+        while edge_index < neighbor_count:
+            next = neighbors[edge_index]
+            indegree[next] = indegree[next] - 1
+            if indegree[next] == 0:
+                push(queue, next)
+                TOPO_ENQUEUES = TOPO_ENQUEUES + 1
+                queue_size = len(queue) - front
+                if queue_size > TOPO_MAX_QUEUE:
+                    TOPO_MAX_QUEUE = queue_size
+
+                mut insert_index = len(queue) - 1
+                while true:
+                    if insert_index == front:
+                        break
+                    previous_index = insert_index - 1
+                    previous_value = queue[previous_index]
+                    current_value = queue[insert_index]
+                    if previous_value <= current_value:
+                        break
+                    queue[previous_index] = current_value
+                    queue[insert_index] = previous_value
+                    insert_index = insert_index - 1
+            edge_index = edge_index + 1
+
+    print("topological_sort", label, "enqueues:", TOPO_ENQUEUES, "dequeues:", TOPO_DEQUEUES, "edge_visits:", TOPO_EDGE_VISITS, "max_queue:", TOPO_MAX_QUEUE)
+    return order
+
+fn assert_sequence(label, observed, expected):
+    if len(observed) != len(expected):
+        print("FAIL", label, "length mismatch", len(observed), "expected", len(expected))
+        return
+    mut i = 0
+    mut ok = true
+    while i < len(expected):
+        if observed[i] != expected[i]:
+            ok = false
+        i = i + 1
+    if ok:
+        print(label, "order", observed)
+    else:
+        print("FAIL", label, "=>", observed, "expected", expected)
+
+fn make_dag_linear():
+    mut graph = []
+
+    mut row0 = []
+    push(row0, 1)
+    push(row0, 2)
+    push(graph, row0)
+
+    mut row1 = []
+    push(row1, 3)
+    push(graph, row1)
+
+    mut row2 = []
+    push(row2, 3)
+    push(row2, 4)
+    push(graph, row2)
+
+    mut row3 = []
+    push(row3, 5)
+    push(graph, row3)
+
+    mut row4 = []
+    push(row4, 5)
+    push(graph, row4)
+
+    mut row5 = []
+    push(graph, row5)
+
+    return graph
+
+// === Tests ===
+dag = make_dag_linear()
+
+expected_order = [0, 1, 2, 3, 4, 5]
+assert_sequence("dag_linear", topological_sort("dag_linear", dag), expected_order)
+
+fn make_multiple_roots():
+    mut graph = []
+
+    mut row0 = []
+    push(row0, 3)
+    push(graph, row0)
+
+    mut row1 = []
+    push(row1, 3)
+    push(row1, 4)
+    push(graph, row1)
+
+    mut row2 = []
+    push(row2, 4)
+    push(graph, row2)
+
+    mut row3 = []
+    push(row3, 5)
+    push(graph, row3)
+
+    mut row4 = []
+    push(row4, 5)
+    push(graph, row4)
+
+    mut row5 = []
+    push(graph, row5)
+
+    return graph
+
+multiple_roots = make_multiple_roots()
+
+expected_multiple = [0, 1, 2, 3, 4, 5]
+assert_sequence("multiple_roots", topological_sort("multiple_roots", multiple_roots), expected_multiple)
+
+fn make_wide_dag():
+    mut graph = []
+
+    mut row0 = []
+    push(row0, 2)
+    push(row0, 3)
+    push(row0, 4)
+    push(graph, row0)
+
+    mut row1 = []
+    push(row1, 2)
+    push(row1, 4)
+    push(graph, row1)
+
+    mut row2 = []
+    push(row2, 5)
+    push(graph, row2)
+
+    mut row3 = []
+    push(row3, 5)
+    push(graph, row3)
+
+    mut row4 = []
+    push(row4, 5)
+    push(graph, row4)
+
+    mut row5 = []
+    push(graph, row5)
+
+    return graph
+
+wide_dag = make_wide_dag()
+
+expected_wide = [0, 1, 2, 3, 4, 5]
+assert_sequence("wide", topological_sort("wide", wide_dag), expected_wide)


### PR DESCRIPTION
## Summary
- flatten the Bellman-Ford edge fixtures into sequential triplets and iterate with triple-stride relaxation loops so the phase 1 test compiles cleanly under Orus
- construct the Bellman-Ford expected distance fixtures with push-based helpers to avoid nested literals while preserving the asserted outputs