### PR TITLE
Implement input builtin opcode and smoke test

### DIFF
--- a/include/runtime/builtins.h
+++ b/include/runtime/builtins.h
@@ -19,11 +19,22 @@
 /**
  * Print the provided values to standard output.
  *
- * @param args   Array of values to print.
- * @param count  Number of values in the array.
+ * @param args    Array of values to print.
+ * @param count   Number of values in the array.
  * @param newline When true, append a newline after printing.
  */
 void builtin_print(Value* args, int count, bool newline);
+
+/**
+ * Read a line of input from standard input, optionally displaying a prompt.
+ *
+ * @param args      Optional array containing a single prompt value.
+ * @param count     Number of values provided in {@code args} (0 or 1).
+ * @param out_value Receives the captured input as a string value.
+ * @return true on success, false if input was unavailable or invalid arguments
+ *         were supplied.
+ */
+bool builtin_input(Value* args, int count, Value* out_value);
 
 /**
  * Push a value onto an array, growing the backing store when needed.
@@ -44,11 +55,11 @@ bool builtin_array_push(Value array_value, Value element);
 bool builtin_array_pop(Value array_value, Value* out_value);
 
 /**
- * Obtain a monotonic timestamp in milliseconds.
+ * Obtain a monotonic timestamp in seconds.
  *
  * The epoch is unspecified but monotonically increasing for the
  * duration of the process.
  */
