### PR TITLE
Refactor typed arithmetic handlers via macro generator

### DIFF
--- a/src/vm/handlers/vm_arithmetic_handlers.c
+++ b/src/vm/handlers/vm_arithmetic_handlers.c
@@ -99,592 +99,87 @@ static inline bool read_f64_operand(uint16_t reg, double* out) {
     return true;
 }
 
+#define DEFINE_TYPED_ARITH_HANDLER(OP_NAME, TYPE_SUFFIX, CTYPE, READ_FN, STORE_FN, ZERO_GUARD, RESULT_EXPR) \
+    void handle_##OP_NAME##_##TYPE_SUFFIX##_typed(void) { \
+        uint8_t dst = READ_BYTE(); \
+        uint8_t left = READ_BYTE(); \
+        uint8_t right = READ_BYTE(); \
+        CTYPE left_val; \
+        if (!(READ_FN(left, &left_val))) { \
+            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be " #TYPE_SUFFIX); \
+            return; \
+        } \
+        CTYPE right_val; \
+        if (!(READ_FN(right, &right_val))) { \
+            runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be " #TYPE_SUFFIX); \
+            return; \
+        } \
+        ZERO_GUARD; \
+        STORE_FN(dst, (RESULT_EXPR)); \
+    }
+
+#define NO_EXTRA_GUARD do { } while (0)
+#define GUARD_DIV_ZERO_INT do { \
+    if ((right_val) == 0) { \
+        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero"); \
+        return; \
+    } \
+} while (0)
+#define GUARD_DIV_ZERO_F64 do { \
+    if ((right_val) == 0.0) { \
+        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero"); \
+        return; \
+    } \
+} while (0)
+
+#define READ_I32_OPERAND(reg, out_ptr) read_i32_operand((reg), (out_ptr), NULL)
+#define READ_I64_OPERAND(reg, out_ptr) read_i64_operand((reg), (out_ptr))
+#define READ_U32_OPERAND(reg, out_ptr) read_u32_operand((reg), (out_ptr))
+#define READ_U64_OPERAND(reg, out_ptr) read_u64_operand((reg), (out_ptr))
+#define READ_F64_OPERAND(reg, out_ptr) read_f64_operand((reg), (out_ptr))
+
+#define STORE_I32_RESULT(dst_reg, value) vm_store_i32_typed_hot((dst_reg), (value))
+#define STORE_I64_RESULT(dst_reg, value) store_i64_register((dst_reg), (value))
+#define STORE_U32_RESULT(dst_reg, value) store_u32_register((dst_reg), (value))
+#define STORE_U64_RESULT(dst_reg, value) store_u64_register((dst_reg), (value))
+#define STORE_F64_RESULT(dst_reg, value) store_f64_register((dst_reg), (value))
+
 // ====== I32 Typed Arithmetic Handlers ======
 
-void handle_add_i32_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    int32_t left_val;
-    bool left_typed = false;
-    if (!read_i32_operand(left, &left_val, &left_typed)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-        return;
-    }
-
-    int32_t right_val;
-    bool right_typed = false;
-    if (!read_i32_operand(right, &right_val, &right_typed)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-        return;
-    }
-
-    if (left_typed && right_typed) {
-    } else {
-    }
-
-    vm_store_i32_typed_hot(dst, left_val + right_val);
-}
-
-void handle_sub_i32_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    int32_t left_val;
-    bool left_typed = false;
-    if (!read_i32_operand(left, &left_val, &left_typed)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-        return;
-    }
-
-    int32_t right_val;
-    bool right_typed = false;
-    if (!read_i32_operand(right, &right_val, &right_typed)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-        return;
-    }
-
-    if (left_typed && right_typed) {
-    } else {
-    }
-
-    vm_store_i32_typed_hot(dst, left_val - right_val);
-}
-
-void handle_mul_i32_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    int32_t left_val;
-    bool left_typed = false;
-    if (!read_i32_operand(left, &left_val, &left_typed)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-        return;
-    }
-
-    int32_t right_val;
-    bool right_typed = false;
-    if (!read_i32_operand(right, &right_val, &right_typed)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-        return;
-    }
-
-    if (left_typed && right_typed) {
-    } else {
-    }
-
-    vm_store_i32_typed_hot(dst, left_val * right_val);
-}
-
-void handle_div_i32_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    int32_t left_val;
-    bool left_typed = false;
-    if (!read_i32_operand(left, &left_val, &left_typed)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-        return;
-    }
-
-    int32_t right_val;
-    bool right_typed = false;
-    if (!read_i32_operand(right, &right_val, &right_typed)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-        return;
-    }
-
-    if (right_val == 0) {
-        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero");
-        return;
-    }
-
-    if (left_typed && right_typed) {
-    } else {
-    }
-
-    vm_store_i32_typed_hot(dst, left_val / right_val);
-}
-
-void handle_mod_i32_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    int32_t left_val;
-    bool left_typed = false;
-    if (!read_i32_operand(left, &left_val, &left_typed)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-        return;
-    }
-
-    int32_t right_val;
-    bool right_typed = false;
-    if (!read_i32_operand(right, &right_val, &right_typed)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i32");
-        return;
-    }
-
-    if (right_val == 0) {
-        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero");
-        return;
-    }
-
-    if (left_typed && right_typed) {
-    } else {
-    }
-
-    vm_store_i32_typed_hot(dst, left_val % right_val);
-}
+DEFINE_TYPED_ARITH_HANDLER(add, i32, int32_t, READ_I32_OPERAND, STORE_I32_RESULT, NO_EXTRA_GUARD, left_val + right_val)
+DEFINE_TYPED_ARITH_HANDLER(sub, i32, int32_t, READ_I32_OPERAND, STORE_I32_RESULT, NO_EXTRA_GUARD, left_val - right_val)
+DEFINE_TYPED_ARITH_HANDLER(mul, i32, int32_t, READ_I32_OPERAND, STORE_I32_RESULT, NO_EXTRA_GUARD, left_val * right_val)
+DEFINE_TYPED_ARITH_HANDLER(div, i32, int32_t, READ_I32_OPERAND, STORE_I32_RESULT, GUARD_DIV_ZERO_INT, left_val / right_val)
+DEFINE_TYPED_ARITH_HANDLER(mod, i32, int32_t, READ_I32_OPERAND, STORE_I32_RESULT, GUARD_DIV_ZERO_INT, left_val % right_val)
 
 // ====== I64 Typed Arithmetic Handlers ======
 
