### PR TITLE
Fix loop safety integration iteration tracking arrays

### DIFF
--- a/tests/control_flow/loop_safety_integration.orus
+++ b/tests/control_flow/loop_safety_integration.orus
@@ -6,87 +6,182 @@ print("=== Loop Optimization Test Suite ===")
 // Test 1: Basic unrolling - small constant loop
 print("Test 1: Basic unrolling (1..4)")
 mut test1_count = 0
+mut test1_values: [i32] = []
 for i in 1..4:
     print("Unrolled:", i)
     test1_count = test1_count + 1
+    push(test1_values, i)
+mut expected_test1_values: [i32] = []
+push(expected_test1_values, 1)
+push(expected_test1_values, 2)
+push(expected_test1_values, 3)
+if assert_eq("loop_safety_integration test1_values", test1_values, expected_test1_values):
+    print("ok", "test1_values", test1_values)
 print("Test 1 done")
 
 // Test 2: Single iteration - should be unrolled
 print("Test 2: Single iteration (5..6)")
 mut test2_count = 0
+mut test2_values: [i32] = []
 for i in 5..6:
     print("Single:", i)
     test2_count = test2_count + 1
+    push(test2_values, i)
+mut expected_test2_values: [i32] = []
+push(expected_test2_values, 5)
+if assert_eq("loop_safety_integration test2_values", test2_values, expected_test2_values):
+    print("ok", "test2_values", test2_values)
 print("Test 2 done")
 
 // Test 3: Two iterations - should be unrolled
 print("Test 3: Two iterations (0..2)")
 mut test3_count = 0
+mut test3_values: [i32] = []
 for i in 0..2:
     print("Two:", i)
     test3_count = test3_count + 1
+    push(test3_values, i)
+mut expected_test3_values: [i32] = []
+push(expected_test3_values, 0)
+push(expected_test3_values, 1)
+if assert_eq("loop_safety_integration test3_values", test3_values, expected_test3_values):
+    print("ok", "test3_values", test3_values)
 print("Test 3 done")
 
 // Test 4: Step loop - should be unrolled
 print("Test 4: Step loop (0..6..2)")
 mut test4_count = 0
+mut test4_values: [i32] = []
 for i in 0..6..2:
     print("Step:", i)
     test4_count = test4_count + 1
+    push(test4_values, i)
+mut expected_test4_values: [i32] = []
+push(expected_test4_values, 0)
+push(expected_test4_values, 2)
+push(expected_test4_values, 4)
+if assert_eq("loop_safety_integration test4_values", test4_values, expected_test4_values):
+    print("ok", "test4_values", test4_values)
 print("Test 4 done")
 
 // Test 5: Large step - should be unrolled
 print("Test 5: Large step (10..50..10)")
 mut test5_count = 0
+mut test5_values: [i32] = []
 for i in 10..50..10:
     print("Large step:", i)
     test5_count = test5_count + 1
+    push(test5_values, i)
+mut expected_test5_values: [i32] = []
+push(expected_test5_values, 10)
+push(expected_test5_values, 20)
+push(expected_test5_values, 30)
+push(expected_test5_values, 40)
+if assert_eq("loop_safety_integration test5_values", test5_values, expected_test5_values):
+    print("ok", "test5_values", test5_values)
 print("Test 5 done")
 
 // Test 6: Loop with break - should NOT be unrolled
 print("Test 6: Loop with break (1..10)")
 mut test6_count = 0
+mut test6_values: [i32] = []
+mut test6_events: [string] = []
 for i in 1..10:
     if i == 3:
+        push(test6_events, "break at 3")
         break
     print("Break test:", i)
     test6_count = test6_count + 1
