### PR TITLE
Support destructuring and hex-friendly sorting test

### DIFF
--- a/include/compiler/ast.h
+++ b/include/compiler/ast.h
@@ -202,6 +202,7 @@ struct ASTNode {
         struct {
             ASTNode** statements;
             int count;
+            bool createsScope;
         } block;
         struct {
             ASTNode* condition;

--- a/src/compiler/backend/codegen/codegen.c
+++ b/src/compiler/backend/codegen/codegen.c
@@ -3609,9 +3609,14 @@ void compile_statement(CompilerContext* ctx, TypedASTNode* stmt) {
         case NODE_IF:
             compile_if_statement(ctx, stmt);
             break;
-        case NODE_BLOCK:
-            compile_block_with_scope(ctx, stmt, true);
+        case NODE_BLOCK: {
+            bool create_scope = true;
+            if (stmt->original && stmt->original->type == NODE_BLOCK) {
+                create_scope = stmt->original->block.createsScope;
+            }
+            compile_block_with_scope(ctx, stmt, create_scope);
             break;
+        }
             
         case NODE_WHILE:
             compile_while_statement(ctx, stmt);
@@ -3970,7 +3975,7 @@ static int compile_assignment_internal(CompilerContext* ctx, TypedASTNode* assig
         }
 
         bool is_in_loop = (ctx->current_loop_start != -1);
-        bool should_be_mutable = is_in_loop || ctx->branch_depth > 0;
+        bool should_be_mutable = is_in_loop || ctx->branch_depth > 0 || ctx->compiling_function;
 
         SymbolTable* target_scope = ctx->symbols;
         if (ctx->branch_depth > 0 && target_scope) {

--- a/tests/algorithms/phase4/phase4_sort.orus
+++ b/tests/algorithms/phase4/phase4_sort.orus
@@ -3,27 +3,27 @@
 // ==============================
 print("== Phase 4: Sorting Property Tests (with Counting) ==")
 
+// ---------- Deterministic RNG ----------
 global mut RNG_SEED: i32 = 0x13579BDF
 
-fn srand(seed: i32):
-    RNG_SEED = seed
-
+fn srand(seed: i32): RNG_SEED = seed
 fn rand_u32() -> i32:
+    // LCG: X_{n+1} = (aX + c) mod 2^32  (wrap via i32 overflow)
     RNG_SEED = (RNG_SEED * 1664525) + 1013904223
     return RNG_SEED
 
 fn rand_range(lo: i32, hi: i32) -> i32:
-    if hi <= lo:
-        return lo
+    if hi <= lo: return lo
     span = hi - lo + 1
     r = rand_u32()
-    mut m = r % span
-    if m < 0:
-        m = m + span
+    // safe modulo for possibly negative r
+    m = r % span
+    if m < 0: m = m + span
     return lo + m
 
 fn rand_len(max_len: i32) -> i32:
-    return rand_range(0, max_len)
+    v = rand_range(0, max_len)
+    return v
 
 fn copy_array(xs):
     mut out = []
@@ -36,13 +36,9 @@ fn copy_array(xs):
 fn concat(a, b):
     mut out = []
     mut i: i32 = 0
-    while i < len(a):
-        push(out, a[i])
-        i = i + 1
+    while i < len(a): push(out, a[i]); i = i + 1
     i = 0
-    while i < len(b):
-        push(out, b[i])
-        i = i + 1
+    while i < len(b): push(out, b[i]); i = i + 1
     return out
 
 fn add_k(xs, k: i32):
@@ -58,42 +54,35 @@ fn split_at(xs, mid: i32):
     mut right = []
     mut i: i32 = 0
     while i < len(xs):
-        if i < mid:
-            push(left, xs[i])
-        else:
-            push(right, xs[i])
+        if i < mid: push(left, xs[i])
+        else: push(right, xs[i])
         i = i + 1
-    return [left, right]
+    return left, right
 
+// ---------- Oracle merge sort (reference) ----------
 fn merge(a, b):
     mut out = []
     mut i: i32 = 0
     mut j: i32 = 0
     while i < len(a) and j < len(b):
         if a[i] <= b[j]:
-            push(out, a[i])
-            i = i + 1
+            push(out, a[i]); i = i + 1
         else:
-            push(out, b[j])
-            j = j + 1
-    while i < len(a):
-        push(out, a[i])
-        i = i + 1
-    while j < len(b):
-        push(out, b[j])
-        j = j + 1
+            push(out, b[j]); j = j + 1
+    while i < len(a): push(out, a[i]); i = i + 1
+    while j < len(b): push(out, b[j]); j = j + 1
     return out
 
 fn oracle_merge_sort(xs):
     n: i32 = len(xs)
-    if n <= 1:
-        return copy_array(xs)
+    if n <= 1: return copy_array(xs)
     mid: i32 = n / 2
-    parts = split_at(xs, mid)
-    left_sorted = oracle_merge_sort(parts[0])
-    right_sorted = oracle_merge_sort(parts[1])
-    return merge(left_sorted, right_sorted)
+    left, right = split_at(xs, mid)
+    sl = oracle_merge_sort(left)
+    sr = oracle_merge_sort(right)
+    return merge(sl, sr)
 
+// ---------- In-place insertion sort (for demo) ----------
 fn insertion_sort(label, values):
     n: i32 = len(values)
     mut i: i32 = 1
@@ -102,34 +91,29 @@ fn insertion_sort(label, values):
         mut j: i32 = i
         while j > 0:
             prev: i32 = j - 1
-            if values[prev] <= key:
-                break
+            if values[prev] <= key: break
             values[j] = values[prev]
             j = j - 1
         values[j] = key
         i = i + 1
     return values
 
+// ---------- Counting sort (frequency table; returns new array) ----------
 fn counting_sort(label, values):
     n: i32 = len(values)
-    if n <= 1:
-        return copy_array(values)
+    if n <= 1: return copy_array(values)
     mut min_v = values[0]
     mut max_v = values[0]
     mut i: i32 = 1
     while i < n:
         v = values[i]
-        if v < min_v:
-            min_v = v
-        if v > max_v:
-            max_v = v
+        if v < min_v: min_v = v
+        if v > max_v: max_v = v
         i = i + 1
     range_size: i32 = (max_v - min_v) + 1
     mut counts = []
     mut k: i32 = 0
-    while k < range_size:
-        push(counts, 0)
-        k = k + 1
+    while k < range_size: push(counts, 0); k = k + 1
     i = 0
     while i < n:
         idx: i32 = values[i] - min_v
@@ -145,110 +129,128 @@ fn counting_sort(label, values):
         ci = ci + 1
     return out
 
+// ---------- Helpers: predicates & checks ----------
 fn is_sorted(xs) -> bool:
     mut i: i32 = 1
     while i < len(xs):
-        if xs[i - 1] > xs[i]:
-            return false
+        if xs[i - 1] > xs[i]: return false
         i = i + 1
     return true
 
 fn arrays_equal(a, b) -> bool:
-    if len(a) != len(b):
-        return false
+    if len(a) != len(b): return false
     mut i: i32 = 0
     while i < len(a):
-        if a[i] != b[i]:
-            return false
+        if a[i] != b[i]: return false
         i = i + 1
     return true
 
 fn assert_prop(ok: bool, name, algo):
-    if ok == false:
-        print("FAIL", algo, "-", name)
+    if ok == false: print("FAIL", algo, "—", name)
 
-ALG_INSERTION = 1
-ALG_COUNTING = 2
-ALG_ORACLE = 3
+// ---------- Algorithm registry ----------
+const ALG_INSERTION = 1
+const ALG_COUNTING  = 2
+const ALG_ORACLE    = 3    // reference; also used as differential oracle
 
 fn apply_sort(algo_id: i32, label, xs):
+    // Always pass a copy so in-place algos don't mutate test fixtures
     work = copy_array(xs)
-    if algo_id == ALG_INSERTION:
-        return insertion_sort(label, work)
-    if algo_id == ALG_COUNTING:
-        return counting_sort(label, work)
-    if algo_id == ALG_ORACLE:
-        return oracle_merge_sort(work)
+    if algo_id == ALG_INSERTION: return insertion_sort(label, work)
+    if algo_id == ALG_COUNTING:  return counting_sort(label, work)
+    if algo_id == ALG_ORACLE:    return oracle_merge_sort(work)
+    // default fallback
     return oracle_merge_sort(work)
 
+// ---------- Property suite for a single algorithm ----------
 fn run_sort_properties_once(algo_name, algo_id: i32, xs):
+    // expected via oracle
     expected = oracle_merge_sort(xs)
 
+    // 1) length preserved
     got = apply_sort(algo_id, "len", xs)
     assert_prop(len(got) == len(xs), "length preserved", algo_name)
 
+    // 2) sortedness
     assert_prop(is_sorted(got), "non-decreasing order", algo_name)
 
+    // 3) differential equivalence to oracle
     assert_prop(arrays_equal(got, expected), "equals oracle(sorted)", algo_name)
 
+    // 4) idempotence
     got2 = apply_sort(algo_id, "idemp", got)
     assert_prop(arrays_equal(got, got2), "idempotent", algo_name)
 
+    // 5) metamorphic (concat & merge)
     mid: i32 = len(xs) / 2
-    parts = split_at(xs, mid)
-    left = parts[0]
-    right = parts[1]
-    s_left = apply_sort(algo_id, "m_left", left)
+    left, right = split_at(xs, mid)
+    s_left  = apply_sort(algo_id, "m_left", left)
     s_right = apply_sort(algo_id, "m_right", right)
-    merged = merge(s_left, s_right)
-    s_all = apply_sort(algo_id, "m_all", xs)
+    merged  = merge(s_left, s_right)
+    s_all   = apply_sort(algo_id, "m_all", xs)
     assert_prop(arrays_equal(s_all, merged), "concat-merge relation", algo_name)
 
+    // 6) metamorphic (offset): sort(map(+k,xs)) == map(+k, sort(xs))
     k: i32 = rand_range(-7, 7)
-    xs_k = add_k(xs, k)
-    s_k = apply_sort(algo_id, "offA", xs_k)
+    xs_k   = add_k(xs, k)
+    s_k    = apply_sort(algo_id, "offA", xs_k)
     s_base = apply_sort(algo_id, "offB", xs)
     s_base_k = add_k(s_base, k)
     assert_prop(arrays_equal(s_k, s_base_k), "offset invariance", algo_name)
 
+// ---------- Generators ----------
 fn gen_random_array(max_len: i32, min_v: i32, max_v: i32):
-    length = rand_len(max_len)
+    L = rand_len(max_len)
     mut out = []
     mut i: i32 = 0
-    while i < length:
+    while i < L:
         push(out, rand_range(min_v, max_v))
         i = i + 1
     return out
 
 fn fixed_cases():
     mut cases = []
+
+    // Empty
+    push(cases, [])
+    // Single
     push(cases, [42])
-    push(cases, [1, 2, 3, 4, 5, 6])
-    push(cases, [9, 7, 5, 3, 1, -1])
-    push(cases, [4, 2, 4, 1, 4, 3, 2])
-    push(cases, [0, -3, -1, 4, 2, -3])
-    push(cases, [2, 3, 4, 5, 1])
-    push(cases, [7, 7, 7, 7, 7])
+    // Ascending
+    push(cases, [1,2,3,4,5,6])
+    // Reversed
+    push(cases, [9,7,5,3,1,-1])
+    // Duplicates
+    push(cases, [4,2,4,1,4,3,2])
+    // Negatives mixed
+    push(cases, [0,-3,-1,4,2,-3])
+    // Nearly sorted
+    push(cases, [2,3,4,5,1])
+    // All equal
+    push(cases, [7,7,7,7,7])
     return cases
 
+// ---------- Runner for one algorithm ----------
 fn run_props_for(algo_name, algo_id: i32, random_trials: i32):
     print("-- props:", algo_name, "--")
-    run_sort_properties_once(algo_name, algo_id, [])
+    // Fixed edge cases
     edge = fixed_cases()
     mut i: i32 = 0
     while i < len(edge):
         run_sort_properties_once(algo_name, algo_id, edge[i])
         i = i + 1
 
+    // Random trials
     mut t: i32 = 0
     while t < random_trials:
         xs = gen_random_array(100, -100, 100)
         run_sort_properties_once(algo_name, algo_id, xs)
         t = t + 1
 
-srand(1792609982)
+// ---------- Main ----------
+srand(0xCAFEBABE)
 run_props_for("insertion_sort (in-place)", ALG_INSERTION, 100)
-run_props_for("counting_sort (new array)", ALG_COUNTING, 100)
+run_props_for("counting_sort (new array)",  ALG_COUNTING,  100)
+// Oracle should of course satisfy its own properties; also serves as control.
 run_props_for("oracle_merge_sort (reference)", ALG_ORACLE, 50)
 
 print("== Done: Sorting Property Tests ==")


### PR DESCRIPTION
## Summary
- extend the parser and code generator to understand const declarations, destructuring assignments, and inline blocks without introducing a new scope
- allow hexadecimal integer literals with uppercase digits to bind to i32 values and make locals implicitly mutable when declared inside functions
- rewrite the phase4 sorting property suite to use tuple unpacking, const ids, and the original RNG seed