### PR TITLE
Avoid repeating error messages in diagnostics

### DIFF
--- a/include/errors/features/variable_errors.h
+++ b/include/errors/features/variable_errors.h
@@ -95,6 +95,14 @@ ErrorReportResult report_mutable_required(SrcLocation location, const char* vari
 ErrorReportResult report_invalid_variable_name(SrcLocation location, const char* variable_name, const char* reason);
 
 /**
+ * Report use of a reserved keyword as an identifier
+ * @param location Source location of the misuse
+ * @param keyword The reserved keyword text
+ * @param context Description of what was being named (e.g. "variable")
+ */
+ErrorReportResult report_reserved_keyword_usage(SrcLocation location, const char* keyword, const char* context);
+
+/**
  * Report invalid multiple declaration error
  * @param location Source location of the error
  * @param variable_name Name of the variable with declaration issues

--- a/src/errors/features/variable_errors.c
+++ b/src/errors/features/variable_errors.c
@@ -15,6 +15,8 @@
 #include <ctype.h>
 #include <limits.h>
 
+static bool is_reserved_keyword_name_internal(const char* name);
+
 // Variable error definitions with friendly, mentor-like messages
 static const FeatureErrorInfo variable_errors[] = {
     {
@@ -135,14 +137,23 @@ ErrorReportResult report_mutable_required(SrcLocation location, const char* vari
 
 ErrorReportResult report_invalid_variable_name(SrcLocation location, const char* variable_name, const char* reason) {
     if (reason) {
-        return report_feature_error_f(E1013_INVALID_VARIABLE_NAME, location, 
-                                     "Invalid variable name '%s': %s", 
+        return report_feature_error_f(E1013_INVALID_VARIABLE_NAME, location,
+                                     "Invalid variable name '%s': %s",
                                      variable_name, reason);
     } else {
-        return report_feature_error_f(E1013_INVALID_VARIABLE_NAME, location, 
-                                     "Invalid variable name '%s'", 
+        return report_feature_error_f(E1013_INVALID_VARIABLE_NAME, location,
+                                     "Invalid variable name '%s'",
                                      variable_name);
     }
+}
+
+ErrorReportResult report_reserved_keyword_usage(SrcLocation location, const char* keyword, const char* context) {
+    if (!context || *context == '\0') {
+        context = "identifier";
+    }
+    return report_feature_error_f(E1013_INVALID_VARIABLE_NAME, location,
+                                 "Cannot use reserved keyword '%s' as the %s name.",
+                                 keyword, context);
 }
 
 ErrorReportResult report_invalid_multiple_declaration(SrcLocation location, const char* variable_name, const char* issue) {
@@ -254,7 +265,7 @@ bool is_valid_variable_name(const char* name) {
     if (!name || *name == '\0') {
         return false;
     }
-    
+
     // Must start with letter or underscore
     if (!isalpha(*name) && *name != '_') {
         return false;
@@ -266,7 +277,11 @@ bool is_valid_variable_name(const char* name) {
             return false;
         }
     }
-    
+
+    if (is_reserved_keyword_name_internal(name)) {
+        return false;
+    }
+
     return true;
 }
 
@@ -289,6 +304,68 @@ const char* get_variable_name_violation_reason(const char* name) {
             return "name can only contain letters, digits, and underscores";
         }
     }
-    
+
+    if (is_reserved_keyword_name_internal(name)) {
+        return "this name is reserved by the language";
+    }
+
     return NULL; // Name is valid
+}
+
+static bool is_reserved_keyword_name_internal(const char* name) {
+    static const char* const reserved_keywords[] = {
+        "and",
+        "as",
+        "bool",
+        "break",
+        "catch",
+        "const",
+        "continue",
+        "elif",
+        "else",
+        "enum",
+        "false",
+        "fn",
+        "for",
+        "f64",
+        "global",
+        "if",
+        "impl",
+        "in",
+        "i32",
+        "i64",
+        "match",
+        "matches",
+        "module",
+        "mut",
+        "not",
+        "or",
+        "pass",
+        "print",
+        "print_no_newline",
+        "pub",
+        "return",
+        "static",
+        "struct",
+        "throw",
+        "time_stamp",
+        "true",
+        "try",
+        "while",
+        "u32",
+        "u64",
+        "use"
+    };
+
+    if (!name) {
+        return false;
+    }
+
+    size_t count = sizeof(reserved_keywords) / sizeof(reserved_keywords[0]);
+    for (size_t i = 0; i < count; i++) {
+        if (strcmp(name, reserved_keywords[i]) == 0) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/errors/infrastructure/error_infrastructure.c
+++ b/src/errors/infrastructure/error_infrastructure.c
@@ -515,12 +515,9 @@ ErrorReportResult report_enhanced_error_ctx(ErrorContext* ctx, const EnhancedErr
         fprintf(stderr, "      |\n");
     }
     
-    // Main explanation
-    fprintf(stderr, "      = %s\n", error->message ? error->message : "Unknown error");
-    
     // Help and notes with bounds checking
     if (error->help && ctx->config.show_help) {
-        fprintf(stderr, "      = %shelp%s: %s\n", 
+        fprintf(stderr, "      = %shelp%s: %s\n",
                 help_color, reset_color, error->help);
     }
     
@@ -631,12 +628,9 @@ ErrorReportResult report_enhanced_error(const EnhancedError* error) {
         fprintf(stderr, "      |\n");
     }
     
-    // Main explanation
-    fprintf(stderr, "      = %s\n", error->message ? error->message : "Unknown error");
-    
     // Help and notes with bounds checking
     if (error->help && g_error_state.config.show_help) {
-        fprintf(stderr, "      = %shelp%s: %s\n", 
+        fprintf(stderr, "      = %shelp%s: %s\n",
                 help_color, reset_color, error->help);
     }
     


### PR DESCRIPTION
## Summary
- stop printing the same error message twice in the enhanced error reporter
- keep the caret line messaging while leaving the help/note section unchanged