### PR TITLE
Default macOS arm64 release builds to portable mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ make clean
 make help
 ```
 
+> **Apple Silicon note:** On macOS arm64 the build system now defaults to the
+> portable configuration when producing `orus` to avoid Apple Clang
+> mis-optimizations that could stop programs mid-run. Once you've confirmed your
+> toolchain is stable you can opt back into the tuned binary with
+> `make release PORTABLE=0`.
+
 **Build Features:**
 - **Release**: Maximum optimization (-O3, LTO, fast-math) for production use
 - **Debug**: Full debugging symbols (-O0, -g3) with assertions for development

--- a/makefile
+++ b/makefile
@@ -15,6 +15,26 @@ BASE_CFLAGS = -Wall -Wextra -std=c11
 
 # Architecture-specific optimizations
 # Set PORTABLE=1 to build without aggressive CPU-specific tuning (safer on some macOS setups)
+# On Apple Silicon we default to the portable configuration because the aggressive
+# cpu-specific flags have been observed to cause truncated execution when Apple
+# Clang mis-optimizes hot dispatch loops. Users can opt back in with PORTABLE=0
+# once they have verified their toolchain.
+
+# Determine the default portability mode only if the caller did not specify it.
+ifeq ($(origin PORTABLE), undefined)
+    ifeq ($(UNAME_S),Darwin)
+        ifeq ($(UNAME_M),arm64)
+            PORTABLE := 1
+            PORTABLE_AUTO_REASON := " (auto-enabled for macOS arm64 to avoid Apple Clang mis-optimizations)"
+        endif
+    endif
+endif
+
+PORTABLE ?= 0
+
+PORTABLE_DESC = $(if $(filter 1,$(PORTABLE)),enabled,disabled)
+PORTABLE_NOTE = $(if $(and $(filter 1,$(PORTABLE)),$(PORTABLE_AUTO_REASON)),$(PORTABLE_AUTO_REASON),)
+
 ARCH_FLAGS =
 ARCH_DEFINES =
 
@@ -176,6 +196,7 @@ build-info:
 	@echo "Profile: $(PROFILE_DESC)"
 	@echo "Target: $(ORUS)"
 	@echo "Architecture: $(UNAME_S) $(UNAME_M)"
+	@echo "Portable mode: $(PORTABLE_DESC)$(PORTABLE_NOTE)"
 	@echo ""
 
 # Profile-specific build targets


### PR DESCRIPTION
## Summary
- default macOS arm64 builds to the portable profile to avoid release binaries exiting early when Apple Clang mis-optimizes tuned flags
- surface the active portable mode in build-info output and document the new default in the README with guidance for opting back into tuned builds