-void handle_add_i64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    int64_t left_val;
-    if (!read_i64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-        return;
-    }
-
-    int64_t right_val;
-    if (!read_i64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-        return;
-    }
-
-    store_i64_register(dst, left_val + right_val);
-}
-
-void handle_sub_i64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    int64_t left_val;
-    if (!read_i64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-        return;
-    }
-
-    int64_t right_val;
-    if (!read_i64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-        return;
-    }
-
-    store_i64_register(dst, left_val - right_val);
-}
-
-void handle_mul_i64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    int64_t left_val;
-    if (!read_i64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-        return;
-    }
-
-    int64_t right_val;
-    if (!read_i64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-        return;
-    }
-
-    store_i64_register(dst, left_val * right_val);
-}
-
-void handle_div_i64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    int64_t left_val;
-    if (!read_i64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-        return;
-    }
-
-    int64_t right_val;
-    if (!read_i64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-        return;
-    }
-
-    if (right_val == 0) {
-        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero");
-        return;
-    }
-
-    store_i64_register(dst, left_val / right_val);
-}
-
-void handle_mod_i64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    int64_t left_val;
-    if (!read_i64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-        return;
-    }
-
-    int64_t right_val;
-    if (!read_i64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be i64");
-        return;
-    }
-
-    if (right_val == 0) {
-        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero");
-        return;
-    }
-
-    store_i64_register(dst, left_val % right_val);
-}
+DEFINE_TYPED_ARITH_HANDLER(add, i64, int64_t, READ_I64_OPERAND, STORE_I64_RESULT, NO_EXTRA_GUARD, left_val + right_val)
+DEFINE_TYPED_ARITH_HANDLER(sub, i64, int64_t, READ_I64_OPERAND, STORE_I64_RESULT, NO_EXTRA_GUARD, left_val - right_val)
+DEFINE_TYPED_ARITH_HANDLER(mul, i64, int64_t, READ_I64_OPERAND, STORE_I64_RESULT, NO_EXTRA_GUARD, left_val * right_val)
+DEFINE_TYPED_ARITH_HANDLER(div, i64, int64_t, READ_I64_OPERAND, STORE_I64_RESULT, GUARD_DIV_ZERO_INT, left_val / right_val)
+DEFINE_TYPED_ARITH_HANDLER(mod, i64, int64_t, READ_I64_OPERAND, STORE_I64_RESULT, GUARD_DIV_ZERO_INT, left_val % right_val)
 
 // ====== F64 Typed Arithmetic Handlers ======
 
