### PR TITLE
Treat time_stamp builtin as identifier

### DIFF
--- a/include/compiler/lexer.h
+++ b/include/compiler/lexer.h
@@ -67,7 +67,6 @@ typedef enum {
     TOKEN_NOT,
     TOKEN_PRINT,
     TOKEN_PRINT_NO_NL,
-    TOKEN_TIME_STAMP,
     TOKEN_RETURN,
     TOKEN_MUT,
     TOKEN_CONST,

--- a/src/compiler/frontend/lexer.c
+++ b/src/compiler/frontend/lexer.c
@@ -311,7 +311,6 @@ static TokenType identifier_type(const char* start, int length) {
         case 't':
             if (length == 3 && memcmp(start, "try", 3) == 0) return TOKEN_TRY;
             if (length == 5 && memcmp(start, "throw", 5) == 0) return TOKEN_THROW;
-            if (length == 10 && memcmp(start, "time_stamp", 10) == 0) return TOKEN_TIME_STAMP;
             break;
         case 'u':
             if (length == 3 && memcmp(start, "use", 3) == 0) return TOKEN_IMPORT;
@@ -955,7 +954,6 @@ const char* token_type_to_string(TokenType type) {
         case TOKEN_NOT: return "NOT";
         case TOKEN_PRINT: return "PRINT";
         case TOKEN_PRINT_NO_NL: return "PRINT_NO_NL";
-        case TOKEN_TIME_STAMP: return "TIME_STAMP";
         case TOKEN_RETURN: return "RETURN";
         case TOKEN_MUT: return "MUT";
         case TOKEN_CONST: return "CONST";

--- a/src/compiler/frontend/parser.c
+++ b/src/compiler/frontend/parser.c
@@ -143,7 +143,6 @@ static bool is_reserved_keyword_token(TokenType type) {
         case TOKEN_NOT:
         case TOKEN_PRINT:
         case TOKEN_PRINT_NO_NL:
-        case TOKEN_TIME_STAMP:
         case TOKEN_RETURN:
         case TOKEN_MUT:
         case TOKEN_CONST:
@@ -3793,12 +3792,12 @@ static ASTNode* parsePrimaryExpression(ParserContext* ctx) {
         case TOKEN_IDENTIFIER:
             if (token_text_equals(&token, "true") || token_text_equals(&token, "false")) {
                 node = parseBooleanLiteral(ctx, token);
+            } else if (token_text_equals(&token, "time_stamp") &&
+                       peekToken(ctx).type == TOKEN_LEFT_PAREN) {
+                node = parseTimeStampExpression(ctx, token);
             } else {
                 node = parseIdentifierExpression(ctx, token);
             }
-            break;
-        case TOKEN_TIME_STAMP:
-            node = parseTimeStampExpression(ctx, token);
             break;
         case TOKEN_LEFT_PAREN:
             node = parseParenthesizedExpressionToken(ctx, token);


### PR DESCRIPTION
## Summary
- remove `time_stamp` from the lexer keyword table so it tokenizes as a regular identifier
- adjust the parser to recognize the builtin call by identifier text while allowing non-call uses