### PR TITLE
Add VM support for i64→u32 casts

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -541,6 +541,7 @@ typedef enum {
     OP_U64_TO_BOOL_R,
     OP_F64_TO_BOOL_R,
     OP_I32_TO_U32_R,
+    OP_I64_TO_U32_R,
     OP_U32_TO_I32_R,
     OP_F64_TO_U32_R,
     OP_U32_TO_F64_R,

--- a/src/compiler/backend/codegen/codegen.c
+++ b/src/compiler/backend/codegen/codegen.c
@@ -1367,6 +1367,7 @@ uint8_t get_cast_opcode(TypeKind from_type, TypeKind to_type) {
             case TYPE_I32: return OP_I64_TO_I32_R;
             case TYPE_F64: return OP_I64_TO_F64_R;
             case TYPE_U64: return OP_I64_TO_U64_R;
+            case TYPE_U32: return OP_I64_TO_U32_R;
             default: break;
         }
     }
@@ -3910,6 +3911,8 @@ int compile_expression(CompilerContext* ctx, TypedASTNode* expr) {
                 cast_opcode = OP_I64_TO_F64_R;
             } else if (source_type->kind == TYPE_I64 && target_type->kind == TYPE_U64) {
                 cast_opcode = OP_I64_TO_U64_R;
+            } else if (source_type->kind == TYPE_I64 && target_type->kind == TYPE_U32) {
+                cast_opcode = OP_I64_TO_U32_R;
             } else if (source_type->kind == TYPE_I64 && target_type->kind == TYPE_BOOL) {
                 cast_opcode = OP_I64_TO_BOOL_R;
             } else if (source_type->kind == TYPE_F64 && target_type->kind == TYPE_I32) {

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -296,6 +296,7 @@ InterpretResult vm_run_dispatch(void) {
         vm_dispatch_table[OP_I32_TO_BOOL_R] = &&LABEL_OP_I32_TO_BOOL_R;
         vm_dispatch_table[OP_U32_TO_I32_R] = &&LABEL_OP_U32_TO_I32_R;
         vm_dispatch_table[OP_I64_TO_I32_R] = &&LABEL_OP_I64_TO_I32_R;
+        vm_dispatch_table[OP_I64_TO_U32_R] = &&LABEL_OP_I64_TO_U32_R;
         vm_dispatch_table[OP_I64_TO_BOOL_R] = &&LABEL_OP_I64_TO_BOOL_R;
         vm_dispatch_table[OP_ADD_F64_R] = &&LABEL_OP_ADD_F64_R;
         vm_dispatch_table[OP_SUB_F64_R] = &&LABEL_OP_SUB_F64_R;
@@ -1487,6 +1488,22 @@ InterpretResult vm_run_dispatch(void) {
                 VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i64");
             }
             vm_set_register_safe(dst, I32_VAL((int32_t)AS_I64(src_val)));
+            DISPATCH();
+        }
+
+    LABEL_OP_I64_TO_U32_R: {
+            uint8_t dst = READ_BYTE();
+            uint8_t src = READ_BYTE();
+             (void)READ_BYTE(); // Skip third operand (unused)
+            Value src_val = vm_get_register_safe(src);
+            if (!IS_I64(src_val)) {
+                VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i64");
+            }
+            int64_t val = AS_I64(src_val);
+            if (val < 0 || val > (int64_t)UINT32_MAX) {
+                VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "i64 value out of u32 range");
+            }
+            vm_set_register_safe(dst, U32_VAL((uint32_t)val));
             DISPATCH();
         }
 

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -1023,6 +1023,21 @@ InterpretResult vm_run_dispatch(void) {
                     break;
                 }
 
+                case OP_I64_TO_U32_R: {
+                    uint8_t dst = READ_BYTE();
+                    uint8_t src = READ_BYTE();
+                    READ_BYTE(); // Skip third operand (unused)
+                    if (!IS_I64(vm_get_register_safe(src))) {
+                        VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Source must be i64");
+                    }
+                    int64_t val = AS_I64(vm_get_register_safe(src));
+                    if (val < 0 || val > (int64_t)UINT32_MAX) {
+                        VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "i64 value out of u32 range");
+                    }
+                    vm_set_register_safe(dst, U32_VAL((uint32_t)val));
+                    break;
+                }
+
                 case OP_I64_TO_BOOL_R: {
                     uint8_t dst = READ_BYTE();
                     uint8_t src = READ_BYTE();


### PR DESCRIPTION
## Summary
- add a dedicated OP_I64_TO_U32_R opcode to the VM and register it in both dispatch loops
- update the code generator to request the new opcode when emitting i64 to u32 casts
- expose the opcode through the public VM enum so chained casts including i64→u32 succeed

## Testing
- ./orus tests/types/casts/comprehensive_cast_matrix.orus

------
https://chatgpt.com/codex/tasks/task_e_68e1aa79a58c83258b6788b0a8989009