+    push(test6_values, i)
+mut expected_test6_values: [i32] = []
+push(expected_test6_values, 1)
+push(expected_test6_values, 2)
+mut expected_test6_events: [string] = []
+push(expected_test6_events, "break at 3")
+if assert_eq("loop_safety_integration test6_values", test6_values, expected_test6_values):
+    print("ok", "test6_values", test6_values)
+if assert_eq("loop_safety_integration test6_events", test6_events, expected_test6_events):
+    print("ok", "test6_events", test6_events)
 print("Test 6 done")
 
 // Test 7: Loop with continue - should NOT be unrolled
 print("Test 7: Loop with continue (1..5)")
 mut test7_count = 0
+mut test7_values: [i32] = []
+mut test7_events: [string] = []
 for i in 1..5:
     if i == 3:
+        push(test7_events, "continue at 3")
         continue
     print("Continue test:", i)
     test7_count = test7_count + 1
+    push(test7_values, i)
+mut expected_test7_values: [i32] = []
+push(expected_test7_values, 1)
+push(expected_test7_values, 2)
+push(expected_test7_values, 4)
+mut expected_test7_events: [string] = []
+push(expected_test7_events, "continue at 3")
+if assert_eq("loop_safety_integration test7_values", test7_values, expected_test7_values):
+    print("ok", "test7_values", test7_values)
+if assert_eq("loop_safety_integration test7_events", test7_events, expected_test7_events):
+    print("ok", "test7_events", test7_events)
 print("Test 7 done")
 
 // Test 8: Nested loops - inner should be unrolled
 print("Test 8: Nested loops")
 mut nested_inner_count = 0
+mut test8_outer_values: [i32] = []
+mut test8_inner_values: [i32] = []
 for i in 1..3:
     print("Outer:", i)
+    push(test8_outer_values, i)
     for j in 1..3:
         print("  Inner:", j)
         nested_inner_count = nested_inner_count + 1
+        push(test8_inner_values, j)
+mut expected_test8_outer_values: [i32] = []
+push(expected_test8_outer_values, 1)
+push(expected_test8_outer_values, 2)
+mut expected_test8_inner_values: [i32] = []
+push(expected_test8_inner_values, 1)
+push(expected_test8_inner_values, 2)
+push(expected_test8_inner_values, 1)
+push(expected_test8_inner_values, 2)
+if assert_eq("loop_safety_integration test8_outer_values", test8_outer_values, expected_test8_outer_values):
+    print("ok", "test8_outer_values", test8_outer_values)
+if assert_eq("loop_safety_integration test8_inner_values", test8_inner_values, expected_test8_inner_values):
+    print("ok", "test8_inner_values", test8_inner_values)
 print("Test 8 done")
 
 // Test 9: Large loop - should NOT be unrolled
 print("Test 9: Large loop (1..15)")
 mut test9_count = 0
+mut test9_values: [i32] = []
 for i in 1..15:
     print("Large:", i)
     test9_count = test9_count + 1
+    push(test9_values, i)
+mut expected_test9_values: [i32] = []
+for value in 1..15:
+    push(expected_test9_values, value)
+if assert_eq("loop_safety_integration test9_values", test9_values, expected_test9_values):
+    print("ok", "test9_values", test9_values)
 print("Test 9 done")
 
 // Test 10: Negative step - should be unrolled
 print("Test 10: Negative step (10..6..-2)")
 mut test10_count = 0
+mut test10_values: [i32] = []
 for i in 10..6..-2:
     print("Negative step:", i)
     test10_count = test10_count + 1
+    push(test10_values, i)
+mut expected_test10_values: [i32] = []
+push(expected_test10_values, 10)
+push(expected_test10_values, 8)
+if assert_eq("loop_safety_integration test10_values", test10_values, expected_test10_values):
+    print("ok", "test10_values", test10_values)
 print("Test 10 done")
 
 print("=== All Loop Optimization Tests Complete ===")


### PR DESCRIPTION
## Summary
- update loop safety integration tracking arrays to use i32 elements and record expected sequences explicitly
- build runtime arrays for expected iteration values and control-flow events before assert_eq checks