### PR TITLE
Fix matches enum payload regression test

### DIFF
--- a/tests/control_flow/matches_enum_payload.orus
+++ b/tests/control_flow/matches_enum_payload.orus
@@ -1,0 +1,22 @@
+// Control flow tests for `matches` with enum payloads
+enum Result:
+    Ok(value: i32)
+    Err(message: string)
+
+mut value = Result.Ok(42)
+if value matches Result.Ok(42):
+    print("enum ok literal equality works")
+
+if value matches Result.Ok(7):
+    print("unexpected ok branch")
+else:
+    print("enum ok literal mismatch works")
+
+if value matches Result.Err("boom"):
+    print("unexpected err branch")
+else:
+    print("enum variant mismatch works")
+
+value = Result.Err("boom")
+if value matches Result.Err("boom"):
+    print("enum err literal equality works")

--- a/tests/expressions/matches_keyword.orus
+++ b/tests/expressions/matches_keyword.orus
@@ -1,0 +1,8 @@
+// Tests for the `matches` keyword evaluating to booleans
+value = 42
+print("value matches 42 =", value matches 42)
+print("value matches 100 =", value matches 100)
+
+text = "hello"
+print("text matches \"hello\" =", text matches "hello")
+print("text matches \"world\" =", text matches "world")


### PR DESCRIPTION
## Summary
- update the matches regression test to use the canonical `string` type annotation
- declare the enum instance binding as mutable so reassignment compiles

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ddb542d2c88325ae7711708230e648