### PR TITLE
Let callers manage constant folding statistics

### DIFF
--- a/include/compiler/optimization/constantfold.h
+++ b/include/compiler/optimization/constantfold.h
@@ -13,7 +13,6 @@
 #define CONSTANTFOLD_H
 
 #include "compiler/typed_ast.h"
-#include "compiler/optimization/optimizer.h"
 
 // Constant folding algorithm implementation
 // Transforms binary expressions with literal operands into single literals
@@ -27,13 +26,13 @@ typedef struct ConstantFoldContext {
 } ConstantFoldContext;
 
 // Main constant folding function
-bool apply_constant_folding(TypedASTNode* ast, OptimizationContext* opt_ctx);
-bool apply_constant_folding_recursive(TypedASTNode* ast);
+bool apply_constant_folding(TypedASTNode* ast, ConstantFoldContext* ctx);
+bool apply_constant_folding_recursive(TypedASTNode* ast, ConstantFoldContext* ctx);
 
 // Individual folding functions
-bool fold_binary_expression(TypedASTNode* node);
-bool fold_unary_expression(TypedASTNode* node);
-void fold_ast_node_directly(ASTNode* node);
+bool fold_binary_expression(TypedASTNode* node, ConstantFoldContext* ctx);
+bool fold_unary_expression(TypedASTNode* node, ConstantFoldContext* ctx);
+void fold_ast_node_directly(ASTNode* node, ConstantFoldContext* ctx);
 
 // Helper functions
 bool is_foldable_binary(TypedASTNode* node);

--- a/src/compiler/backend/optimization/optimizer.c
+++ b/src/compiler/backend/optimization/optimizer.c
@@ -66,10 +66,16 @@ TypedASTNode* optimize_typed_ast(TypedASTNode* input_ast, OptimizationContext* c
     
     // Phase 1: Constant Folding (re-enabled after fixing memory corruption)
     if (ctx->enable_constant_folding) {
-        if (!apply_constant_folding(input_ast, ctx)) {
+        ConstantFoldContext fold_ctx;
+        if (!apply_constant_folding(input_ast, &fold_ctx)) {
             printf("[OPTIMIZER] ❌ Constant folding failed\n");
             return input_ast;
         }
+
+        ctx->optimizations_applied += fold_ctx.optimizations_applied;
+        ctx->constants_folded += fold_ctx.constants_folded;
+        ctx->binary_expressions_folded += fold_ctx.binary_expressions_folded;
+        ctx->nodes_eliminated += fold_ctx.nodes_eliminated;
     }
     
     // Phase 2: Dead Code Elimination (Future)


### PR DESCRIPTION
## Summary
- allow `apply_constant_folding` to accept a caller-supplied statistics context and fall back to a local stack allocation when none is provided
- remove the direct dependency on the optimizer context from the constant folding module
- update the optimizer to allocate a folding context, pass it into the pass, and merge the resulting counters back into its aggregate statistics