### PR TITLE
Ensure typed register writes defer boxing and add regression tests

### DIFF
--- a/include/vm/vm_arithmetic.h
+++ b/include/vm/vm_arithmetic.h
@@ -12,6 +12,7 @@
 #define ORUS_VM_ARITHMETIC_H
 
 #include "../../src/vm/core/vm_internal.h"
+#include "vm/vm_comparison.h"
 #include <math.h>
 
 // These macros implement automatic overflow handling and type promotion
@@ -27,7 +28,7 @@
                        "Integer overflow"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } else { \
-            vm.registers[dst_reg] = I32_VAL(result); \
+            vm_store_i32_typed_hot((dst_reg), result); \
         } \
     } while (0)
 
@@ -40,7 +41,7 @@
                        "Integer overflow"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } else { \
-            vm.registers[dst_reg] = I32_VAL(result); \
+            vm_store_i32_typed_hot((dst_reg), result); \
         } \
     } while (0)
 
@@ -53,7 +54,7 @@
                        "Integer overflow"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } else { \
-            vm.registers[dst_reg] = I32_VAL(result); \
+            vm_store_i32_typed_hot((dst_reg), result); \
         } \
     } while (0)
 
@@ -71,7 +72,7 @@
                        "Integer overflow"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } else { \
-            vm.registers[dst_reg] = I32_VAL(a / b); \
+            vm_store_i32_typed_hot((dst_reg), a / b); \
         } \
     } while (0)
 
@@ -89,7 +90,7 @@
                        "Integer overflow"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } else { \
-            vm.registers[dst_reg] = I32_VAL(a % b); \
+            vm_store_i32_typed_hot((dst_reg), a % b); \
         } \
     } while (0)
 
@@ -102,7 +103,7 @@
                        "Unsigned integer overflow"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } else { \
-            vm.registers[dst_reg] = U32_VAL(result); \
+            vm_store_u32_typed_hot((dst_reg), result); \
         } \
     } while (0)
 
@@ -115,7 +116,7 @@
                        "Unsigned integer underflow"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } else { \
-            vm.registers[dst_reg] = U32_VAL(result); \
+            vm_store_u32_typed_hot((dst_reg), result); \
         } \
     } while (0)
 
@@ -128,7 +129,7 @@
                        "Unsigned integer overflow"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } else { \
-            vm.registers[dst_reg] = U32_VAL(result); \
+            vm_store_u32_typed_hot((dst_reg), result); \
         } \
     } while (0)
 
@@ -140,7 +141,7 @@
                        "Division by zero"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = U32_VAL(a / b); \
+        vm_store_u32_typed_hot((dst_reg), a / b); \
     } while (0)
 
 #define HANDLE_U32_OVERFLOW_MOD(a, b, dst_reg) \
@@ -151,7 +152,7 @@
                        "Division by zero"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = U32_VAL(a % b); \
+        vm_store_u32_typed_hot((dst_reg), a % b); \
     } while (0)
 
 #define HANDLE_I64_OVERFLOW_ADD(a, b, dst_reg) \
@@ -163,7 +164,7 @@
                        "Integer overflow: result exceeds i64 range"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = I64_VAL(result); \
+        vm_store_i64_typed_hot((dst_reg), result); \
     } while (0)
 
 #define HANDLE_I64_OVERFLOW_SUB(a, b, dst_reg) \
@@ -175,7 +176,7 @@
                        "Integer overflow: result exceeds i64 range"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = I64_VAL(result); \
+        vm_store_i64_typed_hot((dst_reg), result); \
     } while (0)
 
 #define HANDLE_I64_OVERFLOW_MUL(a, b, dst_reg) \
@@ -187,7 +188,7 @@
                        "Integer overflow: result exceeds i64 range"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = I64_VAL(result); \
+        vm_store_i64_typed_hot((dst_reg), result); \
     } while (0)
 
 #define HANDLE_I64_OVERFLOW_DIV(a, b, dst_reg) \
@@ -204,7 +205,7 @@
                        "Integer overflow: result exceeds i64 range"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = I64_VAL(a / b); \
+        vm_store_i64_typed_hot((dst_reg), a / b); \
     } while (0)
 
 #define HANDLE_I64_OVERFLOW_MOD(a, b, dst_reg) \
@@ -216,9 +217,9 @@
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
         if (unlikely(a == INT64_MIN && b == -1)) { \
-            vm.registers[dst_reg] = I64_VAL(0); \
+            vm_store_i64_typed_hot((dst_reg), 0); \
         } else { \
-            vm.registers[dst_reg] = I64_VAL(a % b); \
+            vm_store_i64_typed_hot((dst_reg), a % b); \
         } \
     } while (0)
 
@@ -231,7 +232,7 @@
                        "Unsigned integer overflow: result exceeds u64 range"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = U64_VAL(result); \
+        vm_store_u64_typed_hot((dst_reg), result); \
     } while (0)
 
 #define HANDLE_U64_OVERFLOW_SUB(a, b, dst_reg) \
@@ -243,7 +244,7 @@
                        "Unsigned integer underflow"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = U64_VAL(result); \
+        vm_store_u64_typed_hot((dst_reg), result); \
     } while (0)
 
 #define HANDLE_U64_OVERFLOW_MUL(a, b, dst_reg) \
@@ -255,7 +256,7 @@
                        "Unsigned integer overflow: result exceeds u64 range"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = U64_VAL(result); \
+        vm_store_u64_typed_hot((dst_reg), result); \
     } while (0)
 
 #define HANDLE_U64_OVERFLOW_DIV(a, b, dst_reg) \
@@ -266,7 +267,7 @@
                        "Division by zero"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = U64_VAL(a / b); \
+        vm_store_u64_typed_hot((dst_reg), a / b); \
     } while (0)
 
 #define HANDLE_U64_OVERFLOW_MOD(a, b, dst_reg) \
@@ -277,7 +278,7 @@
                        "Division by zero"); \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = U64_VAL(a % b); \
+        vm_store_u64_typed_hot((dst_reg), a % b); \
     } while (0)
 
 #define HANDLE_F64_OVERFLOW_ADD(a, b, dst_reg) \
@@ -294,7 +295,7 @@
             } \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = F64_VAL(result); \
+        store_f64_register((dst_reg), result); \
     } while (0)
 
 #define HANDLE_F64_OVERFLOW_SUB(a, b, dst_reg) \
@@ -311,7 +312,7 @@
             } \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = F64_VAL(result); \
+        store_f64_register((dst_reg), result); \
     } while (0)
 
 #define HANDLE_F64_OVERFLOW_MUL(a, b, dst_reg) \
@@ -328,7 +329,7 @@
             } \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = F64_VAL(result); \
