### PR TITLE
Ensure register allocator logging macros are statement-safe

### DIFF
--- a/include/compiler/register_allocator.h
+++ b/include/compiler/register_allocator.h
@@ -16,6 +16,10 @@
 #include <stdbool.h>
 #include "vm/vm.h"  // For RegisterType enum
 
+#ifndef REGISTER_ALLOCATOR_DEBUG
+#define REGISTER_ALLOCATOR_DEBUG 0
+#endif
+
 // Multi-pass compiler register ranges (mirrors VM register layout)
 #define MP_GLOBAL_REG_START    GLOBAL_REG_START
 #define MP_GLOBAL_REG_END      (GLOBAL_REG_START + GLOBAL_REGISTERS - 1)


### PR DESCRIPTION
## Summary
- wrap the register allocator logging macros in statement-safe do-while blocks so they behave consistently with semicolon usage while keeping warnings and errors always active
- add the missing newline terminator to the register allocator header for cleaner includes