### PR TITLE
Improve int() error guidance for decimal input

### DIFF
--- a/src/vm/runtime/builtin_number.c
+++ b/src/vm/runtime/builtin_number.c
@@ -62,6 +62,21 @@ static void format_string_preview(const ObjString* string, char* buffer, size_t 
     }
 }
 
+static bool string_contains_decimal_hint(const ObjString* string) {
+    if (!string || !string->chars) {
+        return false;
+    }
+
+    for (int i = 0; i < string->length; i++) {
+        char c = string->chars[i];
+        if (c == '.' || c == 'e' || c == 'E') {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static bool parse_int_string(const ObjString* string, int32_t* out_value, bool* out_overflow) {
     if (!string || !string->chars || !out_value || !out_overflow) {
         return false;
@@ -227,9 +242,16 @@ BuiltinParseResult builtin_parse_int(Value input, Value* out_value,
                 return BUILTIN_PARSE_OVERFLOW;
             }
 
-            write_message(message, message_size,
-                          "int() argument must be an integer string, got \"%s\"",
-                          preview);
+            if (string_contains_decimal_hint(string)) {
+                write_message(message, message_size,
+                              "int() argument must be an integer string (decimals are not allowed). "
+                              "Use float() to parse decimal values, got \"%s\"",
+                              preview);
+            } else {
+                write_message(message, message_size,
+                              "int() argument must be an integer string, got \"%s\"",
+                              preview);
+            }
             return BUILTIN_PARSE_INVALID;
         }
 

--- a/tests/error_reporting/cases.json
+++ b/tests/error_reporting/cases.json
@@ -274,6 +274,25 @@
     ]
   },
   {
+    "name": "runtime_invalid_int_decimal",
+    "source": "runtime_invalid_int_decimal.orus",
+    "description": "Calling int() on a decimal string should suggest using float().",
+    "expected_exit": 70,
+    "expected_diagnostic_count": 1,
+    "expected_diagnostics": [
+      {
+        "category": "RUNTIME PANIC",
+        "message_contains": "decimals are not allowed",
+        "help_contains": "Ensure the text only contains digits",
+        "note_contains": "Only base-10 numbers are supported",
+        "location_contains": "runtime_invalid_int_decimal.orus:3:10"
+      }
+    ],
+    "expected": [
+      "int() argument must be an integer string (decimals are not allowed). Use float() to parse decimal values, got \"9.7\""
+    ]
+  },
+  {
     "name": "runtime_invalid_float_literal",
     "source": "runtime_invalid_float_literal.orus",
     "description": "Calling float() on a non-numeric string should surface a conversion runtime panic with guidance.",

--- a/tests/error_reporting/runtime_invalid_int_decimal.orus
+++ b/tests/error_reporting/runtime_invalid_int_decimal.orus
@@ -1,0 +1,3 @@
+print("runtime invalid int decimal")
+value = "9.7"
+print(int(value))


### PR DESCRIPTION
## Summary
- detect decimal markers in int() string conversions and suggest using float() when found
- add an error-reporting regression case that exercises decimal input and verifies the new messaging

## Testing
- make debug
- python3 tests/error_reporting/run_error_tests.py ./orus_debug

------
https://chatgpt.com/codex/tasks/task_e_68ddbe014c208325b7a8b142b489315b