-void handle_add_f64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    double left_val;
-    if (!read_f64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-        return;
-    }
-
-    double right_val;
-    if (!read_f64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-        return;
-    }
-
-    store_f64_register(dst, left_val + right_val);
-}
-
-void handle_sub_f64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    double left_val;
-    if (!read_f64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-        return;
-    }
-
-    double right_val;
-    if (!read_f64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-        return;
-    }
-
-    store_f64_register(dst, left_val - right_val);
-}
-
-void handle_mul_f64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    double left_val;
-    if (!read_f64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-        return;
-    }
-
-    double right_val;
-    if (!read_f64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-        return;
-    }
-
-    store_f64_register(dst, left_val * right_val);
-}
-
-void handle_div_f64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    double left_val;
-    if (!read_f64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-        return;
-    }
-
-    double right_val;
-    if (!read_f64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-        return;
-    }
-
-    if (right_val == 0.0) {
-        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero");
-        return;
-    }
-
-    store_f64_register(dst, left_val / right_val);
-}
-
-void handle_mod_f64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    double left_val;
-    if (!read_f64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-        return;
-    }
-
-    double right_val;
-    if (!read_f64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be f64");
-        return;
-    }
-
-    if (right_val == 0.0) {
-        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero");
-        return;
-    }
-
-    store_f64_register(dst, fmod(left_val, right_val));
-}
+DEFINE_TYPED_ARITH_HANDLER(add, f64, double, READ_F64_OPERAND, STORE_F64_RESULT, NO_EXTRA_GUARD, left_val + right_val)
+DEFINE_TYPED_ARITH_HANDLER(sub, f64, double, READ_F64_OPERAND, STORE_F64_RESULT, NO_EXTRA_GUARD, left_val - right_val)
+DEFINE_TYPED_ARITH_HANDLER(mul, f64, double, READ_F64_OPERAND, STORE_F64_RESULT, NO_EXTRA_GUARD, left_val * right_val)
+DEFINE_TYPED_ARITH_HANDLER(div, f64, double, READ_F64_OPERAND, STORE_F64_RESULT, GUARD_DIV_ZERO_F64, left_val / right_val)
+DEFINE_TYPED_ARITH_HANDLER(mod, f64, double, READ_F64_OPERAND, STORE_F64_RESULT, GUARD_DIV_ZERO_F64, fmod(left_val, right_val))
 
 // ====== U32 Typed Arithmetic Handlers ======
 
-void handle_add_u32_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    uint32_t left_val;
-    if (!read_u32_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-        return;
-    }
-
-    uint32_t right_val;
-    if (!read_u32_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-        return;
-    }
-
-    store_u32_register(dst, left_val + right_val);
-}
-
-void handle_sub_u32_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    uint32_t left_val;
-    if (!read_u32_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-        return;
-    }
-
-    uint32_t right_val;
-    if (!read_u32_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-        return;
-    }
-
-    store_u32_register(dst, left_val - right_val);
-}
-
-void handle_mul_u32_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    uint32_t left_val;
-    if (!read_u32_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-        return;
-    }
-
-    uint32_t right_val;
-    if (!read_u32_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-        return;
-    }
-
-    store_u32_register(dst, left_val * right_val);
-}
-
-void handle_div_u32_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    uint32_t left_val;
-    if (!read_u32_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-        return;
-    }
-
-    uint32_t right_val;
-    if (!read_u32_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-        return;
-    }
-
-    if (right_val == 0) {
-        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero");
-        return;
-    }
-
-    store_u32_register(dst, left_val / right_val);
-}
-
-void handle_mod_u32_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    uint32_t left_val;
-    if (!read_u32_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-        return;
-    }
-
-    uint32_t right_val;
-    if (!read_u32_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u32");
-        return;
-    }
-
-    if (right_val == 0) {
-        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero");
-        return;
-    }
-
-    store_u32_register(dst, left_val % right_val);
-}
+DEFINE_TYPED_ARITH_HANDLER(add, u32, uint32_t, READ_U32_OPERAND, STORE_U32_RESULT, NO_EXTRA_GUARD, left_val + right_val)
+DEFINE_TYPED_ARITH_HANDLER(sub, u32, uint32_t, READ_U32_OPERAND, STORE_U32_RESULT, NO_EXTRA_GUARD, left_val - right_val)
+DEFINE_TYPED_ARITH_HANDLER(mul, u32, uint32_t, READ_U32_OPERAND, STORE_U32_RESULT, NO_EXTRA_GUARD, left_val * right_val)
+DEFINE_TYPED_ARITH_HANDLER(div, u32, uint32_t, READ_U32_OPERAND, STORE_U32_RESULT, GUARD_DIV_ZERO_INT, left_val / right_val)
+DEFINE_TYPED_ARITH_HANDLER(mod, u32, uint32_t, READ_U32_OPERAND, STORE_U32_RESULT, GUARD_DIV_ZERO_INT, left_val % right_val)
 
 // ====== U64 Typed Arithmetic Handlers ======
 
