### PR TITLE
Fix string index detection for fallback array types

### DIFF
--- a/src/compiler/backend/codegen/codegen.c
+++ b/src/compiler/backend/codegen/codegen.c
@@ -2485,40 +2485,41 @@ int compile_expression(CompilerContext* ctx, TypedASTNode* expr) {
                 container_type = array_node->original->dataType;
             }
 
-            TypeKind container_kind = TYPE_UNKNOWN;
-            if (container_type) {
-                container_kind = container_type->kind;
+            Type* resolved_container_type = container_type;
+            if (!resolved_container_type && array_node->original &&
+                array_node->original->dataType) {
+                resolved_container_type = array_node->original->dataType;
             }
 
-            if (container_kind != TYPE_STRING && container_kind != TYPE_ARRAY &&
-                array_node->original &&
+            if (!resolved_container_type && array_node->original &&
                 array_node->original->type == NODE_IDENTIFIER) {
                 const char* ident_name = array_node->original->identifier.name;
                 Symbol* symbol = resolve_symbol(ctx->symbols, ident_name);
                 if (symbol && symbol->type) {
-                    container_kind = symbol->type->kind;
+                    resolved_container_type = symbol->type;
                 }
             }
 
-            if (container_kind != TYPE_STRING && container_kind != TYPE_ARRAY &&
-                array_node->original) {
-                container_kind = fallback_type_kind_from_ast(array_node->original);
-                if (container_kind != TYPE_STRING &&
-                    array_node->original->type == NODE_LITERAL &&
-                    array_node->original->literal.value.type == VAL_STRING) {
-                    container_kind = TYPE_STRING;
-                }
-            }
-
-            uint8_t opcode = (container_kind == TYPE_STRING) ? OP_STRING_GET_R
-                                                             : OP_ARRAY_GET_R;
-
-            set_location_from_node(ctx, expr);
-            emit_byte_to_buffer(ctx->bytecode, opcode);
             bool is_string_index = expr->typed.indexAccess.isStringIndex;
+            if (!is_string_index) {
+                const Type* base_type = resolved_container_type;
+                if (base_type && base_type->kind == TYPE_INSTANCE &&
+                    base_type->info.instance.base) {
+                    base_type = base_type->info.instance.base;
+                }
+
+                if (base_type && base_type->kind == TYPE_STRING) {
+                    is_string_index = true;
+                } else if (!base_type && array_node->original &&
+                           array_node->original->type == NODE_LITERAL &&
+                           array_node->original->literal.value.type == VAL_STRING) {
+                    is_string_index = true;
+                }
+            }
 
             set_location_from_node(ctx, expr);
-            emit_byte_to_buffer(ctx->bytecode, is_string_index ? OP_STRING_INDEX_R : OP_ARRAY_GET_R);
+            emit_byte_to_buffer(ctx->bytecode,
+                                is_string_index ? OP_STRING_INDEX_R : OP_ARRAY_GET_R);
             emit_byte_to_buffer(ctx->bytecode, result_reg);
             emit_byte_to_buffer(ctx->bytecode, array_reg);
             emit_byte_to_buffer(ctx->bytecode, index_reg);


### PR DESCRIPTION
## Summary
- avoid using fallback element kinds when determining string index emission
- detect string instances via resolved container types or literal containers