+        store_f64_register((dst_reg), result); \
     } while (0)
 
 #define HANDLE_F64_OVERFLOW_DIV(a, b, dst_reg) \
@@ -350,7 +351,7 @@
             } \
             RETURN(INTERPRET_RUNTIME_ERROR); \
         } \
-        vm.registers[dst_reg] = F64_VAL(result); \
+        store_f64_register((dst_reg), result); \
     } while (0)
 
 #define HANDLE_MIXED_ADD(val1, val2, dst_reg) \
@@ -366,16 +367,16 @@
                            "Integer overflow: result exceeds i64 range"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = I64_VAL(result); \
+            vm_store_i64_typed_hot((dst_reg), result); \
         } else if (IS_U32(val1) && IS_U32(val2)) { \
             uint32_t a = AS_U32(val1); \
             uint32_t b = AS_U32(val2); \
             uint32_t result; \
             if (unlikely(__builtin_add_overflow(a, b, &result))) { \
                 uint64_t result64 = (uint64_t)a + (uint64_t)b; \
-                vm.registers[dst_reg] = U64_VAL(result64); \
+                vm_store_u64_typed_hot((dst_reg), result64); \
             } else { \
-                vm.registers[dst_reg] = U32_VAL(result); \
+                vm_store_u32_typed_hot((dst_reg), result); \
             } \
         } else if (IS_U64(val1) && IS_U64(val2)) { \
             uint64_t a = AS_U64(val1); \
@@ -386,11 +387,11 @@
                            "Integer overflow: result exceeds u64 range"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = U64_VAL(result); \
+            vm_store_u64_typed_hot((dst_reg), result); \
         } else if (IS_F64(val1) && IS_F64(val2)) { \
             double a = AS_F64(val1); \
             double b = AS_F64(val2); \
-            vm.registers[dst_reg] = F64_VAL(a + b); \
+            store_f64_register((dst_reg), a + b); \
         } else if ((IS_I32(val1) || IS_I64(val1)) && (IS_I32(val2) || IS_I64(val2))) { \
             int64_t a = IS_I64(val1) ? AS_I64(val1) : (int64_t)AS_I32(val1); \
             int64_t b = IS_I64(val2) ? AS_I64(val2) : (int64_t)AS_I32(val2); \
@@ -400,7 +401,7 @@
                            "Integer overflow: result exceeds i64 range"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = I64_VAL(result); \
+            vm_store_i64_typed_hot((dst_reg), result); \
         } else if ((IS_U32(val1) || IS_U64(val1)) && (IS_U32(val2) || IS_U64(val2))) { \
             uint64_t a = IS_U64(val1) ? AS_U64(val1) : (uint64_t)AS_U32(val1); \
             uint64_t b = IS_U64(val2) ? AS_U64(val2) : (uint64_t)AS_U32(val2); \
@@ -410,7 +411,7 @@
                            "Integer overflow: result exceeds u64 range"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = U64_VAL(result); \
+            vm_store_u64_typed_hot((dst_reg), result); \
         } else { \
             runtimeError(ERROR_TYPE, (SrcLocation){NULL, 0, 0}, \
                         "Type mismatch: Cannot mix signed/unsigned integers or integers/floats. Use 'as' to convert explicitly."); \
@@ -431,7 +432,7 @@
                            "Integer overflow: result exceeds i64 range"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = I64_VAL(result); \
+            vm_store_i64_typed_hot((dst_reg), result); \
         } else if (IS_U32(val1) && IS_U32(val2)) { \
             uint32_t a = AS_U32(val1); \
             uint32_t b = AS_U32(val2); \
@@ -441,7 +442,7 @@
                            "Integer underflow: result exceeds u32 range"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = U32_VAL(result); \
+            vm_store_u32_typed_hot((dst_reg), result); \
         } else if (IS_U64(val1) && IS_U64(val2)) { \
             uint64_t a = AS_U64(val1); \
             uint64_t b = AS_U64(val2); \
@@ -451,11 +452,11 @@
                            "Integer underflow: result exceeds u64 range"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = U64_VAL(result); \
+            vm_store_u64_typed_hot((dst_reg), result); \
         } else if (IS_F64(val1) && IS_F64(val2)) { \
             double a = AS_F64(val1); \
             double b = AS_F64(val2); \
-            vm.registers[dst_reg] = F64_VAL(a - b); \
+            store_f64_register((dst_reg), a - b); \
         } else if ((IS_I32(val1) || IS_I64(val1)) && (IS_I32(val2) || IS_I64(val2))) { \
             int64_t a = IS_I64(val1) ? AS_I64(val1) : (int64_t)AS_I32(val1); \
             int64_t b = IS_I64(val2) ? AS_I64(val2) : (int64_t)AS_I32(val2); \
@@ -465,7 +466,7 @@
                            "Integer overflow: result exceeds i64 range"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = I64_VAL(result); \
+            vm_store_i64_typed_hot((dst_reg), result); \
         } else if ((IS_U32(val1) || IS_U64(val1)) && (IS_U32(val2) || IS_U64(val2))) { \
             uint64_t a = IS_U64(val1) ? AS_U64(val1) : (uint64_t)AS_U32(val1); \
             uint64_t b = IS_U64(val2) ? AS_U64(val2) : (uint64_t)AS_U32(val2); \
@@ -475,7 +476,7 @@
                            "Integer underflow: result exceeds u64 range"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = U64_VAL(result); \
+            vm_store_u64_typed_hot((dst_reg), result); \
         } else { \
             runtimeError(ERROR_TYPE, (SrcLocation){NULL, 0, 0}, \
                         "Type mismatch: Cannot mix signed/unsigned integers or integers/floats. Use 'as' to convert explicitly."); \
@@ -490,7 +491,7 @@
                       (IS_I64(val1) ? (double)AS_I64(val1) : (double)AS_I32(val1)); \
             double b = IS_F64(val2) ? AS_F64(val2) : \
                       (IS_I64(val2) ? (double)AS_I64(val2) : (double)AS_I32(val2)); \
-            vm.registers[dst_reg] = F64_VAL(a * b); \
+            store_f64_register((dst_reg), a * b); \
         } else if (IS_I32(val1) && IS_I32(val2)) { \
             HANDLE_I32_OVERFLOW_MUL(AS_I32(val1), AS_I32(val2), dst_reg); \
         } else if (IS_I64(val1) && IS_I64(val2)) { \
@@ -502,7 +503,7 @@
                            "Integer overflow: result exceeds i64 range"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = I64_VAL(result); \
+            vm_store_i64_typed_hot((dst_reg), result); \
         } else { \
             int64_t a = IS_I32(val1) ? (int64_t)AS_I32(val1) : AS_I64(val1); \
             int64_t b = IS_I32(val2) ? (int64_t)AS_I32(val2) : AS_I64(val2); \
@@ -512,7 +513,7 @@
                            "Integer overflow: result exceeds i64 range"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = I64_VAL(result); \
+            vm_store_i64_typed_hot((dst_reg), result); \
         } \
     } while (0)
 
