### PR TITLE
Fix goto dispatch string indexing handlers

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -550,6 +550,7 @@ typedef enum {
     OP_CONCAT_R,
     OP_TO_STRING_R,
     OP_STRING_INDEX_R,
+    OP_STRING_GET_R,
 
     // Array operations
     OP_MAKE_ARRAY_R,  // dst, start_reg, count


### PR DESCRIPTION
## Summary
- add the missing OP_STRING_GET_R opcode to the VM enum so both dispatchers build
- clean up the goto-threaded string index handler and add a dedicated OP_STRING_GET_R label that matches the switch dispatcher
- remove duplicated statements so the dispatch table compiles again