-void handle_add_u64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    uint64_t left_val;
-    if (!read_u64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-        return;
-    }
-
-    uint64_t right_val;
-    if (!read_u64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-        return;
-    }
-
-    store_u64_register(dst, left_val + right_val);
-}
-
-void handle_sub_u64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    uint64_t left_val;
-    if (!read_u64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-        return;
-    }
-
-    uint64_t right_val;
-    if (!read_u64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-        return;
-    }
-
-    store_u64_register(dst, left_val - right_val);
-}
-
-void handle_mul_u64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    uint64_t left_val;
-    if (!read_u64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-        return;
-    }
-
-    uint64_t right_val;
-    if (!read_u64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-        return;
-    }
-
-    store_u64_register(dst, left_val * right_val);
-}
-
-void handle_div_u64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    uint64_t left_val;
-    if (!read_u64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-        return;
-    }
-
-    uint64_t right_val;
-    if (!read_u64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-        return;
-    }
-
-    if (right_val == 0) {
-        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero");
-        return;
-    }
-
-    store_u64_register(dst, left_val / right_val);
-}
-
-void handle_mod_u64_typed(void) {
-    uint8_t dst = READ_BYTE();
-    uint8_t left = READ_BYTE();
-    uint8_t right = READ_BYTE();
-
-    uint64_t left_val;
-    if (!read_u64_operand(left, &left_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-        return;
-    }
-
-    uint64_t right_val;
-    if (!read_u64_operand(right, &right_val)) {
-        runtimeError(ERROR_TYPE, (SrcLocation){NULL,0,0}, "Operands must be u64");
-        return;
-    }
-
-    if (right_val == 0) {
-        runtimeError(ERROR_RUNTIME, (SrcLocation){NULL,0,0}, "Division by zero");
-        return;
-    }
-
-    store_u64_register(dst, left_val % right_val);
-}
+DEFINE_TYPED_ARITH_HANDLER(add, u64, uint64_t, READ_U64_OPERAND, STORE_U64_RESULT, NO_EXTRA_GUARD, left_val + right_val)
+DEFINE_TYPED_ARITH_HANDLER(sub, u64, uint64_t, READ_U64_OPERAND, STORE_U64_RESULT, NO_EXTRA_GUARD, left_val - right_val)
+DEFINE_TYPED_ARITH_HANDLER(mul, u64, uint64_t, READ_U64_OPERAND, STORE_U64_RESULT, NO_EXTRA_GUARD, left_val * right_val)
+DEFINE_TYPED_ARITH_HANDLER(div, u64, uint64_t, READ_U64_OPERAND, STORE_U64_RESULT, GUARD_DIV_ZERO_INT, left_val / right_val)
+DEFINE_TYPED_ARITH_HANDLER(mod, u64, uint64_t, READ_U64_OPERAND, STORE_U64_RESULT, GUARD_DIV_ZERO_INT, left_val % right_val)


### PR DESCRIPTION
## Summary
- add a reusable macro that consolidates typed arithmetic handler boilerplate
- generate the i32/i64/u32/u64/f64 arithmetic handlers from the macro with shared guard logic