@@ -527,7 +528,7 @@
                 runtimeError(ERROR_VALUE, (SrcLocation){NULL, 0, 0}, "Division by zero"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = F64_VAL(a / b); \
+            store_f64_register((dst_reg), a / b); \
         } else if (IS_I32(val1) && IS_I32(val2)) { \
             int32_t a = AS_I32(val1); \
             int32_t b = AS_I32(val2); \
@@ -536,9 +537,9 @@
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
             if (a == INT32_MIN && b == -1) { \
-                vm.registers[dst_reg] = I64_VAL((int64_t)INT32_MAX + 1); \
+                vm_store_i64_typed_hot((dst_reg), (int64_t)INT32_MAX + 1); \
             } else { \
-                vm.registers[dst_reg] = I32_VAL(a / b); \
+                vm_store_i32_typed_hot((dst_reg), a / b); \
             } \
         } else { \
             int64_t a = IS_I32(val1) ? (int64_t)AS_I32(val1) : AS_I64(val1); \
@@ -547,7 +548,7 @@
                 runtimeError(ERROR_VALUE, (SrcLocation){NULL, 0, 0}, "Division by zero"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = I64_VAL(a / b); \
+            vm_store_i64_typed_hot((dst_reg), a / b); \
         } \
     } while (0)
 
@@ -562,7 +563,7 @@
                 runtimeError(ERROR_VALUE, (SrcLocation){NULL, 0, 0}, "Division by zero"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = F64_VAL(fmod(a, b)); \
+            store_f64_register((dst_reg), fmod(a, b)); \
         } else if (IS_I32(val1) && IS_I32(val2)) { \
             int32_t a = AS_I32(val1); \
             int32_t b = AS_I32(val2); \
@@ -571,9 +572,9 @@
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
             if (a == INT32_MIN && b == -1) { \
-                vm.registers[dst_reg] = I32_VAL(0); \
+                vm_store_i32_typed_hot((dst_reg), 0); \
             } else { \
-                vm.registers[dst_reg] = I32_VAL(a % b); \
+                vm_store_i32_typed_hot((dst_reg), a % b); \
             } \
         } else { \
             int64_t a = IS_I32(val1) ? (int64_t)AS_I32(val1) : AS_I64(val1); \
@@ -582,7 +583,7 @@
                 runtimeError(ERROR_VALUE, (SrcLocation){NULL, 0, 0}, "Division by zero"); \
                 RETURN(INTERPRET_RUNTIME_ERROR); \
             } \
-            vm.registers[dst_reg] = I64_VAL(a % b); \
+            vm_store_i64_typed_hot((dst_reg), a % b); \
         } \
     } while (0)
 

--- a/include/vm/vm_dispatch.h
+++ b/include/vm/vm_dispatch.h
@@ -106,7 +106,8 @@ void runtimeError(ErrorType type, SrcLocation location, const char* format, ...)
                     printf("        "); \
                     for (int i = 0; i < 8; i++) { \
                         printf("[ R%d: ", i); \
-                        printValue(vm.registers[i]); \
+                        Value debug_val = vm_get_register_safe((uint16_t)i); \
+                        printValue(debug_val); \
                         printf(" ]"); \
                     } \
                     printf("\\n"); \

--- a/makefile
+++ b/makefile
@@ -236,6 +236,7 @@ SCOPE_TRACKING_TEST_BIN = $(BUILDDIR)/tests/test_scope_tracking
 PEEPHOLE_TEST_BIN = $(BUILDDIR)/tests/test_constant_propagation
 LICM_METADATA_TEST_BIN = $(BUILDDIR)/tests/test_licm_typed_metadata
 TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
+TYPED_REGISTER_TEST_BIN = $(BUILDDIR)/tests/test_vm_typed_registers
 BUILTIN_INPUT_TEST_BIN = $(BUILDDIR)/tests/test_builtin_input
 BUILTIN_SORTED_ORUS_TESTS = \
     tests/builtins/sorted_runtime.orus
@@ -381,6 +382,9 @@ SUBDIRS="arrays arithmetic algorithms benchmarks builtins comments comprehensive
 	@echo "\033[36m=== Tagged Union Tests ===\033[0m"
 	@$(MAKE) tagged-union-tests
 	@echo ""
+	@echo "\033[36m=== Typed Register Tests ===\033[0m"
+	@$(MAKE) typed-register-tests
+	@echo ""
 	@echo "\033[36m=== Builtin Input Tests ===\033[0m"
 	@$(MAKE) builtin-input-tests
 	@echo ""
