### PR TITLE
Add dedicated string indexing opcode and tests

### DIFF
--- a/include/compiler/ast.h
+++ b/include/compiler/ast.h
@@ -153,6 +153,7 @@ struct ASTNode {
         struct {
             ASTNode* array;
             ASTNode* index;
+            bool isStringIndex;
         } indexAccess;
         struct {
             char* op;

--- a/include/compiler/typed_ast.h
+++ b/include/compiler/typed_ast.h
@@ -176,6 +176,7 @@ struct TypedASTNode {
         struct {
             TypedASTNode* array;
             TypedASTNode* index;
+            bool isStringIndex;
         } indexAccess;
         struct {
             TypedASTNode* value;

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -545,6 +545,7 @@ typedef enum {
     // String operations
     OP_CONCAT_R,
     OP_TO_STRING_R,
+    OP_STRING_INDEX_R,
 
     // Array operations
     OP_MAKE_ARRAY_R,  // dst, start_reg, count

--- a/include/vm/vm_string_ops.h
+++ b/include/vm/vm_string_ops.h
@@ -74,6 +74,7 @@ void freeStringBuilder(StringBuilder* sb);
 // Rope helpers
 StringRope* rope_from_cstr(const char* str, size_t len);
 char* rope_to_cstr(StringRope* rope);
+ObjString* rope_index_to_string(StringRope* rope, size_t index);
 
 // Interning
 void init_string_table(StringInternTable* table);

--- a/src/compiler/backend/codegen/codegen.c
+++ b/src/compiler/backend/codegen/codegen.c
@@ -2477,8 +2477,10 @@ int compile_expression(CompilerContext* ctx, TypedASTNode* expr) {
                 return -1;
             }
 
+            bool is_string_index = expr->typed.indexAccess.isStringIndex;
+
             set_location_from_node(ctx, expr);
-            emit_byte_to_buffer(ctx->bytecode, OP_ARRAY_GET_R);
+            emit_byte_to_buffer(ctx->bytecode, is_string_index ? OP_STRING_INDEX_R : OP_ARRAY_GET_R);
             emit_byte_to_buffer(ctx->bytecode, result_reg);
             emit_byte_to_buffer(ctx->bytecode, array_reg);
             emit_byte_to_buffer(ctx->bytecode, index_reg);

--- a/src/compiler/frontend/parser.c
+++ b/src/compiler/frontend/parser.c
@@ -4019,6 +4019,7 @@ static ASTNode* parseIndexExpression(ParserContext* ctx, ASTNode* arrayExpr, Tok
         indexNode->type = NODE_INDEX_ACCESS;
         indexNode->indexAccess.array = arrayExpr;
         indexNode->indexAccess.index = firstExpr;
+        indexNode->indexAccess.isStringIndex = false;
     }
 
     return indexNode;

--- a/src/compiler/typed_ast.c
+++ b/src/compiler/typed_ast.c
@@ -150,6 +150,7 @@ TypedASTNode* create_typed_ast_node(ASTNode* original) {
         case NODE_INDEX_ACCESS:
             typed->typed.indexAccess.array = NULL;
             typed->typed.indexAccess.index = NULL;
+            typed->typed.indexAccess.isStringIndex = original->indexAccess.isStringIndex;
             break;
         case NODE_RETURN:
             typed->typed.returnStmt.value = NULL;

--- a/src/type/type_inference.c
+++ b/src/type/type_inference.c
@@ -1211,6 +1211,21 @@ Type* algorithm_w(TypeEnv* env, ASTNode* node) {
             array_type = prune(array_type);
             index_type = prune(index_type);
 
+            if (index_type && index_type->kind == TYPE_VAR) {
+                Type* assumed_index = getPrimitiveType(TYPE_I32);
+                if (assumed_index) {
+                    unify(index_type, assumed_index);
+                    index_type = prune(index_type);
+                }
+            }
+
+            if (!is_integer_type(index_type)) {
+                report_type_mismatch(node->indexAccess.index->location, "integer index",
+                                     getTypeName(index_type->kind));
+                set_type_error();
+                return NULL;
+            }
+
             if (array_type && array_type->kind == TYPE_VAR) {
                 Type* element_var = make_var_type(env);
                 if (!element_var) {
@@ -1233,24 +1248,20 @@ Type* algorithm_w(TypeEnv* env, ASTNode* node) {
                 array_type = prune(array_type);
             }
 
-            if (index_type && index_type->kind == TYPE_VAR) {
-                Type* assumed_index = getPrimitiveType(TYPE_I32);
-                if (assumed_index) {
-                    unify(index_type, assumed_index);
-                    index_type = prune(index_type);
-                }
+            if (array_type->kind == TYPE_STRING) {
+                node->indexAccess.isStringIndex = true;
+                return getPrimitiveType(TYPE_STRING);
+            }
+
+            if (array_type->kind == TYPE_INSTANCE && array_type->info.instance.base &&
+                array_type->info.instance.base->kind == TYPE_STRING) {
+                node->indexAccess.isStringIndex = true;
+                return getPrimitiveType(TYPE_STRING);
             }
 
             if (array_type->kind != TYPE_ARRAY) {
                 report_type_mismatch(node->indexAccess.array->location, "array",
                                      getTypeName(array_type->kind));
-                set_type_error();
-                return NULL;
-            }
-
-            if (!is_integer_type(index_type)) {
-                report_type_mismatch(node->indexAccess.index->location, "integer index",
-                                     getTypeName(index_type->kind));
                 set_type_error();
                 return NULL;
             }
@@ -3663,6 +3674,7 @@ static TypedASTNode* generate_typed_ast_recursive(ASTNode* ast, TypeEnv* type_en
                 free_typed_ast_node(typed);
                 return NULL;
             }
+            typed->typed.indexAccess.isStringIndex = ast->indexAccess.isStringIndex;
             break;
 
         case NODE_CAST:

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -303,6 +303,7 @@ InterpretResult vm_run_dispatch(void) {
         vm_dispatch_table[OP_OR_BOOL_R] = &&LABEL_OP_OR_BOOL_R;
         vm_dispatch_table[OP_NOT_BOOL_R] = &&LABEL_OP_NOT_BOOL_R;
         vm_dispatch_table[OP_CONCAT_R] = &&LABEL_OP_CONCAT_R;
+        vm_dispatch_table[OP_STRING_INDEX_R] = &&LABEL_OP_STRING_INDEX_R;
         vm_dispatch_table[OP_MAKE_ARRAY_R] = &&LABEL_OP_MAKE_ARRAY_R;
         vm_dispatch_table[OP_ENUM_NEW_R] = &&LABEL_OP_ENUM_NEW_R;
         vm_dispatch_table[OP_ENUM_TAG_EQ_R] = &&LABEL_OP_ENUM_TAG_EQ_R;
@@ -2223,6 +2224,42 @@ InterpretResult vm_run_dispatch(void) {
         }
 
         vm_set_register_safe(dst, payload->elements[fieldIndex]);
+        DISPATCH();
+    }
+
+    LABEL_OP_STRING_INDEX_R: {
+        uint8_t dst = READ_BYTE();
+        uint8_t string_reg = READ_BYTE();
+        uint8_t index_reg = READ_BYTE();
+
+        Value string_value = vm_get_register_safe(string_reg);
+        if (!IS_STRING(string_value)) {
+            VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Value is not a string");
+        }
+
+        int index;
+        if (!value_to_index(vm_get_register_safe(index_reg), &index)) {
+            VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "String index must be a non-negative integer");
+        }
+
+        ObjString* source = AS_STRING(string_value);
+        if (!source || index < 0 || index >= source->length) {
+            VM_ERROR_RETURN(ERROR_INDEX, CURRENT_LOCATION(), "String index out of bounds");
+        }
+
+        ObjString* result = NULL;
+        if (source->rope) {
+            result = rope_index_to_string(source->rope, (size_t)index);
+        }
+
+        if (!result) {
+            char buffer[2];
+            buffer[0] = source->chars[index];
+            buffer[1] = '\0';
+            result = allocateString(buffer, 1);
+        }
+
+        vm_set_register_safe(dst, STRING_VAL(result));
         DISPATCH();
     }
 

--- a/src/vm/utils/debug.c
+++ b/src/vm/utils/debug.c
@@ -235,6 +235,14 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return offset + 5;
         }
 
+        case OP_STRING_INDEX_R: {
+            uint8_t dst = chunk->code[offset + 1];
+            uint8_t string_reg = chunk->code[offset + 2];
+            uint8_t index_reg = chunk->code[offset + 3];
+            printf("%-16s R%d, R%d, R%d\n", "STRING_INDEX", dst, string_reg, index_reg);
+            return offset + 4;
+        }
+
         case OP_ARRAY_GET_R: {
             uint8_t dst = chunk->code[offset + 1];
             uint8_t array_reg = chunk->code[offset + 2];

--- a/tests/strings/string_index_basic.orus
+++ b/tests/strings/string_index_basic.orus
@@ -1,0 +1,5 @@
+// Basic string indexing smoke test exercising dedicated opcode.
+text = "rope indexing"
+print("first:", text[0])
+print("middle:", text[5])
+print("last:", text[12])

--- a/tests/strings/string_index_out_of_range.orus
+++ b/tests/strings/string_index_out_of_range.orus
@@ -1,0 +1,9 @@
+// Guard against out-of-range string indexing and ensure runtime error is catchable.
+text = "guard"
+
+try:
+    print(text[10])
+    print("unreachable")
+catch err:
+    print("caught string index error")
+    print(err)

--- a/tests/strings/string_index_substring.orus
+++ b/tests/strings/string_index_substring.orus
@@ -1,0 +1,11 @@
+// Build a substring via incremental concatenation and ensure indexing works on the derived rope leaf.
+source = "substring demo"
+mut part = ""
+mut i = 0
+while i < 6:
+    part = part + source[3 + i]
+    i = i + 1
+
+print("slice:", part)
+print("slice first:", part[0])
+print("slice mid:", part[2])


### PR DESCRIPTION
## Summary
- add an `isStringIndex` flag to AST/typed nodes and mark it during type inference
- emit a new `OP_STRING_INDEX_R` opcode and implement VM handlers that slice rope data without flattening
- cover positive, guarded, and derived substring indexing in new VM-level string tests

## Testing
- `make`
- `./orus_debug tests/strings/string_index_basic.orus`
- `./orus_debug tests/strings/string_index_out_of_range.orus`
- `./orus_debug tests/strings/string_index_substring.orus`

------
https://chatgpt.com/codex/tasks/task_e_68d67230050c8325b1db26a04e56fd68