### PR TITLE
Refactor module system to infer modules from file paths

### DIFF
--- a/docs/COMPLETE_ORUS_TUTORIAL.md
+++ b/docs/COMPLETE_ORUS_TUTORIAL.md
@@ -566,22 +566,16 @@ predictable.
 
 ## 16. Modules
 
-A file may begin with a `module` declaration to establish its path. The declaration must be the first non-comment statement and
-may appear only once per file.
+Module names are inferred directly from the filesystem. The file `geometry/points.orus` defines the module `geometry.points`, and declarations live at the top level—there is no `module` keyword to wrap the file.
 
 ```orus
-module geometry.points:
+pub struct Point:
+    x: i32
+    y: i32
 
-    pub struct Point:
-        x: i32
-        y: i32
-
-    pub fn origin() -> Point:
-        return Point{ x: 0, y: 0 }
+pub fn origin() -> Point:
+    return Point{ x: 0, y: 0 }
 ```
-
-The block form shown above requires the whole file to remain indented beneath the module declaration. Alternatively, use the
-single-line form `module geometry.points` followed by top-level definitions.
 
 ### 16.1 Imports with `use`
 
@@ -669,7 +663,7 @@ print("elapsed seconds:", elapsed)
 - **Annotate intent.** Type annotations communicate design intent to readers and help the compiler surface better diagnostics.
 - **Prefer explicit casts.** Because Orus does not perform implicit promotions, sprinkle `as` conversions where clarity demands it
   rather than relying on subtle coercion rules.
-- **Use modules early.** Organise code by feature. Even small programs benefit from `module` declarations and selective `use`
+- **Use modules early.** Organise code by feature. Even small programs benefit from directory-based modules and selective `use`
   imports.
 - **Design enums for exhaustive matches.** Pattern matching shines when every state is accounted for. Include a `_` arm only when
   you intentionally accept all remaining cases.
@@ -686,21 +680,19 @@ programs with confidence.
 Here is a complete example that exercises the concepts covered above:
 
 ```orus
-module diagnostics.report:
+pub struct Sample:
+    values: [i32]
 
-    pub struct Sample:
-        values: [i32]
+pub fn collect(limit: i32) -> Sample:
+    mut data: [i32] = []
+    for n in 0..=limit:
+        if n % 2 == 0:
+            push(data, n)
+    return Sample{ values: data }
 
-    pub fn collect(limit: i32) -> Sample:
-        mut data: [i32] = []
-        for n in 0..=limit:
-            if n % 2 == 0:
-                push(data, n)
-        return Sample{ values: data }
-
-    pub fn summarize(sample: Sample) -> string:
-        total = len(sample.values)
-        return "even count: " + (total as string)
+pub fn summarize(sample: Sample) -> string:
+    total = len(sample.values)
+    return "even count: " + (total as string)
 ```
 
 ```orus

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -302,8 +302,8 @@ throw "boom"
 ```
 
 ### Modules and Imports
-- Files may start with `module path` or `module path:`. The declaration must be the first non-comment statement and may appear only once. The block form (`module pkg.tools:`) requires the entire file to be indented under the declaration.
-- Dotted module names map to directories (`module pkg.stats` lives at `pkg/stats.orus`).
+- Module names are inferred from the file path. The file `geometry/points.orus` defines the module `geometry.points`.
+- Files contain declarations directly—there is no `module` keyword or required indentation block.
 - `use` is available only at module scope:
   - `use math` imports all public symbols.
   - `use math: *` is synonymous with importing all symbols.
@@ -313,14 +313,12 @@ throw "boom"
 - Globals must be uppercase identifiers and may be exported with `pub global`.
 
 ```orus
-module geometry.points:
+pub struct Point:
+    x: i32
+    y: i32
 
-    pub struct Point:
-        x: i32
-        y: i32
-
-    pub fn origin() -> Point:
-        return Point{ x: 0, y: 0 }
+pub fn origin() -> Point:
+    return Point{ x: 0, y: 0 }
 ```
 
 In another file:

--- a/docs/REGISTER_VM_ARCHITECTURE_IMPROVEMENT.md
+++ b/docs/REGISTER_VM_ARCHITECTURE_IMPROVEMENT.md
@@ -296,12 +296,11 @@ fn fibonacci(n: i32) -> i32:
 ### Modular Code
 ```orus
 // Module-level organization
-module math:
-    mut PI = 3.14159;     // ✅ Module register
-    
-    fn calculate_area(r: f64) -> f64:
-        mut area = PI * r * r;  // ✅ Frame register
-        return area;
+pub global mut PI = 3.14159;     // ✅ Module register
+
+fn calculate_area(r: f64) -> f64:
+    mut area = PI * r * r;  // ✅ Frame register
+    return area;
 ```
 
 ## Risk Assessment

--- a/include/compiler/ast.h
+++ b/include/compiler/ast.h
@@ -123,7 +123,6 @@ struct ASTNode {
             ASTNode** declarations;
             int count;
             char* moduleName;
-            bool hasModuleDeclaration;
         } program;
         struct {
             char* name;

--- a/include/compiler/lexer.h
+++ b/include/compiler/lexer.h
@@ -90,7 +90,6 @@ typedef enum {
     TOKEN_MATCHES,
     TOKEN_PUB,
     TOKEN_GLOBAL,
-    TOKEN_MODULE,
     TOKEN_STATIC,
 
     // Add type tokens

--- a/include/compiler/parser.h
+++ b/include/compiler/parser.h
@@ -62,7 +62,9 @@ void parser_context_reset(ParserContext* ctx);
 
 // Main parsing interface
 ASTNode* parseSource(const char* source);
+ASTNode* parseSourceWithModuleName(const char* source, const char* module_name);
 ASTNode* parseSourceWithContext(ParserContext* ctx, const char* source);
+ASTNode* parseSourceWithContextAndModule(ParserContext* ctx, const char* source, const char* module_name);
 
 // Debug control
 void set_parser_debug(bool enabled);

--- a/include/compiler/typed_ast.h
+++ b/include/compiler/typed_ast.h
@@ -80,7 +80,6 @@ struct TypedASTNode {
             TypedASTNode** declarations;
             int count;
             const char* moduleName;
-            bool hasModuleDeclaration;
         } program;
         struct {
             TypedASTNode* initializer;

--- a/src/compiler/backend/typed_ast_visualizer.c
+++ b/src/compiler/backend/typed_ast_visualizer.c
@@ -361,7 +361,7 @@ static void visualize_node_recursive(TypedASTNode* node, int depth, bool is_last
             }
             break;
         case NODE_PROGRAM:
-            if (node->typed.program.hasModuleDeclaration && node->typed.program.moduleName) {
+            if (node->typed.program.moduleName) {
                 printf(" module='%s'", node->typed.program.moduleName);
             }
             break;

--- a/src/compiler/frontend/lexer.c
+++ b/src/compiler/frontend/lexer.c
@@ -288,8 +288,6 @@ static TokenType identifier_type(const char* start, int length) {
                 return TOKEN_MATCH;
             if (length == 7 && memcmp(start, "matches", 7) == 0)
                 return TOKEN_MATCHES;
-            if (length == 6 && memcmp(start, "module", 6) == 0)
-                return TOKEN_MODULE;
             break;
         case 'n':
             if (length == 3 && memcmp(start, "not", 3) == 0) return TOKEN_NOT;
@@ -988,7 +986,6 @@ const char* token_type_to_string(TokenType type) {
         case TOKEN_MATCHES: return "MATCHES";
         case TOKEN_PUB: return "PUB";
         case TOKEN_GLOBAL: return "GLOBAL";
-        case TOKEN_MODULE: return "MODULE";
         case TOKEN_STATIC: return "STATIC";
         case TOKEN_U32: return "U32";
         case TOKEN_U64: return "U64";

--- a/src/compiler/typed_ast.c
+++ b/src/compiler/typed_ast.c
@@ -48,7 +48,6 @@ TypedASTNode* create_typed_ast_node(ASTNode* original) {
             typed->typed.program.declarations = NULL;
             typed->typed.program.count = 0;
             typed->typed.program.moduleName = original->program.moduleName;
-            typed->typed.program.hasModuleDeclaration = original->program.hasModuleDeclaration;
             break;
         case NODE_VAR_DECL:
             typed->typed.varDecl.initializer = NULL;

--- a/src/type/type_inference.c
+++ b/src/type/type_inference.c
@@ -3811,7 +3811,6 @@ static TypedASTNode* generate_typed_ast_recursive(ASTNode* ast, TypeEnv* type_en
                 }
             }
             typed->typed.program.moduleName = ast->program.moduleName;
-            typed->typed.program.hasModuleDeclaration = ast->program.hasModuleDeclaration;
             break;
 
         case NODE_VAR_DECL:

--- a/tests/modules/alias_provider.orus
+++ b/tests/modules/alias_provider.orus
@@ -1,5 +1,3 @@
-module alias_provider
-
 pub global OFFSET: i32 = 7
 
 pub fn add_offset(value: i32) -> i32:

--- a/tests/modules/math_module.orus
+++ b/tests/modules/math_module.orus
@@ -1,5 +1,3 @@
-module math_module
-
 pub global PI = 314
 
 pub fn double(value):

--- a/tests/modules/module_import_alias.orus
+++ b/tests/modules/module_import_alias.orus
@@ -1,5 +1,5 @@
-use alias_provider: OFFSET as START, add_offset as bump
-use math_module: double as twice
+use tests.modules.alias_provider: OFFSET as START, add_offset as bump
+use tests.modules.math_module: double as twice
 
 bumped = bump(START)
 doubled = twice(bumped)

--- a/tests/modules/module_imports.orus
+++ b/tests/modules/module_imports.orus
@@ -1,4 +1,4 @@
-use math_module: PI, bump
+use tests.modules.math_module: PI, bump
 
 print("PI:", PI)
 print("First bump:", bump())

--- a/tests/modules/package_import.orus
+++ b/tests/modules/package_import.orus
@@ -1,4 +1,4 @@
-use pkg.stats: add, sum_three, ZERO
+use tests.modules.pkg.stats: add, sum_three, ZERO
 
 pair_sum = add(4, 5)
 triple_sum = sum_three(ZERO, pair_sum, 6)

--- a/tests/modules/pkg/stats.orus
+++ b/tests/modules/pkg/stats.orus
@@ -1,9 +1,7 @@
-module pkg.stats:
+pub global ZERO = 0
 
-    pub global ZERO = 0
+pub fn add(a: i32, b: i32) -> i32:
+    return a + b
 
-    pub fn add(a: i32, b: i32) -> i32:
-        return a + b
-
-    pub fn sum_three(a: i32, b: i32, c: i32) -> i32:
-        return add(add(a, b), c)
+pub fn sum_three(a: i32, b: i32, c: i32) -> i32:
+    return add(add(a, b), c)

--- a/tests/modules/type_imports.orus
+++ b/tests/modules/type_imports.orus
@@ -1,4 +1,4 @@
-use type_provider: Point as P, Color, origin
+use tests.modules.type_provider: Point as P, Color, origin
 
 fn add(point: P) -> i32:
     return point.x + point.y

--- a/tests/modules/type_provider.orus
+++ b/tests/modules/type_provider.orus
@@ -1,5 +1,3 @@
-module type_provider
-
 pub struct Point:
     x: i32
     y: i32

--- a/tests/type_safety_fails/import_alias_type_mismatch_fail.orus
+++ b/tests/type_safety_fails/import_alias_type_mismatch_fail.orus
@@ -1,4 +1,4 @@
-use alias_provider: add_offset as bump
+use tests.modules.alias_provider: add_offset as bump
 
 // Passing a string should fail because bump expects i32
 bump("oops")


### PR DESCRIPTION
## Summary
- drop the `module` keyword by updating the parser and AST to infer module names from file paths
- extend the VM runtime to derive module identifiers from file paths and resolve `use` imports against the new naming scheme
- refresh documentation and module-based tests to use path-based module names and imports

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68e12aa9c02c83259a7880dd091bc5d4