-double builtin_time_stamp();
+double builtin_time_stamp(void);
 
 #endif // ORUS_BUILTINS_H

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -609,6 +609,7 @@ typedef enum {
     OP_CLOSE_UPVALUE_R, // local_reg (close upvalue pointing to this local)
 
     // I/O
+    OP_INPUT_R,           // dst_reg, arg_count, prompt_reg
     OP_PRINT_MULTI_R,     // first_reg, count, newline_flag
     OP_PRINT_R,           // reg
     OP_PRINT_NO_NL_R,     // reg

--- a/include/vm/vm_opcode_handlers.h
+++ b/include/vm/vm_opcode_handlers.h
@@ -85,6 +85,7 @@ void handle_move_f64(void);
 void handle_print(void);
 void handle_print_multi(void);
 void handle_print_no_nl(void);
+void handle_input(void);
 void handle_halt(void);
 void handle_time_stamp(void);
 

--- a/makefile
+++ b/makefile
@@ -137,7 +137,7 @@ COMPILER_BACKEND_SRCS = $(SRCDIR)/compiler/backend/typed_ast_visualizer.c $(SRCD
 
 # Combined simplified compiler sources  
 COMPILER_SRCS = $(COMPILER_FRONTEND_SRCS) $(COMPILER_BACKEND_SRCS) $(SRCDIR)/compiler/typed_ast.c $(SRCDIR)/debug/debug_config.c
-VM_SRCS = $(SRCDIR)/vm/core/vm_core.c $(SRCDIR)/vm/core/vm_tagged_union.c $(SRCDIR)/vm/runtime/vm.c $(SRCDIR)/vm/runtime/vm_loop_fastpaths.c $(SRCDIR)/vm/core/vm_memory.c $(SRCDIR)/vm/utils/debug.c $(SRCDIR)/vm/runtime/builtins.c $(SRCDIR)/vm/operations/vm_arithmetic.c $(SRCDIR)/vm/operations/vm_control_flow.c $(SRCDIR)/vm/operations/vm_typed_ops.c $(SRCDIR)/vm/operations/vm_string_ops.c $(SRCDIR)/vm/operations/vm_comparison.c $(SRCDIR)/vm/dispatch/vm_dispatch_switch.c $(SRCDIR)/vm/dispatch/vm_dispatch_goto.c $(SRCDIR)/vm/core/vm_validation.c $(SRCDIR)/vm/register_file.c $(SRCDIR)/vm/spill_manager.c $(SRCDIR)/vm/module_manager.c $(SRCDIR)/vm/register_cache.c $(SRCDIR)/vm/profiling/vm_profiling.c $(SRCDIR)/vm/vm_config.c $(SRCDIR)/type/type_representation.c $(SRCDIR)/type/type_inference.c $(SRCDIR)/errors/infrastructure/error_infrastructure.c $(SRCDIR)/errors/core/error_base.c $(SRCDIR)/errors/features/type_errors.c $(SRCDIR)/errors/features/variable_errors.c $(SRCDIR)/errors/features/control_flow_errors.c $(SRCDIR)/config/config.c $(SRCDIR)/internal/logging.c
+VM_SRCS = $(SRCDIR)/vm/core/vm_core.c $(SRCDIR)/vm/core/vm_tagged_union.c $(SRCDIR)/vm/runtime/vm.c $(SRCDIR)/vm/runtime/vm_loop_fastpaths.c $(SRCDIR)/vm/core/vm_memory.c $(SRCDIR)/vm/utils/debug.c $(SRCDIR)/vm/runtime/builtin_print.c $(SRCDIR)/vm/runtime/builtin_input.c $(SRCDIR)/vm/runtime/builtin_array_push.c $(SRCDIR)/vm/runtime/builtin_array_pop.c $(SRCDIR)/vm/runtime/builtin_time_stamp.c $(SRCDIR)/vm/operations/vm_arithmetic.c $(SRCDIR)/vm/operations/vm_control_flow.c $(SRCDIR)/vm/operations/vm_typed_ops.c $(SRCDIR)/vm/operations/vm_string_ops.c $(SRCDIR)/vm/operations/vm_comparison.c $(SRCDIR)/vm/dispatch/vm_dispatch_switch.c $(SRCDIR)/vm/dispatch/vm_dispatch_goto.c $(SRCDIR)/vm/core/vm_validation.c $(SRCDIR)/vm/register_file.c $(SRCDIR)/vm/spill_manager.c $(SRCDIR)/vm/module_manager.c $(SRCDIR)/vm/register_cache.c $(SRCDIR)/vm/profiling/vm_profiling.c $(SRCDIR)/vm/vm_config.c $(SRCDIR)/type/type_representation.c $(SRCDIR)/type/type_inference.c $(SRCDIR)/errors/infrastructure/error_infrastructure.c $(SRCDIR)/errors/core/error_base.c $(SRCDIR)/errors/features/type_errors.c $(SRCDIR)/errors/features/variable_errors.c $(SRCDIR)/errors/features/control_flow_errors.c $(SRCDIR)/config/config.c $(SRCDIR)/internal/logging.c
 REPL_SRC = $(SRCDIR)/repl.c
 MAIN_SRC = $(SRCDIR)/main.c
 
@@ -166,7 +166,6 @@ SCOPE_TRACKING_TEST_BIN = $(BUILDDIR)/tests/test_scope_tracking
 PEEPHOLE_TEST_BIN = $(BUILDDIR)/tests/test_constant_propagation
 LICM_METADATA_TEST_BIN = $(BUILDDIR)/tests/test_licm_typed_metadata
 TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
-
 .PHONY: all clean test unit-test test-control-flow test-loop-telemetry benchmark help debug release profiling analyze install bytecode-jump-tests source-map-tests scope-tracking-tests peephole-tests cli-smoke-tests licm-metadata-tests tagged-union-tests test-optimizer wasm
 
 all: build-info $(ORUS)

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -2245,6 +2245,11 @@ InterpretResult vm_run_dispatch(void) {
                 }
 
                 // I/O operations
+                case OP_INPUT_R: {
+                    handle_input();
+                    break;
+                }
+
                 case OP_PRINT_MULTI_R: {
                     handle_print_multi();
                     break;

--- a/src/vm/handlers/vm_memory_handlers.c
+++ b/src/vm/handlers/vm_memory_handlers.c
@@ -403,6 +403,34 @@ void handle_move_f64(void) {
 
 // ====== Print Operation Handlers ======
 
+void handle_input(void) {
+    uint8_t dst = READ_BYTE();
+    uint8_t arg_count = READ_BYTE();
+    uint8_t prompt_reg = READ_BYTE();
+
+    if (arg_count > 1) {
+        SrcLocation loc = {vm.filePath, vm.currentLine, vm.currentColumn};
+        runtimeError(ERROR_ARGUMENT, loc, "input() accepts at most one argument");
+        return;
+    }
+
+    Value args_storage[1];
+    Value* args_ptr = NULL;
+    if (arg_count == 1) {
+        args_storage[0] = vm_get_register_safe(prompt_reg);
+        args_ptr = args_storage;
+    }
+
+    Value result;
+    if (!builtin_input(args_ptr, (int)arg_count, &result)) {
+        SrcLocation loc = {vm.filePath, vm.currentLine, vm.currentColumn};
+        runtimeError(ERROR_EOF, loc, "input() reached end of file");
+        return;
+    }
+
+    vm_set_register_safe(dst, result);
+}
+
 void handle_print(void) {
     uint8_t reg = READ_BYTE();
     Value temp_value = vm_get_register_safe(reg);

--- a/src/vm/runtime/builtin_array_pop.c
+++ b/src/vm/runtime/builtin_array_pop.c
@@ -1,0 +1,19 @@
+/*
+ * Orus Language Project
+ * ---------------------------------------------------------------------------
+ * File: src/vm/runtime/builtin_array_pop.c
+ * Author: Jordy Orel KONDA
+ * Description: Implements the builtin routine to pop values from arrays.
+ */
+
+#include "runtime/builtins.h"
+#include "runtime/memory.h"
+
+bool builtin_array_pop(Value array_value, Value* out_value) {
+    if (!IS_ARRAY(array_value)) {
+        return false;
+    }
+
+    ObjArray* array = AS_ARRAY(array_value);
+    return arrayPop(array, out_value);
+}

--- a/src/vm/runtime/builtin_array_push.c
+++ b/src/vm/runtime/builtin_array_push.c
@@ -1,0 +1,19 @@
+/*
+ * Orus Language Project
+ * ---------------------------------------------------------------------------
+ * File: src/vm/runtime/builtin_array_push.c
+ * Author: Jordy Orel KONDA
+ * Description: Implements the builtin routine to append values to arrays.
+ */
+
+#include "runtime/builtins.h"
+#include "runtime/memory.h"
+
+bool builtin_array_push(Value array_value, Value element) {
+    if (!IS_ARRAY(array_value)) {
+        return false;
+    }
+
+    ObjArray* array = AS_ARRAY(array_value);
+    return arrayPush(array, element);
+}

--- a/src/vm/runtime/builtin_time_stamp.c
+++ b/src/vm/runtime/builtin_time_stamp.c
@@ -1,0 +1,60 @@
+/*
+ * Orus Language Project
+ * ---------------------------------------------------------------------------
+ * File: src/vm/runtime/builtin_time_stamp.c
+ * Author: Jordy Orel KONDA
+ * Description: Provides a cross-platform monotonic timestamp builtin.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+#include "runtime/builtins.h"
+
+#include <stdint.h>
+#include <time.h>
+
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#endif
+
+#ifdef __APPLE__
+static uint64_t timebase_numer = 0;
+static uint64_t timebase_denom = 0;
+static bool timebase_initialized = false;
+
+static void init_timebase() {
+    if (!timebase_initialized) {
+        mach_timebase_info_data_t info;
+        mach_timebase_info(&info);
+        timebase_numer = info.numer;
+        timebase_denom = info.denom;
+        timebase_initialized = true;
+    }
+}
+#endif
+
+double builtin_time_stamp(void) {
+#ifdef __APPLE__
+    init_timebase();
+    uint64_t abs_time = mach_absolute_time();
+    uint64_t nanoseconds = (abs_time * timebase_numer) / timebase_denom;
+    return (double)nanoseconds / 1e9;
+#elif defined(__linux__)
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+        return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
+    }
+    return 0.0;
+#elif defined(_WIN32)
+    static LARGE_INTEGER frequency = {0};
+    if (frequency.QuadPart == 0) {
+        QueryPerformanceFrequency(&frequency);
+    }
+    LARGE_INTEGER counter;
+    QueryPerformanceCounter(&counter);
+    return (double)counter.QuadPart / (double)frequency.QuadPart;
+#else
+    return (double)clock() / (double)CLOCKS_PER_SEC;
+#endif
+}

--- a/src/vm/utils/debug.c
+++ b/src/vm/utils/debug.c
@@ -179,6 +179,14 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return offset + 4;
         }
 
+        case OP_INPUT_R: {
+            uint8_t dst = chunk->code[offset + 1];
+            uint8_t arg_count = chunk->code[offset + 2];
+            uint8_t prompt_reg = chunk->code[offset + 3];
+            printf("%-16s R%d, args=%d, prompt_reg=R%d\n", "INPUT", dst, arg_count, prompt_reg);
+            return offset + 4;
+        }
+
         case OP_PRINT_MULTI_R: {
             uint8_t first = chunk->code[offset + 1];
             uint8_t count = chunk->code[offset + 2];

--- a/tests/io/input_prompt_echo.orus
+++ b/tests/io/input_prompt_echo.orus
@@ -1,0 +1,10 @@
+prompt = "Prompt> "
+first = input(prompt)
+second = input()
+
+print("First:" + first)
+
+if second == "":
+    print("Second:<empty>")
+else:
+    print("Second:" + second)

--- a/tests/unit/test_builtin_input.c
+++ b/tests/unit/test_builtin_input.c
@@ -1,0 +1,306 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "runtime/builtins.h"
+#include "runtime/memory.h"
+
+#define ASSERT_TRUE(cond, message)                                                         \
+    do {                                                                                   \
+        if (!(cond)) {                                                                     \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", message, __FILE__, __LINE__); \
+            return false;                                                                  \
+        }                                                                                  \
+    } while (0)
+
+static bool redirect_stdin_to_buffer(const char* contents, int* saved_fd, FILE** temp_file) {
+    if (!saved_fd || !temp_file) {
+        return false;
+    }
+
+    FILE* temp = tmpfile();
+    if (!temp) {
+        return false;
+    }
+
+    size_t length = contents ? strlen(contents) : 0;
+    if (length > 0) {
+        if (fwrite(contents, 1, length, temp) != length) {
+            fclose(temp);
+            return false;
+        }
+    }
+    rewind(temp);
+
+    int original_fd = dup(fileno(stdin));
+    if (original_fd == -1) {
+        fclose(temp);
+        return false;
+    }
+
+    if (dup2(fileno(temp), fileno(stdin)) == -1) {
+        close(original_fd);
+        fclose(temp);
+        return false;
+    }
+
+    clearerr(stdin);
+
+    *saved_fd = original_fd;
+    *temp_file = temp;
+    return true;
+}
+
+static void restore_stdin_from_buffer(int saved_fd, FILE* temp_file) {
+    if (saved_fd >= 0) {
+        dup2(saved_fd, fileno(stdin));
+        close(saved_fd);
+        clearerr(stdin);
+    }
+    if (temp_file) {
+        fclose(temp_file);
+    }
+}
+
+static bool redirect_stdout_to_capture(int* saved_fd, FILE** capture_file) {
+    if (!saved_fd || !capture_file) {
+        return false;
+    }
+
+    FILE* capture = tmpfile();
+    if (!capture) {
+        return false;
+    }
+
+    int original_fd = dup(fileno(stdout));
+    if (original_fd == -1) {
+        fclose(capture);
+        return false;
+    }
+
+    if (dup2(fileno(capture), fileno(stdout)) == -1) {
+        close(original_fd);
+        fclose(capture);
+        return false;
+    }
+
+    clearerr(stdout);
+
+    *saved_fd = original_fd;
+    *capture_file = capture;
+    return true;
+}
+
+static void restore_stdout_from_capture(int saved_fd, FILE* capture_file) {
+    if (saved_fd >= 0) {
+        fflush(stdout);
+        dup2(saved_fd, fileno(stdout));
+        close(saved_fd);
+        clearerr(stdout);
+    }
+    if (capture_file) {
+        fclose(capture_file);
+    }
+}
+
+static bool read_capture(FILE* capture_file, char* buffer, size_t buffer_size, size_t* out_length) {
+    if (!capture_file || !buffer || buffer_size == 0) {
+        return false;
+    }
+
+    long current = ftell(capture_file);
+    if (current < 0) {
+        return false;
+    }
+
+    if (fseek(capture_file, 0, SEEK_SET) != 0) {
+        return false;
+    }
+
+    size_t read = fread(buffer, 1, buffer_size - 1, capture_file);
+    buffer[read] = '\0';
+
+    if (out_length) {
+        *out_length = read;
+    }
+
+    if (fseek(capture_file, current, SEEK_SET) != 0) {
+        return false;
+    }
+
+    return true;
+}
+
+static bool test_builtin_input_reads_line_without_prompt(void) {
+    initVM();
+
+    int saved_stdin_fd = -1;
+    FILE* temp_stdin = NULL;
+    if (!redirect_stdin_to_buffer("hello world\n", &saved_stdin_fd, &temp_stdin)) {
+        freeVM();
+        return false;
+    }
+
+    Value out = BOOL_VAL(false);
+    bool ok = builtin_input(NULL, 0, &out);
+
+    restore_stdin_from_buffer(saved_stdin_fd, temp_stdin);
+
+    if (!ok) {
+        freeVM();
+        return false;
+    }
+
+    ASSERT_TRUE(IS_STRING(out), "builtin_input should produce a string value");
+    ObjString* str = AS_STRING(out);
+    ASSERT_TRUE(str != NULL, "Resulting string should be non-null");
+    ASSERT_TRUE(str->length == 11, "Input should capture characters up to newline");
+    ASSERT_TRUE(strncmp(str->chars, "hello world", (size_t)str->length) == 0,
+                "Captured text should match input");
+
+    freeVM();
+    return true;
+}
+
+static bool test_builtin_input_allows_empty_line(void) {
+    initVM();
+
+    int saved_stdin_fd = -1;
+    FILE* temp_stdin = NULL;
+    if (!redirect_stdin_to_buffer("\n", &saved_stdin_fd, &temp_stdin)) {
+        freeVM();
+        return false;
+    }
+
+    Value out = BOOL_VAL(true);
+    bool ok = builtin_input(NULL, 0, &out);
+
+    restore_stdin_from_buffer(saved_stdin_fd, temp_stdin);
+
+    if (!ok) {
+        freeVM();
+        return false;
+    }
+
+    ASSERT_TRUE(IS_STRING(out), "Empty line should still produce a string");
+    ObjString* str = AS_STRING(out);
+    ASSERT_TRUE(str != NULL, "Resulting string should be allocated");
+    ASSERT_TRUE(str->length == 0, "Empty line should result in zero-length string");
+
+    freeVM();
+    return true;
+}
+
+static bool test_builtin_input_returns_false_on_eof(void) {
+    initVM();
+
+    int saved_stdin_fd = -1;
+    FILE* temp_stdin = NULL;
+    if (!redirect_stdin_to_buffer("", &saved_stdin_fd, &temp_stdin)) {
+        freeVM();
+        return false;
+    }
+
+    Value sentinel = BOOL_VAL(true);
+    bool ok = builtin_input(NULL, 0, &sentinel);
+
+    restore_stdin_from_buffer(saved_stdin_fd, temp_stdin);
+
+    if (ok) {
+        freeVM();
+        return false;
+    }
+
+    ASSERT_TRUE(IS_BOOL(sentinel) && AS_BOOL(sentinel),
+                "Output value should remain untouched on EOF");
+
+    freeVM();
+    return true;
+}
+
+static bool test_builtin_input_writes_prompt(void) {
+    initVM();
+
+    int saved_stdin_fd = -1;
+    FILE* temp_stdin = NULL;
+    if (!redirect_stdin_to_buffer("value\n", &saved_stdin_fd, &temp_stdin)) {
+        freeVM();
+        return false;
+    }
+
+    int saved_stdout_fd = -1;
+    FILE* capture = NULL;
+    if (!redirect_stdout_to_capture(&saved_stdout_fd, &capture)) {
+        restore_stdin_from_buffer(saved_stdin_fd, temp_stdin);
+        freeVM();
+        return false;
+    }
+
+    Value prompt_args[1];
+    prompt_args[0] = STRING_VAL(allocateString(">>> ", 4));
+
+    Value out = BOOL_VAL(false);
+    bool ok = builtin_input(prompt_args, 1, &out);
+
+    fflush(stdout);
+
+    char buffer[32];
+    size_t written = 0;
+    bool captured = read_capture(capture, buffer, sizeof(buffer), &written);
+
+    restore_stdout_from_capture(saved_stdout_fd, capture);
+    restore_stdin_from_buffer(saved_stdin_fd, temp_stdin);
+
+    if (!ok || !captured) {
+        freeVM();
+        return false;
+    }
+
+    ASSERT_TRUE(written == 4, "Prompt output length should match prompt text");
+    ASSERT_TRUE(strncmp(buffer, ">>> ", written) == 0, "Prompt output should match provided string");
+
+    ASSERT_TRUE(IS_STRING(out), "Prompted input should still produce string value");
+    ObjString* str = AS_STRING(out);
+    ASSERT_TRUE(str != NULL, "Captured string should be allocated");
+    ASSERT_TRUE(str->length == 5, "Captured input should exclude newline");
+    ASSERT_TRUE(strncmp(str->chars, "value", (size_t)str->length) == 0,
+                "Captured input should match provided line");
+
+    freeVM();
+    return true;
+}
+
+int main(void) {
+    bool (*tests[])(void) = {
+        test_builtin_input_reads_line_without_prompt,
+        test_builtin_input_allows_empty_line,
+        test_builtin_input_returns_false_on_eof,
+        test_builtin_input_writes_prompt,
+    };
+
+    const char* names[] = {
+        "builtin_input captures characters before newline",
+        "builtin_input returns empty string for blank line",
+        "builtin_input signals failure on EOF",
+        "builtin_input writes prompt and captures response",
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; i++) {
+        if (tests[i]()) {
+            printf("[PASS] %s\n", names[i]);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", names[i]);
+            return 1;
+        }
+    }
+
+    printf("%d/%d builtin input tests passed\n", passed, total);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expose a new OP_INPUT_R opcode and runtime handler so the VM can call the Python-style input builtin
- teach the code generator/type inference about input(), including optional prompt handling
- add a CLI smoke test case plus a new input_prompt_echo.orus program to exercise stdin behavior