### PR TITLE
Group expected failure tests under CORRECT FAIL category

### DIFF
--- a/include/compiler/optimization/optimizer.h
+++ b/include/compiler/optimization/optimizer.h
@@ -25,7 +25,6 @@ typedef struct OptimizationContext {
     bool enable_constant_folding;       // Fold 2+3 → 5
     bool enable_dead_code_elimination;  // Remove unused variables
     bool enable_common_subexpression;   // Eliminate duplicate expressions
-    bool enable_loop_invariant_code_motion; // Deprecated – loop optimizations removed
     
     // Analysis results (TODO: implement in advanced phases)
     ConstantTable* constants;          // Known constant values
@@ -37,10 +36,6 @@ typedef struct OptimizationContext {
     int nodes_eliminated;
     int constants_folded;
     int binary_expressions_folded;      // Specific to constant folding
-    int loop_invariants_hoisted;        // Legacy LICM statistics (always zero)
-    int loops_optimized;                // Legacy LICM statistics (always zero)
-    int licm_guard_fusions;             // Legacy LICM statistics (always zero)
-    int licm_redundant_guard_fusions;   // Legacy LICM statistics (always zero)
 
     // Debug information
     bool verbose_output;               // Enable detailed optimization logging

--- a/include/compiler/typed_ast.h
+++ b/include/compiler/typed_ast.h
@@ -74,11 +74,6 @@ struct TypedASTNode {
     int suggestedRegister;   // Suggested register for this value (-1 if none)
     bool spillable;          // Whether this value can be spilled to memory
 
-    // Typed loop optimization metadata
-    uint32_t typed_escape_mask;   // Bitmask describing which guards escape the loop
-    bool typed_guard_witness;     // True if guard has a stable type witness
-    bool typed_metadata_stable;   // Tracks whether typed metadata survived optimization
-    
     // Child nodes (typed versions)
     union {
         struct {

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -763,7 +763,6 @@ typedef struct {
     bool nestedLoopUsage;   // Whether used in nested loops
     bool crossesLoopBoundary; // Whether lifetime crosses loop boundaries
     bool isShortLived;      // Whether variable has short lifetime
-    bool isLoopInvariant;   // Whether variable is loop invariant
     int priority;           // Priority for register allocation
 } LiveRange;
 
@@ -790,26 +789,6 @@ typedef struct {
     int loopVarStartInstr; // Instruction where loop variable becomes live
 } LoopContext;
 
-// Loop Invariant Code Motion (LICM) instruction-level data structures
-typedef struct {
-    int instructionOffset;    // Offset in bytecode where invariant operation occurs
-    uint8_t operation;        // The operation opcode
-    uint8_t operand1;         // First operand register
-    uint8_t operand2;         // Second operand register  
-    uint8_t result;           // Result register
-    bool canHoist;            // Whether this operation can be safely hoisted
-    bool hasBeenHoisted;      // Whether this has already been hoisted
-} InvariantNode;
-
-typedef struct {
-    InvariantNode* invariantNodes;  // Array of detected invariant operations
-    int count;                      // Number of invariant operations found
-    int capacity;                   // Capacity of arrays
-    uint8_t* hoistedRegs;          // Registers used for hoisted values
-    uint8_t* originalInstructions; // Original instruction opcodes
-    bool* canHoist;                // Which operations can be hoisted
-} InstructionLICMAnalysis;
-
 // Forward declarations  
 struct TypeInferer;
 
@@ -822,7 +801,6 @@ typedef struct ScopeVariable {
     int lastUse;             // Last use of the variable
     bool escapes;            // Whether variable escapes current scope
     bool isLoopVar;          // Whether this is a loop induction variable
-    bool isLoopInvariant;    // Whether variable is loop invariant
     bool crossesLoopBoundary; // Whether lifetime crosses loop boundaries
     uint8_t reg;             // Assigned register
     int priority;            // Priority for register allocation

--- a/src/compiler/backend/optimization/optimizer.c
+++ b/src/compiler/backend/optimization/optimizer.c
@@ -30,7 +30,6 @@ OptimizationContext* init_optimization_context(void) {
     ctx->enable_constant_folding = true;
     ctx->enable_dead_code_elimination = false; // Future phase
     ctx->enable_common_subexpression = false;  // Future phase
-    ctx->enable_loop_invariant_code_motion = false;
     
     // Initialize analysis structures (for future advanced features)
     ctx->constants = NULL;
@@ -42,10 +41,6 @@ OptimizationContext* init_optimization_context(void) {
     ctx->nodes_eliminated = 0;
     ctx->constants_folded = 0;
     ctx->binary_expressions_folded = 0;
-    ctx->loop_invariants_hoisted = 0;
-    ctx->loops_optimized = 0;
-    ctx->licm_guard_fusions = 0;
-    ctx->licm_redundant_guard_fusions = 0;
     
     // Enable detailed logging
     ctx->verbose_output = true;
@@ -77,15 +72,12 @@ TypedASTNode* optimize_typed_ast(TypedASTNode* input_ast, OptimizationContext* c
         }
     }
     
-    // Phase 2: Loop Invariant Code Motion
-    (void)ctx; // Loop optimization hooks removed; keep signature stable for now.
-
-    // Phase 3: Dead Code Elimination (Future)
+    // Phase 2: Dead Code Elimination (Future)
     if (ctx->enable_dead_code_elimination) {
         printf("[OPTIMIZER] Dead code elimination not yet implemented\n");
     }
 
-    // Phase 4: Common Subexpression Elimination (Future)
+    // Phase 3: Common Subexpression Elimination (Future)
     if (ctx->enable_common_subexpression) {
         printf("[OPTIMIZER] Common subexpression elimination not yet implemented\n");
     }

--- a/src/compiler/typed_ast.c
+++ b/src/compiler/typed_ast.c
@@ -38,12 +38,9 @@ TypedASTNode* create_typed_ast_node(ASTNode* original) {
     typed->hasTypeError = false;
     typed->errorMessage = NULL;
     typed->isConstant = false;
-   typed->canInline = false;
-   typed->suggestedRegister = -1;
-   typed->spillable = true;
-    typed->typed_escape_mask = 0;
-    typed->typed_guard_witness = false;
-    typed->typed_metadata_stable = false;
+    typed->canInline = false;
+    typed->suggestedRegister = -1;
+    typed->spillable = true;
 
     // Initialize union based on node type
     switch (original->type) {

--- a/src/main.c
+++ b/src/main.c
@@ -21,7 +21,6 @@
 #include "errors/error_interface.h"
 #include "errors/features/type_errors.h"
 #include "errors/features/variable_errors.h"
-// #include "compiler/loop_optimization.h" // DISABLED in Phase 2
 #include "tools/repl.h"
 #include "public/version.h"
 #include "config/config.h"

--- a/tests/error_reporting/run_error_tests.py
+++ b/tests/error_reporting/run_error_tests.py
@@ -89,6 +89,16 @@ def run_case(binary: Path, case: ErrorCase) -> tuple[bool, str]:
     return True, ""
 
 
+def format_status(passed: bool, expect_success: bool) -> str:
+    if passed:
+        label = "PASS" if expect_success else "CORRECT FAIL"
+        color = "\033[32m"
+    else:
+        label = "FAIL"
+        color = "\033[31m"
+    return f"{color}{label}\033[0m"
+
+
 def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run Orus error-reporting regression suite")
     parser.add_argument(
@@ -108,7 +118,7 @@ def main(argv: Iterable[str] | None = None) -> int:
     failures: list[tuple[ErrorCase, str]] = []
     for case in cases:
         passed, detail = run_case(binary, case)
-        status = "PASS" if passed else "FAIL"
+        status = format_status(passed, case.expect_success)
         print(f"[{status}] {binary.name} {case.program.relative_to(repo_root)}")
         if detail:
             for line in detail.splitlines():


### PR DESCRIPTION
## Summary
- update the main test harness to collect all expected failure programs into a single CORRECT FAIL section
- ensure CLI smoke and error-reporting runners label successful failure cases as CORRECT FAIL
- limit the expected-failure list to scenarios that currently terminate with errors