### PR TITLE
Prevent double initialization of string intern table

### DIFF
--- a/src/vm/core/vm_core.c
+++ b/src/vm/core/vm_core.c
@@ -38,7 +38,14 @@ void initVM(void) {
     
     // printf("[VM_CORE_TRACE] About to call init_string_table()\n");
     // fflush(stdout);
-    init_string_table(&globalStringTable);
+    if (globalStringTable.interned == NULL) {
+        init_string_table(&globalStringTable);
+    } else if (globalStringTable.threshold == 0) {
+        // The table may have been pre-initialized by the caller (e.g. main.c)
+        // to guarantee cleanup on early exits. Avoid reinitializing it here to
+        // prevent leaking the previously allocated hashmap backing store.
+        globalStringTable.threshold = 32;
+    }
     // printf("[VM_CORE_TRACE] init_string_table() completed\n");
     // fflush(stdout);
 

--- a/src/vm/core/vm_memory.c
+++ b/src/vm/core/vm_memory.c
@@ -80,8 +80,9 @@ static void* allocateObject(size_t size, ObjType type) {
     } else {
         object = (Obj*)malloc(size);
         if (!object) exit(1);
-        vm.bytesAllocated += size;
     }
+
+    vm.bytesAllocated += size;
     object->type = type;
     object->isMarked = false;
     object->next = vm.objects;


### PR DESCRIPTION
## Summary
- guard the VM startup path from reinitializing the global string table so the freelist-backed hashmap is not leaked when main pre-initializes it