### PR TITLE
Allow enum redeclaration to replace builtin variants

### DIFF
--- a/docs/COMPLETE_ORUS_TUTORIAL.md
+++ b/docs/COMPLETE_ORUS_TUTORIAL.md
@@ -279,7 +279,7 @@ match success:
 
 ```orus
 label: string = match failure:
-    Result.Ok(value) -> "ok: " + (value as string)
+    Result.Ok(value) -> "ok: " + ((value as i32) as string)
     Result.Err(reason) -> "error: " + reason
 ```
 
@@ -292,6 +292,9 @@ if flag matches Flag.On:
 ```
 
 The `matches` keyword provides a readable equality check—code generation treats it like `==`.
+
+Until generics land, payload bindings default to the `any` type. Cast the binding to the variant's payload type before chaining
+another conversion (like `as string`) to satisfy the checker.
 
 ## 11. Error Handling
 - `try:` introduces protected code. `catch name:` (or `catch:`) handles thrown values. Both accept either a single statement on the same line or an indented block.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -262,7 +262,7 @@ enum Result:
 ```orus
 fn describe(outcome: Result) -> string:
     return match outcome:
-        Result.Ok(value) -> "ok: " + (value as string)
+        Result.Ok(value) -> "ok: " + ((value as i32) as string)
         Result.Err(reason) -> "error: " + reason
 
 flag = Flag.Off
@@ -271,6 +271,8 @@ if flag matches Flag.On:
 ```
 
 - Payload bindings are available inside the matched arm. `_` ignores fields.
+- Payload bindings currently have the `any` type until they are explicitly cast. Cast them to the declared payload type before
+  performing additional conversions such as `as string`.
 
 ### Error Handling
 - `try:` introduces a protected block. `catch name:` (or `catch:`) must follow immediately and handles thrown values.


### PR DESCRIPTION
## Summary
- always allocate variant metadata for enum declarations and reuse it when updating an existing enum
- replace the stored variant list when an enum is redeclared so builtin definitions (like Result) pick up user-specified payload types