@@ -452,6 +456,15 @@ $(TAGGED_UNION_TEST_BIN): tests/unit/test_vm_tagged_union.c $(COMPILER_OBJS) $(V
 tagged-union-tests: $(TAGGED_UNION_TEST_BIN)
 	@echo "Running tagged union tests..."
 	@./$(TAGGED_UNION_TEST_BIN)
+
+$(TYPED_REGISTER_TEST_BIN): tests/unit/test_vm_typed_registers.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling typed register coherence tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+typed-register-tests: $(TYPED_REGISTER_TEST_BIN)
+	@echo "Running typed register coherence tests..."
+	@./$(TYPED_REGISTER_TEST_BIN)
 
 $(BUILTIN_INPUT_TEST_BIN): tests/unit/test_builtin_input.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/src/vm/core/vm_memory.c
+++ b/src/vm/core/vm_memory.c
@@ -11,6 +11,7 @@
 #include "runtime/memory.h"
 #include "vm/vm.h"
 #include "vm/vm_string_ops.h"
+#include "vm/vm_comparison.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -550,6 +551,11 @@ ObjUpvalue* captureUpvalue(Value* local) {
 void closeUpvalues(Value* last) {
     while (vm.openUpvalues != NULL && vm.openUpvalues->location >= last) {
         ObjUpvalue* upvalue = vm.openUpvalues;
+        if (upvalue->location >= vm.registers &&
+            upvalue->location < vm.registers + REGISTER_COUNT) {
+            uint16_t reg_id = (uint16_t)(upvalue->location - vm.registers);
+            vm_get_register_safe(reg_id);
+        }
         upvalue->closed = *upvalue->location;
         upvalue->location = &upvalue->closed;
         vm.openUpvalues = upvalue->next;

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -511,7 +511,7 @@ InterpretResult vm_run_dispatch(void) {
             
             // CREATIVE SOLUTION: Type safety enforcement with intelligent literal coercion
             // This maintains single-pass design while being flexible for compatible types
-            Value valueToStore = vm.registers[reg];
+            Value valueToStore = vm_get_register_safe(reg);
             Type* declaredType = vm.globalTypes[globalIndex];
             
             // Check if the value being stored matches the declared type
@@ -1169,11 +1169,13 @@ InterpretResult vm_run_dispatch(void) {
             uint8_t dst = READ_BYTE();
             uint8_t src1 = READ_BYTE();
             uint8_t src2 = READ_BYTE();
-            if (!IS_I64(vm.registers[src1]) || !IS_I64(vm.registers[src2])) {
+            Value val1 = vm_get_register_safe(src1);
+            Value val2 = vm_get_register_safe(src2);
+            if (!IS_I64(val1) || !IS_I64(val2)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be i64");
             }
-            int64_t a = AS_I64(vm_get_register_safe(src1));
-            int64_t b = AS_I64(vm_get_register_safe(src2));
+            int64_t a = AS_I64(val1);
+            int64_t b = AS_I64(val2);
     #if USE_FAST_ARITH
             vm_set_register_safe(dst, I64_VAL(a * b));
     #else
@@ -1190,14 +1192,16 @@ InterpretResult vm_run_dispatch(void) {
             uint8_t dst = READ_BYTE();
             uint8_t src1 = READ_BYTE();
             uint8_t src2 = READ_BYTE();
-            if (!IS_I64(vm.registers[src1]) || !IS_I64(vm.registers[src2])) {
+            Value val1 = vm_get_register_safe(src1);
+            Value val2 = vm_get_register_safe(src2);
+            if (!IS_I64(val1) || !IS_I64(val2)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be i64");
             }
-            int64_t b = AS_I64(vm_get_register_safe(src2));
+            int64_t b = AS_I64(val2);
             if (b == 0) {
                 VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Division by zero");
             }
-            vm_set_register_safe(dst, I64_VAL(AS_I64(vm_get_register_safe(src1)) / b));
+            vm_set_register_safe(dst, I64_VAL(AS_I64(val1) / b));
             DISPATCH();
         }
 
@@ -1205,14 +1209,16 @@ InterpretResult vm_run_dispatch(void) {
             uint8_t dst = READ_BYTE();
             uint8_t src1 = READ_BYTE();
             uint8_t src2 = READ_BYTE();
-            if (!IS_I64(vm.registers[src1]) || !IS_I64(vm.registers[src2])) {
+            Value val1 = vm_get_register_safe(src1);
+            Value val2 = vm_get_register_safe(src2);
+            if (!IS_I64(val1) || !IS_I64(val2)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be i64");
             }
-            int64_t b = AS_I64(vm_get_register_safe(src2));
+            int64_t b = AS_I64(val2);
             if (b == 0) {
                 VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Division by zero");
             }
-            vm_set_register_safe(dst, I64_VAL(AS_I64(vm_get_register_safe(src1)) % b));
+            vm_set_register_safe(dst, I64_VAL(AS_I64(val1) % b));
             DISPATCH();
         }
 
@@ -1294,12 +1300,14 @@ InterpretResult vm_run_dispatch(void) {
             uint8_t src1 = READ_BYTE();
             uint8_t src2 = READ_BYTE();
 
-            if (!IS_U64(vm.registers[src1]) || !IS_U64(vm.registers[src2])) {
+            Value val1 = vm_get_register_safe(src1);
+            Value val2 = vm_get_register_safe(src2);
+            if (!IS_U64(val1) || !IS_U64(val2)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be u64");
             }
 
-            uint64_t a = AS_U64(vm.registers[src1]);
-            uint64_t b = AS_U64(vm.registers[src2]);
+            uint64_t a = AS_U64(val1);
+            uint64_t b = AS_U64(val2);
             
             // Check for overflow: if a + b < a, then overflow occurred
             if (UINT64_MAX - a < b) {
@@ -1315,12 +1323,14 @@ InterpretResult vm_run_dispatch(void) {
             uint8_t src1 = READ_BYTE();
             uint8_t src2 = READ_BYTE();
 
-            if (!IS_U64(vm.registers[src1]) || !IS_U64(vm.registers[src2])) {
+            Value val1 = vm_get_register_safe(src1);
+            Value val2 = vm_get_register_safe(src2);
+            if (!IS_U64(val1) || !IS_U64(val2)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be u64");
             }
 
-            uint64_t a = AS_U64(vm.registers[src1]);
-            uint64_t b = AS_U64(vm.registers[src2]);
+            uint64_t a = AS_U64(val1);
+            uint64_t b = AS_U64(val2);
             
             // Check for underflow: if a < b, then underflow would occur
             if (a < b) {
@@ -1336,12 +1346,14 @@ InterpretResult vm_run_dispatch(void) {
             uint8_t src1 = READ_BYTE();
             uint8_t src2 = READ_BYTE();
 
-            if (!IS_U64(vm.registers[src1]) || !IS_U64(vm.registers[src2])) {
+            Value val1 = vm_get_register_safe(src1);
+            Value val2 = vm_get_register_safe(src2);
+            if (!IS_U64(val1) || !IS_U64(val2)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be u64");
             }
 
-            uint64_t a = AS_U64(vm.registers[src1]);
-            uint64_t b = AS_U64(vm.registers[src2]);
+            uint64_t a = AS_U64(val1);
+            uint64_t b = AS_U64(val2);
             
             // Check for multiplication overflow: if a != 0 && result / a != b
             if (a != 0 && b > UINT64_MAX / a) {
@@ -1357,16 +1369,18 @@ InterpretResult vm_run_dispatch(void) {
             uint8_t src1 = READ_BYTE();
             uint8_t src2 = READ_BYTE();
 
-            if (!IS_U64(vm.registers[src1]) || !IS_U64(vm.registers[src2])) {
+            Value val1 = vm_get_register_safe(src1);
+            Value val2 = vm_get_register_safe(src2);
+            if (!IS_U64(val1) || !IS_U64(val2)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be u64");
             }
 
-            uint64_t b = AS_U64(vm_get_register_safe(src2));
+            uint64_t b = AS_U64(val2);
             if (b == 0) {
                 VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Division by zero");
             }
 
-            vm_set_register_safe(dst, U64_VAL(AS_U64(vm_get_register_safe(src1)) / b));
+            vm_set_register_safe(dst, U64_VAL(AS_U64(val1) / b));
             DISPATCH();
         }
 
@@ -1375,16 +1389,18 @@ InterpretResult vm_run_dispatch(void) {
             uint8_t src1 = READ_BYTE();
             uint8_t src2 = READ_BYTE();
 
-            if (!IS_U64(vm.registers[src1]) || !IS_U64(vm.registers[src2])) {
+            Value val1 = vm_get_register_safe(src1);
+            Value val2 = vm_get_register_safe(src2);
+            if (!IS_U64(val1) || !IS_U64(val2)) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be u64");
             }
 
-            uint64_t b = AS_U64(vm_get_register_safe(src2));
+            uint64_t b = AS_U64(val2);
             if (b == 0) {
                 VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Division by zero");
             }
 
-            vm_set_register_safe(dst, U64_VAL(AS_U64(vm_get_register_safe(src1)) % b));
+            vm_set_register_safe(dst, U64_VAL(AS_U64(val1) % b));
             DISPATCH();
         }
 
@@ -2096,48 +2112,9 @@ InterpretResult vm_run_dispatch(void) {
         uint8_t src1 = READ_BYTE();
         uint8_t src2 = READ_BYTE();
         
-        // Convert operands to boolean using truthiness rules
-        bool left_bool = false;
-        bool right_bool = false;
-        
-        // Convert left operand to boolean
-        if (IS_BOOL(vm.registers[src1])) {
-            left_bool = AS_BOOL(vm.registers[src1]);
-        } else if (IS_I32(vm.registers[src1])) {
-            left_bool = AS_I32(vm.registers[src1]) != 0;
-        } else if (IS_I64(vm.registers[src1])) {
-            left_bool = AS_I64(vm.registers[src1]) != 0;
-        } else if (IS_U32(vm.registers[src1])) {
-            left_bool = AS_U32(vm.registers[src1]) != 0;
-        } else if (IS_U64(vm.registers[src1])) {
-            left_bool = AS_U64(vm.registers[src1]) != 0;
-        } else if (IS_F64(vm.registers[src1])) {
-            left_bool = AS_F64(vm.registers[src1]) != 0.0;
-        } else if (IS_BOOL(vm.registers[src1])) {
-            left_bool = false;
-        } else {
-            left_bool = true; // Objects, strings, etc. are truthy
-        }
-        
-        // Convert right operand to boolean
-        if (IS_BOOL(vm.registers[src2])) {
-            right_bool = AS_BOOL(vm.registers[src2]);
-        } else if (IS_I32(vm.registers[src2])) {
-            right_bool = AS_I32(vm.registers[src2]) != 0;
-        } else if (IS_I64(vm.registers[src2])) {
-            right_bool = AS_I64(vm.registers[src2]) != 0;
-        } else if (IS_U32(vm.registers[src2])) {
-            right_bool = AS_U32(vm.registers[src2]) != 0;
-        } else if (IS_U64(vm.registers[src2])) {
-            right_bool = AS_U64(vm.registers[src2]) != 0;
-        } else if (IS_F64(vm.registers[src2])) {
-            right_bool = AS_F64(vm.registers[src2]) != 0.0;
-        } else if (IS_BOOL(vm.registers[src2])) {
-            right_bool = false;
-        } else {
-            right_bool = true; // Objects, strings, etc. are truthy
-        }
-        
+        bool left_bool = vm_register_is_truthy(src1);
+        bool right_bool = vm_register_is_truthy(src2);
+
         vm_set_register_safe(dst, BOOL_VAL(left_bool && right_bool));
         DISPATCH();
     }
@@ -2146,49 +2123,10 @@ InterpretResult vm_run_dispatch(void) {
         uint8_t dst = READ_BYTE();
         uint8_t src1 = READ_BYTE();
         uint8_t src2 = READ_BYTE();
-        
-        // Convert operands to boolean using truthiness rules
-        bool left_bool = false;
-        bool right_bool = false;
-        
-        // Convert left operand to boolean
-        if (IS_BOOL(vm.registers[src1])) {
-            left_bool = AS_BOOL(vm.registers[src1]);
-        } else if (IS_I32(vm.registers[src1])) {
-            left_bool = AS_I32(vm.registers[src1]) != 0;
-        } else if (IS_I64(vm.registers[src1])) {
-            left_bool = AS_I64(vm.registers[src1]) != 0;
-        } else if (IS_U32(vm.registers[src1])) {
-            left_bool = AS_U32(vm.registers[src1]) != 0;
-        } else if (IS_U64(vm.registers[src1])) {
-            left_bool = AS_U64(vm.registers[src1]) != 0;
-        } else if (IS_F64(vm.registers[src1])) {
-            left_bool = AS_F64(vm.registers[src1]) != 0.0;
-        } else if (IS_BOOL(vm.registers[src1])) {
-            left_bool = false;
-        } else {
-            left_bool = true; // Objects, strings, etc. are truthy
-        }
-        
-        // Convert right operand to boolean
-        if (IS_BOOL(vm.registers[src2])) {
-            right_bool = AS_BOOL(vm.registers[src2]);
-        } else if (IS_I32(vm.registers[src2])) {
-            right_bool = AS_I32(vm.registers[src2]) != 0;
-        } else if (IS_I64(vm.registers[src2])) {
-            right_bool = AS_I64(vm.registers[src2]) != 0;
-        } else if (IS_U32(vm.registers[src2])) {
-            right_bool = AS_U32(vm.registers[src2]) != 0;
-        } else if (IS_U64(vm.registers[src2])) {
-            right_bool = AS_U64(vm.registers[src2]) != 0;
-        } else if (IS_F64(vm.registers[src2])) {
-            right_bool = AS_F64(vm.registers[src2]) != 0.0;
-        } else if (IS_BOOL(vm.registers[src2])) {
-            right_bool = false;
-        } else {
-            right_bool = true; // Objects, strings, etc. are truthy
-        }
-        
+
+        bool left_bool = vm_register_is_truthy(src1);
+        bool right_bool = vm_register_is_truthy(src2);
+
         vm_set_register_safe(dst, BOOL_VAL(left_bool || right_bool));
         DISPATCH();
     }
@@ -2196,25 +2134,9 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_NOT_BOOL_R: {
         uint8_t dst = READ_BYTE();
         uint8_t src = READ_BYTE();
-        
-        // Convert operand to boolean using truthiness rules, then negate
-        bool src_bool = false;
-        if (IS_BOOL(vm.registers[src])) {
-            src_bool = AS_BOOL(vm.registers[src]);
-        } else if (IS_I32(vm.registers[src])) {
-            src_bool = AS_I32(vm.registers[src]) != 0;
-        } else if (IS_I64(vm.registers[src])) {
-            src_bool = AS_I64(vm.registers[src]) != 0;
-        } else if (IS_U32(vm.registers[src])) {
-            src_bool = AS_U32(vm.registers[src]) != 0;
-        } else if (IS_U64(vm.registers[src])) {
-            src_bool = AS_U64(vm.registers[src]) != 0;
-        } else if (IS_F64(vm.registers[src])) {
-            src_bool = AS_F64(vm.registers[src]) != 0.0;
-        } else {
-            src_bool = true; // Objects, strings, etc. are truthy
-        }
-        
+
+        bool src_bool = vm_register_is_truthy(src);
+
         vm_set_register_safe(dst, BOOL_VAL(!src_bool));
         DISPATCH();
     }
@@ -2223,11 +2145,13 @@ InterpretResult vm_run_dispatch(void) {
         uint8_t dst = READ_BYTE();
         uint8_t src1 = READ_BYTE();
         uint8_t src2 = READ_BYTE();
-        if (!IS_STRING(vm.registers[src1]) || !IS_STRING(vm.registers[src2])) {
+        Value left_val = vm_get_register_safe(src1);
+        Value right_val = vm_get_register_safe(src2);
+        if (!IS_STRING(left_val) || !IS_STRING(right_val)) {
             VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operands must be string");
         }
-        ObjString* a = AS_STRING(vm.registers[src1]);
-        ObjString* b = AS_STRING(vm.registers[src2]);
+        ObjString* a = AS_STRING(left_val);
+        ObjString* b = AS_STRING(right_val);
         int newLen = a->length + b->length;
         char* buf = malloc(newLen + 1);
         memcpy(buf, a->chars, a->length);
@@ -2610,7 +2534,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_TO_STRING_R: {
         uint8_t dst = READ_BYTE();
         uint8_t src = READ_BYTE();
-        Value val = vm.registers[src];
+        Value val = vm_get_register_safe(src);
         char buffer[64];
         
         if (IS_I32(val)) {
@@ -3278,7 +3202,7 @@ InterpretResult vm_run_dispatch(void) {
                 // We need to be careful about overlapping registers
                 Value tempArgs[FRAME_REGISTERS];
                 for (int i = 0; i < argCount; i++) {
-                    tempArgs[i] = vm.registers[firstArgReg + i];
+                    tempArgs[i] = vm_get_register_safe(firstArgReg + i);
                 }
                 
                 // Clear the current frame's parameter registers first, then set new ones
@@ -3306,6 +3230,7 @@ InterpretResult vm_run_dispatch(void) {
                 CallFrame* frame = &vm.frames[--vm.frameCount];
                 
                 // Close upvalues before restoring registers to prevent corruption
+                vm_get_register_safe(frame->parameterBaseRegister);
                 closeUpvalues(&vm.registers[frame->parameterBaseRegister]);
                 
                 const int temp_reg_start = TEMP_REG_START;
@@ -3340,6 +3265,7 @@ InterpretResult vm_run_dispatch(void) {
                 CallFrame* frame = &vm.frames[--vm.frameCount];
                 
                 // Close upvalues before restoring registers to prevent corruption
+                vm_get_register_safe(frame->parameterBaseRegister);
                 closeUpvalues(&vm.registers[frame->parameterBaseRegister]);
                 
                 const int temp_reg_start = TEMP_REG_START;
@@ -3392,7 +3318,7 @@ InterpretResult vm_run_dispatch(void) {
         uint8_t spill_id_low = READ_BYTE();
         uint8_t reg = READ_BYTE();
         uint16_t spill_id = (spill_id_high << 8) | spill_id_low;
-        Value value = vm.registers[reg];
+        Value value = vm_get_register_safe(reg);
         set_register(&vm.register_file, spill_id, value);
         DISPATCH();
     }
@@ -3815,11 +3741,12 @@ InterpretResult vm_run_dispatch(void) {
         vm.ip += 4;
         
         // Compiler ensures this is only emitted for i32 operations, so trust it
-        if (!IS_I32(vm.registers[src])) {
+        Value mul_val = vm_get_register_safe(src);
+        if (!IS_I32(mul_val)) {
             VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operand must be i32");
         }
-        
-        int32_t result = AS_I32(vm.registers[src]) * imm;
+
+        int32_t result = AS_I32(mul_val) * imm;
         vm_set_register_safe(dst, I32_VAL(result));
         
         DISPATCH_TYPED();
@@ -4068,7 +3995,7 @@ InterpretResult vm_run_dispatch(void) {
         uint8_t functionReg = READ_BYTE();
         uint8_t upvalueCount = READ_BYTE();
         
-        Value functionValue = vm.registers[functionReg];
+        Value functionValue = vm_get_register_safe(functionReg);
         if (!IS_FUNCTION(functionValue)) {
             VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(), "Expected function for closure creation");
         }
@@ -4082,10 +4009,11 @@ InterpretResult vm_run_dispatch(void) {
             
             
             if (isLocal) {
-                // Value localValue = vm.registers[index];
+                vm_get_register_safe(index);
                 closure->upvalues[i] = captureUpvalue(&vm.registers[index]);
             } else {
-                ObjClosure* enclosing = AS_CLOSURE(vm.registers[0]); // Current closure
+                Value enclosing_value = vm_get_register_safe(0);
+                ObjClosure* enclosing = AS_CLOSURE(enclosing_value); // Current closure
                 closure->upvalues[i] = enclosing->upvalues[index];
             }
         }
@@ -4098,7 +4026,7 @@ InterpretResult vm_run_dispatch(void) {
         uint8_t dstReg = READ_BYTE();
         uint8_t upvalueIndex = READ_BYTE();
 
-        Value closureValue = vm.registers[0];
+        Value closureValue = vm_get_register_safe(0);
         if (!IS_CLOSURE(closureValue)) {
             VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(), "Invalid upvalue access");
         }
@@ -4119,7 +4047,7 @@ InterpretResult vm_run_dispatch(void) {
         uint8_t upvalueIndex = READ_BYTE();
         uint8_t valueReg = READ_BYTE();
 
-        Value closureValue = vm.registers[0];
+        Value closureValue = vm_get_register_safe(0);
         if (!IS_CLOSURE(closureValue)) {
             VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(), "Invalid upvalue access");
         }
@@ -4132,12 +4060,13 @@ InterpretResult vm_run_dispatch(void) {
             VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(), "Invalid upvalue access");
         }
 
-        *closure->upvalues[upvalueIndex]->location = vm.registers[valueReg];
+        *closure->upvalues[upvalueIndex]->location = vm_get_register_safe(valueReg);
         DISPATCH();
     }
 
     LABEL_OP_CLOSE_UPVALUE_R: {
         uint8_t localReg = READ_BYTE();
+        vm_get_register_safe(localReg);
         closeUpvalues(&vm.registers[localReg]);
         DISPATCH();
     }

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -1629,47 +1629,8 @@ InterpretResult vm_run_dispatch(void) {
                     uint8_t src1 = READ_BYTE();
                     uint8_t src2 = READ_BYTE();
 
-                    // Convert operands to boolean using truthiness rules
-                    bool left_bool = false;
-                    bool right_bool = false;
-                    
-                    // Convert left operand to boolean
-                    if (IS_BOOL(vm_get_register_safe(src1))) {
-                        left_bool = AS_BOOL(vm_get_register_safe(src1));
-                    } else if (IS_I32(vm_get_register_safe(src1))) {
-                        left_bool = AS_I32(vm_get_register_safe(src1)) != 0;
-                    } else if (IS_I64(vm_get_register_safe(src1))) {
-                        left_bool = AS_I64(vm_get_register_safe(src1)) != 0;
-                    } else if (IS_U32(vm_get_register_safe(src1))) {
-                        left_bool = AS_U32(vm_get_register_safe(src1)) != 0;
-                    } else if (IS_U64(vm_get_register_safe(src1))) {
-                        left_bool = AS_U64(vm_get_register_safe(src1)) != 0;
-                    } else if (IS_F64(vm_get_register_safe(src1))) {
-                        left_bool = AS_F64(vm_get_register_safe(src1)) != 0.0;
-                    } else if (IS_BOOL(vm_get_register_safe(src1))) {
-                        left_bool = false;
-                    } else {
-                        left_bool = true; // Objects, strings, etc. are truthy
-                    }
-                    
-                    // Convert right operand to boolean
-                    if (IS_BOOL(vm_get_register_safe(src2))) {
-                        right_bool = AS_BOOL(vm_get_register_safe(src2));
-                    } else if (IS_I32(vm_get_register_safe(src2))) {
-                        right_bool = AS_I32(vm_get_register_safe(src2)) != 0;
-                    } else if (IS_I64(vm_get_register_safe(src2))) {
-                        right_bool = AS_I64(vm_get_register_safe(src2)) != 0;
-                    } else if (IS_U32(vm_get_register_safe(src2))) {
-                        right_bool = AS_U32(vm_get_register_safe(src2)) != 0;
-                    } else if (IS_U64(vm_get_register_safe(src2))) {
-                        right_bool = AS_U64(vm_get_register_safe(src2)) != 0;
-                    } else if (IS_F64(vm_get_register_safe(src2))) {
-                        right_bool = AS_F64(vm_get_register_safe(src2)) != 0.0;
-                    } else if (IS_BOOL(vm_get_register_safe(src2))) {
-                        right_bool = false;
-                    } else {
-                        right_bool = true; // Objects, strings, etc. are truthy
-                    }
+                    bool left_bool = vm_register_is_truthy(src1);
+                    bool right_bool = vm_register_is_truthy(src2);
 
                     vm_set_register_safe(dst, BOOL_VAL(left_bool && right_bool));
                     break;
@@ -1680,47 +1641,8 @@ InterpretResult vm_run_dispatch(void) {
                     uint8_t src1 = READ_BYTE();
                     uint8_t src2 = READ_BYTE();
 
-                    // Convert operands to boolean using truthiness rules
-                    bool left_bool = false;
-                    bool right_bool = false;
-                    
-                    // Convert left operand to boolean
-                    if (IS_BOOL(vm_get_register_safe(src1))) {
-                        left_bool = AS_BOOL(vm_get_register_safe(src1));
-                    } else if (IS_I32(vm_get_register_safe(src1))) {
-                        left_bool = AS_I32(vm_get_register_safe(src1)) != 0;
-                    } else if (IS_I64(vm_get_register_safe(src1))) {
-                        left_bool = AS_I64(vm_get_register_safe(src1)) != 0;
-                    } else if (IS_U32(vm_get_register_safe(src1))) {
-                        left_bool = AS_U32(vm_get_register_safe(src1)) != 0;
-                    } else if (IS_U64(vm_get_register_safe(src1))) {
-                        left_bool = AS_U64(vm_get_register_safe(src1)) != 0;
-                    } else if (IS_F64(vm_get_register_safe(src1))) {
-                        left_bool = AS_F64(vm_get_register_safe(src1)) != 0.0;
-                    } else if (IS_BOOL(vm_get_register_safe(src1))) {
-                        left_bool = false;
-                    } else {
-                        left_bool = true; // Objects, strings, etc. are truthy
-                    }
-                    
-                    // Convert right operand to boolean
-                    if (IS_BOOL(vm_get_register_safe(src2))) {
-                        right_bool = AS_BOOL(vm_get_register_safe(src2));
-                    } else if (IS_I32(vm_get_register_safe(src2))) {
-                        right_bool = AS_I32(vm_get_register_safe(src2)) != 0;
-                    } else if (IS_I64(vm_get_register_safe(src2))) {
-                        right_bool = AS_I64(vm_get_register_safe(src2)) != 0;
-                    } else if (IS_U32(vm_get_register_safe(src2))) {
-                        right_bool = AS_U32(vm_get_register_safe(src2)) != 0;
-                    } else if (IS_U64(vm_get_register_safe(src2))) {
-                        right_bool = AS_U64(vm_get_register_safe(src2)) != 0;
-                    } else if (IS_F64(vm_get_register_safe(src2))) {
-                        right_bool = AS_F64(vm_get_register_safe(src2)) != 0.0;
-                    } else if (IS_BOOL(vm_get_register_safe(src2))) {
-                        right_bool = false;
-                    } else {
-                        right_bool = true; // Objects, strings, etc. are truthy
-                    }
+                    bool left_bool = vm_register_is_truthy(src1);
+                    bool right_bool = vm_register_is_truthy(src2);
 
                     vm_set_register_safe(dst, BOOL_VAL(left_bool || right_bool));
                     break;
@@ -1730,23 +1652,7 @@ InterpretResult vm_run_dispatch(void) {
                     uint8_t dst = READ_BYTE();
                     uint8_t src = READ_BYTE();
 
-                    // Convert operand to boolean using truthiness rules, then negate
-                    bool src_bool = false;
-                    if (IS_BOOL(vm_get_register_safe(src))) {
-                        src_bool = AS_BOOL(vm_get_register_safe(src));
-                    } else if (IS_I32(vm_get_register_safe(src))) {
-                        src_bool = AS_I32(vm_get_register_safe(src)) != 0;
-                    } else if (IS_I64(vm_get_register_safe(src))) {
-                        src_bool = AS_I64(vm_get_register_safe(src)) != 0;
-                    } else if (IS_U32(vm_get_register_safe(src))) {
-                        src_bool = AS_U32(vm_get_register_safe(src)) != 0;
-                    } else if (IS_U64(vm_get_register_safe(src))) {
-                        src_bool = AS_U64(vm_get_register_safe(src)) != 0;
-                    } else if (IS_F64(vm_get_register_safe(src))) {
-                        src_bool = AS_F64(vm_get_register_safe(src)) != 0.0;
-                    } else {
-                        src_bool = true; // Objects, strings, etc. are truthy
-                    }
+                    bool src_bool = vm_register_is_truthy(src);
 
                     vm_set_register_safe(dst, BOOL_VAL(!src_bool));
                     break;
@@ -2826,9 +2732,11 @@ InterpretResult vm_run_dispatch(void) {
                         uint8_t index = READ_BYTE();
                         
                         if (isLocal) {
-                            closure->upvalues[i] = captureUpvalue(&vm_get_register_safe(index));
+                            vm_get_register_safe(index);
+                            closure->upvalues[i] = captureUpvalue(&vm.registers[index]);
                         } else {
-                            ObjClosure* enclosing = AS_CLOSURE(vm_get_register_safe(0)); // Current closure
+                            Value enclosing_value = vm_get_register_safe(0);
+                            ObjClosure* enclosing = AS_CLOSURE(enclosing_value); // Current closure
                             closure->upvalues[i] = enclosing->upvalues[index];
                         }
                     }
@@ -2841,7 +2749,8 @@ InterpretResult vm_run_dispatch(void) {
                     uint8_t dstReg = READ_BYTE();
                     uint8_t upvalueIndex = READ_BYTE();
                     
-                    ObjClosure* closure = AS_CLOSURE(vm_get_register_safe(0)); // Current closure
+                    Value closure_value = vm_get_register_safe(0);
+                    ObjClosure* closure = AS_CLOSURE(closure_value); // Current closure
                     vm_set_register_safe(dstReg, *closure->upvalues[upvalueIndex]->location);
                     break;
                 }
@@ -2850,14 +2759,16 @@ InterpretResult vm_run_dispatch(void) {
                     uint8_t upvalueIndex = READ_BYTE();
                     uint8_t valueReg = READ_BYTE();
                     
-                    ObjClosure* closure = AS_CLOSURE(vm_get_register_safe(0)); // Current closure
+                    Value closure_value = vm_get_register_safe(0);
+                    ObjClosure* closure = AS_CLOSURE(closure_value); // Current closure
                     *closure->upvalues[upvalueIndex]->location = vm_get_register_safe(valueReg);
                     break;
                 }
 
                 case OP_CLOSE_UPVALUE_R: {
                     uint8_t localReg = READ_BYTE();
-                    closeUpvalues(&vm_get_register_safe(localReg));
+                    vm_get_register_safe(localReg);
+                    closeUpvalues(&vm.registers[localReg]);
                     break;
                 }
 

--- a/tests/unit/test_vm_typed_registers.c
+++ b/tests/unit/test_vm_typed_registers.c
@@ -1,0 +1,89 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "vm/vm.h"
+#include "vm/vm_comparison.h"
+
+#define ASSERT_TRUE(cond, message)                                                         \
+    do {                                                                                   \
+        if (!(cond)) {                                                                     \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", message, __FILE__, __LINE__); \
+            return false;                                                                  \
+        }                                                                                  \
+    } while (0)
+
+static bool test_typed_register_deferred_boxing_flushes_on_read(void) {
+    initVM();
+
+    vm_store_i32_typed_hot(0, 10);
+    ASSERT_TRUE(!vm.typed_regs.dirty[0], "Initial store should synchronize boxed register");
+    ASSERT_TRUE(IS_I32(vm.registers[0]) && AS_I32(vm.registers[0]) == 10,
+                "Initial store should write boxed value");
+
+    vm_store_i32_typed_hot(0, 42);
+    ASSERT_TRUE(vm.typed_regs.dirty[0], "Second store should defer boxing");
+    ASSERT_TRUE(IS_I32(vm.registers[0]) && AS_I32(vm.registers[0]) == 10,
+                "Deferred store should leave boxed value untouched");
+
+    Value flushed = vm_get_register_safe(0);
+    ASSERT_TRUE(IS_I32(flushed) && AS_I32(flushed) == 42,
+                "vm_get_register_safe should flush deferred integer");
+    ASSERT_TRUE(!vm.typed_regs.dirty[0], "Dirty bit should clear after flush");
+    ASSERT_TRUE(IS_I32(vm.registers[0]) && AS_I32(vm.registers[0]) == 42,
+                "Boxed register should reflect flushed value");
+
+    freeVM();
+    return true;
+}
+
+static bool test_typed_register_flushes_for_open_upvalue(void) {
+    initVM();
+
+    vm_set_register_safe(0, I32_VAL(7));
+    Value initial = vm_get_register_safe(0);
+    ASSERT_TRUE(IS_I32(initial) && AS_I32(initial) == 7,
+                "Initial value should be accessible");
+
+    ObjUpvalue* upvalue = captureUpvalue(&vm.registers[0]);
+    ASSERT_TRUE(upvalue != NULL, "captureUpvalue should return handle");
+    ASSERT_TRUE(upvalue->location == &vm.registers[0], "Upvalue should reference register slot");
+
+    vm_store_i32_typed_hot(0, 99);
+    ASSERT_TRUE(!vm.typed_regs.dirty[0], "Registers with open upvalues must stay boxed");
+    ASSERT_TRUE(IS_I32(vm.registers[0]) && AS_I32(vm.registers[0]) == 99,
+                "Boxed register should update when upvalue is open");
+    ASSERT_TRUE(IS_I32(*upvalue->location) && AS_I32(*upvalue->location) == 99,
+                "Open upvalue should see updated value");
+
+    closeUpvalues(&vm.registers[0]);
+    freeVM();
+    return true;
+}
+
+int main(void) {
+    bool (*tests[])(void) = {
+        test_typed_register_deferred_boxing_flushes_on_read,
+        test_typed_register_flushes_for_open_upvalue,
+    };
+
+    const char* names[] = {
+        "Deferred boxing flushes via vm_get_register_safe",
+        "Open upvalues force boxed synchronization",
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; i++) {
+        if (tests[i]()) {
+            printf("[PASS] %s\n", names[i]);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", names[i]);
+            return 1;
+        }
+    }
+
+    printf("%d/%d typed register tests passed\n", passed, total);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add typed register helper routines that skip redundant boxed writes and expose truthiness accessors
- update dispatchers and arithmetic helpers to use typed-safe register access, including upvalue-aware flushing
- extend the Makefile with typed register tests validating deferred boxing and open upvalue synchronization