### PR TITLE
Fix index access type inference merge regression

### DIFF
--- a/src/type/type_inference.c
+++ b/src/type/type_inference.c
@@ -1226,21 +1226,6 @@ Type* algorithm_w(TypeEnv* env, ASTNode* node) {
                 return NULL;
             }
 
-            if (index_type && index_type->kind == TYPE_VAR) {
-                Type* assumed_index = getPrimitiveType(TYPE_I32);
-                if (assumed_index) {
-                    unify(index_type, assumed_index);
-                    index_type = prune(index_type);
-                }
-            }
-
-            if (!is_integer_type(index_type)) {
-                report_type_mismatch(node->indexAccess.index->location, "integer index",
-                                     getTypeName(index_type->kind));
-                set_type_error();
-                return NULL;
-            }
-
             if (array_type && array_type->kind == TYPE_VAR) {
                 Type* element_var = make_var_type(env);
                 if (!element_var) {
@@ -1272,23 +1257,10 @@ Type* algorithm_w(TypeEnv* env, ASTNode* node) {
                 Type* char_type = getPrimitiveType(TYPE_STRING);
                 node->dataType = char_type;
                 return char_type;
-            if (array_type->kind == TYPE_STRING) {
-                node->indexAccess.isStringIndex = true;
-                return getPrimitiveType(TYPE_STRING);
             }
 
-            if (array_type->kind == TYPE_INSTANCE && array_type->info.instance.base &&
-                array_type->info.instance.base->kind == TYPE_STRING) {
-                node->indexAccess.isStringIndex = true;
-                return getPrimitiveType(TYPE_STRING);
-            }
-
-            bool is_string_container = (array_type->kind == TYPE_STRING);
-            bool is_array_container = (array_type->kind == TYPE_ARRAY);
-
-            if (!is_array_container && !is_string_container) {
-                report_type_mismatch(node->indexAccess.array->location,
-                                     "array or string", getTypeName(array_type->kind));
+            if (array_type->kind != TYPE_ARRAY) {
+                report_type_mismatch(node->indexAccess.array->location, "array", getTypeName(array_type->kind));
                 set_type_error();
                 return NULL;
             }
@@ -1298,18 +1270,6 @@ Type* algorithm_w(TypeEnv* env, ASTNode* node) {
                 element_type = getPrimitiveType(TYPE_ANY);
             }
 
-            if (is_string_container) {
-                Type* char_type = getPrimitiveType(TYPE_STRING);
-                node->dataType = char_type;
-                return char_type;
-            }
-
-            node->dataType = element_type;
-            return element_type;
-            Type* element_type = array_type->info.array.elementType;
-            if (!element_type) {
-                element_type = getPrimitiveType(TYPE_ANY);
-            }
             node->dataType = element_type;
             return element_type;
         }


### PR DESCRIPTION
## Summary
- clean up duplicated index access logic introduced by a bad merge
- restore string indexing detection and ensure non-array containers are rejected
- keep element type propagation for arrays unchanged while avoiding local redeclarations
