### PR TITLE
Implement typed loop branch cache fast path

### DIFF
--- a/include/compiler/compiler.h
+++ b/include/compiler/compiler.h
@@ -124,6 +124,8 @@ typedef struct CompilerContext {
     int current_loop_start;            // Bytecode offset of current loop start
     int current_loop_end;              // Bytecode offset of current loop end
     int current_loop_continue;         // Bytecode offset for continue statements (for for-loops)
+    uint16_t current_loop_id;          // Active loop identifier for typed branch cache
+    uint16_t next_loop_id;             // Monotonic loop identifier allocator
     int* break_statements;             // Array of break statement bytecode offsets to patch
     int break_count;                   // Number of break statements in current loop
     int break_capacity;                // Capacity of break_statements array

--- a/include/compiler/scope_stack.h
+++ b/include/compiler/scope_stack.h
@@ -14,6 +14,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 struct SymbolTable;
 
@@ -29,6 +30,9 @@ typedef struct ScopeFrame {
     int start_offset;
     int end_offset;
     int continue_offset;
+
+    uint16_t loop_id;
+    uint16_t prev_loop_id;
 
     int prev_loop_start;
     int prev_loop_end;

--- a/include/vm/vm_comparison.h
+++ b/include/vm/vm_comparison.h
@@ -83,6 +83,7 @@ static inline void vm_update_typed_register(uint16_t id, Value value) {
     if (new_type == REG_TYPE_NONE) {
         uint8_t old_type = vm.typed_regs.reg_types[id];
         if (old_type != REG_TYPE_NONE && old_type != REG_TYPE_HEAP) {
+            vm_branch_cache_bump_generation(id);
             vm_clear_typed_register_slot(id, old_type);
         }
         vm.typed_regs.reg_types[id] = REG_TYPE_HEAP;
@@ -92,6 +93,7 @@ static inline void vm_update_typed_register(uint16_t id, Value value) {
 
     uint8_t old_type = vm.typed_regs.reg_types[id];
     if (old_type != new_type) {
+        vm_branch_cache_bump_generation(id);
         vm_clear_typed_register_slot(id, old_type);
     }
 
@@ -392,6 +394,9 @@ static inline void vm_cache_f64_typed(uint16_t id, double value) {
 
 static inline void vm_cache_bool_typed(uint16_t id, bool value) {
     if (vm_typed_reg_in_range(id)) {
+        if (vm.typed_regs.reg_types[id] != REG_TYPE_BOOL) {
+            vm_branch_cache_bump_generation(id);
+        }
         vm.typed_regs.bool_regs[id] = value;
         vm.typed_regs.reg_types[id] = REG_TYPE_BOOL;
         vm.typed_regs.dirty[id] = false;

--- a/include/vm/vm_loop_fastpaths.h
+++ b/include/vm/vm_loop_fastpaths.h
@@ -68,6 +68,10 @@ VMBoolBranchResult vm_try_branch_bool_fast_cold(uint16_t reg, bool* out_value);
 bool vm_exec_inc_i32_checked(uint16_t reg);
 bool vm_exec_monotonic_inc_cmp_i32(uint16_t counter_reg, uint16_t limit_reg, bool* out_should_continue);
 bool vm_typed_iterator_next(uint16_t reg, Value* out_value);
+void vm_branch_cache_reset(void);
+void vm_branch_cache_bump_generation(uint16_t reg);
+bool vm_branch_cache_try_get(uint16_t loop_id, uint16_t reg, bool* out_value);
+void vm_branch_cache_store(uint16_t loop_id, uint16_t reg);
 
 #ifdef __cplusplus
 }

--- a/src/compiler/backend/compiler.c
+++ b/src/compiler/backend/compiler.c
@@ -272,6 +272,8 @@ static inline int determine_prefix_size(uint8_t opcode) {
     switch (opcode) {
         case OP_JUMP_IF_NOT_I32_TYPED:
             return 3;  // opcode + left_reg + right_reg
+        case OP_BRANCH_TYPED:
+            return 4;  // opcode + loop_id_hi + loop_id_lo + predicate register
         case OP_JUMP_IF_NOT_R:
         case OP_JUMP_IF_R:
         case OP_TRY_BEGIN:
@@ -356,6 +358,7 @@ bool patch_jump(BytecodeBuffer* buffer, int patch_index, int target_offset) {
         case OP_JUMP_IF_R:
         case OP_TRY_BEGIN:
         case OP_JUMP_IF_NOT_I32_TYPED:
+        case OP_BRANCH_TYPED:
         {
             relative = target_offset - next_ip;
             if (relative < 0 || relative > 0xFFFF) {
@@ -479,6 +482,8 @@ CompilerContext* init_compiler_context(TypedASTNode* typed_ast) {
     ctx->current_loop_start = -1;     // No current loop
     ctx->current_loop_end = -1;       // No current loop
     ctx->current_loop_continue = -1;  // No current loop
+    ctx->current_loop_id = 0;
+    ctx->next_loop_id = 1;
     ctx->break_statements = NULL;     // No break statements yet
     ctx->break_count = 0;
     ctx->break_capacity = 0;

--- a/src/compiler/backend/scope_stack.c
+++ b/src/compiler/backend/scope_stack.c
@@ -74,6 +74,8 @@ ScopeFrame* scope_stack_push(ScopeStack* stack, ScopeKind kind) {
     frame->start_offset = -1;
     frame->end_offset = -1;
     frame->continue_offset = -1;
+    frame->loop_id = 0;
+    frame->prev_loop_id = 0;
     frame->prev_loop_start = -1;
     frame->prev_loop_end = -1;
     frame->prev_loop_continue = -1;

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -2744,6 +2744,16 @@ InterpretResult vm_run_dispatch(void) {
                     break;
                 }
 
+                case OP_BRANCH_TYPED: {
+                    uint16_t loop_id = READ_SHORT();
+                    uint8_t reg = READ_BYTE();
+                    uint16_t offset = READ_SHORT();
+                    if (!CF_BRANCH_TYPED(loop_id, reg, offset)) {
+                        RETURN(INTERPRET_RUNTIME_ERROR);
+                    }
+                    break;
+                }
+
                 // Typed arithmetic operations for maximum performance (bypass Value boxing)
 #if ORUS_VM_ENABLE_TYPED_OPS
                 case OP_ADD_I32_TYPED: {

--- a/src/vm/runtime/vm.c
+++ b/src/vm/runtime/vm.c
@@ -38,6 +38,7 @@
 #include "runtime/memory.h"
 #include "runtime/builtins.h"
 #include "tools/debug.h"
+#include "vm/vm_loop_fastpaths.h"
 #include "internal/error_reporting.h"
 #include "config/config.h"
 #include <time.h>
@@ -938,6 +939,7 @@ cleanup:
 
 void vm_reset_loop_trace(void) {
     memset(&vm.profile.loop_trace, 0, sizeof(LoopTraceCounters));
+    vm_branch_cache_reset();
 }
 
 void vm_dump_loop_trace(FILE* out) {
@@ -951,7 +953,8 @@ void vm_dump_loop_trace(FILE* out) {
             " branch_fast_hits=%" PRIu64 " branch_fast_misses=%" PRIu64
             " inc_overflow_bailouts=%" PRIu64 " inc_type_instability=%" PRIu64
             " iter_alloc_saved=%" PRIu64 " iter_fallbacks=%" PRIu64
-            " licm_guard_fusions=%" PRIu64 " licm_guard_demotions=%" PRIu64 "\n",
+            " licm_guard_fusions=%" PRIu64 " licm_guard_demotions=%" PRIu64
+            " branch_cache_hits=%" PRIu64 " branch_cache_misses=%" PRIu64 "\n",
             (uint64_t)vm.profile.loop_trace.typed_hit,
             (uint64_t)vm.profile.loop_trace.typed_miss,
             (uint64_t)vm.profile.loop_trace.boxed_type_mismatch,
@@ -963,5 +966,7 @@ void vm_dump_loop_trace(FILE* out) {
             (uint64_t)vm.profile.loop_trace.iter_allocations_saved,
             (uint64_t)vm.profile.loop_trace.iter_fallbacks,
             (uint64_t)vm.profile.loop_trace.licm_guard_fusions,
-            (uint64_t)vm.profile.loop_trace.licm_guard_demotions);
+            (uint64_t)vm.profile.loop_trace.licm_guard_demotions,
+            (uint64_t)vm.profile.loop_trace.branch_cache_hits,
+            (uint64_t)vm.profile.loop_trace.branch_cache_misses);
 }

--- a/src/vm/utils/debug.c
+++ b/src/vm/utils/debug.c
@@ -386,6 +386,14 @@ int disassembleInstruction(Chunk* chunk, int offset) {
             return offset + 2;
         }
 
+        case OP_BRANCH_TYPED: {
+            uint16_t loop_id = (uint16_t)((chunk->code[offset + 1] << 8) | chunk->code[offset + 2]);
+            uint8_t predicate = chunk->code[offset + 3];
+            uint16_t rel = (uint16_t)((chunk->code[offset + 4] << 8) | chunk->code[offset + 5]);
+            printf("%-16s loop=%u R%d, +%u\n", "BRANCH_TYPED", loop_id, predicate, rel);
+            return offset + 6;
+        }
+
         // Typed operations for performance
         case OP_ADD_I32_TYPED: {
             uint8_t dst = chunk->code[offset + 1];


### PR DESCRIPTION
## Summary
- add a loop-aware branch cache with guard generation tracking and expose its telemetry counters
- introduce the OP_BRANCH_TYPED opcode and update the compiler and dispatchers to use the typed branch cache for loop exits
- refresh the loop roadmap status to note the new infrastructure