### PR TITLE
Refactor optimization pass registry

### DIFF
--- a/include/compiler/optimization/optimizer.h
+++ b/include/compiler/optimization/optimizer.h
@@ -14,23 +14,41 @@
 
 #include "compiler/typed_ast.h"
 #include <stdbool.h>
+#include <stddef.h>
 
-// Forward declarations for future implementation 
+// Forward declarations for future implementation
 typedef struct ConstantTable ConstantTable;
 typedef struct UsageAnalysis UsageAnalysis;
 typedef struct ExpressionCache ExpressionCache;
 
-typedef struct OptimizationContext {
-    // Optimization flags
-    bool enable_constant_folding;       // Fold 2+3 → 5
-    bool enable_dead_code_elimination;  // Remove unused variables
-    bool enable_common_subexpression;   // Eliminate duplicate expressions
-    
+typedef struct OptimizationContext OptimizationContext;
+
+typedef struct OptimizationPassResult {
+    bool success;
+    int optimizations_applied;
+    int nodes_eliminated;
+    int constants_folded;
+    int binary_expressions_folded;
+} OptimizationPassResult;
+
+typedef OptimizationPassResult (*OptimizationPassFunction)(TypedASTNode* node, OptimizationContext* ctx);
+
+typedef struct OptimizationPass {
+    const char* name;
+    bool enabled;
+    OptimizationPassFunction run;
+} OptimizationPass;
+
+struct OptimizationContext {
+    OptimizationPass* passes;
+    size_t pass_count;
+    size_t pass_capacity;
+
     // Analysis results (TODO: implement in advanced phases)
     ConstantTable* constants;          // Known constant values
-    UsageAnalysis* usage;              // Variable usage tracking  
+    UsageAnalysis* usage;              // Variable usage tracking
     ExpressionCache* expressions;      // Common expressions
-    
+
     // Statistics for reporting
     int optimizations_applied;
     int nodes_eliminated;
@@ -39,16 +57,17 @@ typedef struct OptimizationContext {
 
     // Debug information
     bool verbose_output;               // Enable detailed optimization logging
-} OptimizationContext;
+};
 
 // Core optimization functions
 OptimizationContext* init_optimization_context(void);
 TypedASTNode* optimize_typed_ast(TypedASTNode* input, OptimizationContext* ctx);
 void free_optimization_context(OptimizationContext* ctx);
 
-// Individual optimization passes
-TypedASTNode* constant_folding_pass(TypedASTNode* node, OptimizationContext* ctx);
-TypedASTNode* dead_code_elimination_pass(TypedASTNode* node, OptimizationContext* ctx);
+// Pass management helpers
+bool set_optimization_pass_enabled(OptimizationContext* ctx, const char* name, bool enabled);
+bool toggle_optimization_pass(OptimizationContext* ctx, const char* name);
+bool is_optimization_pass_enabled(OptimizationContext* ctx, const char* name);
 
 // Utility functions for optimization
 bool is_constant_literal(TypedASTNode* node);

--- a/src/compiler/backend/optimization/optimizer.c
+++ b/src/compiler/backend/optimization/optimizer.c
@@ -11,6 +11,7 @@
 #include "runtime/memory.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 // Disable all debug output for clean program execution
 #define OPTIMIZER_DEBUG 0
@@ -22,72 +23,196 @@
 // Orchestrates high-level AST optimizations
 // Delegates to specific optimization algorithms
 
+typedef struct OptimizationPassRegistration {
+    const char* name;
+    bool enabled;
+    OptimizationPassFunction fn;
+} OptimizationPassRegistration;
+
+static bool ensure_pass_capacity(OptimizationContext* ctx) {
+    if (ctx->pass_count < ctx->pass_capacity) {
+        return true;
+    }
+
+    size_t new_capacity = ctx->pass_capacity == 0 ? 4 : ctx->pass_capacity * 2;
+    OptimizationPass* resized = realloc(ctx->passes, new_capacity * sizeof(OptimizationPass));
+    if (!resized) {
+        return false;
+    }
+
+    ctx->passes = resized;
+    ctx->pass_capacity = new_capacity;
+    return true;
+}
+
+static bool register_pass(OptimizationContext* ctx, const OptimizationPassRegistration* registration) {
+    if (!ensure_pass_capacity(ctx)) {
+        return false;
+    }
+
+    OptimizationPass* slot = &ctx->passes[ctx->pass_count++];
+    slot->name = registration->name;
+    slot->enabled = registration->enabled;
+    slot->run = registration->fn;
+    return true;
+}
+
+static OptimizationPass* find_pass(OptimizationContext* ctx, const char* name) {
+    if (!ctx || !name) {
+        return NULL;
+    }
+
+    for (size_t i = 0; i < ctx->pass_count; ++i) {
+        if (strcmp(ctx->passes[i].name, name) == 0) {
+            return &ctx->passes[i];
+        }
+    }
+
+    return NULL;
+}
+
+static OptimizationPassResult run_constant_folding_pass(TypedASTNode* ast, OptimizationContext* ctx) {
+    (void)ctx;
+    OptimizationPassResult result = {0};
+    ConstantFoldContext fold_ctx;
+    init_constant_fold_context(&fold_ctx);
+
+    bool success = apply_constant_folding(ast, &fold_ctx);
+    result.success = success;
+
+    if (success) {
+        result.optimizations_applied = fold_ctx.optimizations_applied;
+        result.constants_folded = fold_ctx.constants_folded;
+        result.binary_expressions_folded = fold_ctx.binary_expressions_folded;
+        result.nodes_eliminated = fold_ctx.nodes_eliminated;
+    }
+
+    if (!success) {
+        printf("[OPTIMIZER] ❌ Constant folding failed\n");
+    }
+
+    return result;
+}
+
+static OptimizationPassResult run_not_implemented_pass(TypedASTNode* ast, OptimizationContext* ctx, const char* name) {
+    (void)ast;
+    (void)ctx;
+    (void)name;
+    OptimizationPassResult result = {0};
+    result.success = true;
+    printf("[OPTIMIZER] %s not yet implemented\n", name);
+    return result;
+}
+
+static OptimizationPassResult run_dead_code_elimination_pass(TypedASTNode* ast, OptimizationContext* ctx) {
+    return run_not_implemented_pass(ast, ctx, "Dead code elimination");
+}
+
+static OptimizationPassResult run_common_subexpression_pass(TypedASTNode* ast, OptimizationContext* ctx) {
+    return run_not_implemented_pass(ast, ctx, "Common subexpression elimination");
+}
+
 OptimizationContext* init_optimization_context(void) {
     OptimizationContext* ctx = malloc(sizeof(OptimizationContext));
     if (!ctx) return NULL;
-    
-    // Enable constant folding now that logical operators are implemented
-    ctx->enable_constant_folding = true;
-    ctx->enable_dead_code_elimination = false; // Future phase
-    ctx->enable_common_subexpression = false;  // Future phase
-    
-    // Initialize analysis structures (for future advanced features)
+
+    ctx->passes = NULL;
+    ctx->pass_count = 0;
+    ctx->pass_capacity = 0;
+
     ctx->constants = NULL;
     ctx->usage = NULL;
     ctx->expressions = NULL;
-    
-    // Initialize statistics
+
     ctx->optimizations_applied = 0;
     ctx->nodes_eliminated = 0;
     ctx->constants_folded = 0;
     ctx->binary_expressions_folded = 0;
-    
-    // Enable detailed logging
+
     ctx->verbose_output = true;
-    
+
+    const OptimizationPassRegistration registrations[] = {
+        {"Constant Folding", true, run_constant_folding_pass},
+        {"Dead Code Elimination", false, run_dead_code_elimination_pass},
+        {"Common Subexpression Elimination", false, run_common_subexpression_pass},
+    };
+
+    size_t registration_count = sizeof(registrations) / sizeof(registrations[0]);
+    for (size_t i = 0; i < registration_count; ++i) {
+        if (!register_pass(ctx, &registrations[i])) {
+            free_optimization_context(ctx);
+            return NULL;
+        }
+    }
+
     return ctx;
 }
 
 void free_optimization_context(OptimizationContext* ctx) {
     if (!ctx) return;
-    
+
     // TODO: Free analysis structures when implemented
     // free_constant_table(ctx->constants);
     // free_usage_analysis(ctx->usage);
     // free_expression_cache(ctx->expressions);
-    
+
+    free(ctx->passes);
     free(ctx);
+}
+
+bool set_optimization_pass_enabled(OptimizationContext* ctx, const char* name, bool enabled) {
+    OptimizationPass* pass = find_pass(ctx, name);
+    if (!pass) {
+        return false;
+    }
+
+    pass->enabled = enabled;
+    return true;
+}
+
+bool toggle_optimization_pass(OptimizationContext* ctx, const char* name) {
+    OptimizationPass* pass = find_pass(ctx, name);
+    if (!pass) {
+        return false;
+    }
+
+    pass->enabled = !pass->enabled;
+    return true;
+}
+
+bool is_optimization_pass_enabled(OptimizationContext* ctx, const char* name) {
+    OptimizationPass* pass = find_pass(ctx, name);
+    if (!pass) {
+        return false;
+    }
+
+    return pass->enabled;
 }
 
 TypedASTNode* optimize_typed_ast(TypedASTNode* input_ast, OptimizationContext* ctx) {
     if (!input_ast || !ctx) return input_ast;
-    
+
     printf("[OPTIMIZER] 🚀 Starting production-grade optimization passes...\n");
-    
-    // Phase 1: Constant Folding (re-enabled after fixing memory corruption)
-    if (ctx->enable_constant_folding) {
-        ConstantFoldContext fold_ctx;
-        if (!apply_constant_folding(input_ast, &fold_ctx)) {
-            printf("[OPTIMIZER] ❌ Constant folding failed\n");
-            return input_ast;
+
+    for (size_t i = 0; i < ctx->pass_count; ++i) {
+        OptimizationPass* pass = &ctx->passes[i];
+        if (!pass->enabled) {
+            continue;
         }
 
-        ctx->optimizations_applied += fold_ctx.optimizations_applied;
-        ctx->constants_folded += fold_ctx.constants_folded;
-        ctx->binary_expressions_folded += fold_ctx.binary_expressions_folded;
-        ctx->nodes_eliminated += fold_ctx.nodes_eliminated;
-    }
-    
-    // Phase 2: Dead Code Elimination (Future)
-    if (ctx->enable_dead_code_elimination) {
-        printf("[OPTIMIZER] Dead code elimination not yet implemented\n");
+        printf("[OPTIMIZER] ▶ Running pass: %s\n", pass->name);
+        OptimizationPassResult result = pass->run(input_ast, ctx);
+        if (!result.success) {
+            printf("[OPTIMIZER] ❌ Pass failed: %s\n", pass->name);
+            continue;
+        }
+
+        ctx->optimizations_applied += result.optimizations_applied;
+        ctx->nodes_eliminated += result.nodes_eliminated;
+        ctx->constants_folded += result.constants_folded;
+        ctx->binary_expressions_folded += result.binary_expressions_folded;
     }
 
-    // Phase 3: Common Subexpression Elimination (Future)
-    if (ctx->enable_common_subexpression) {
-        printf("[OPTIMIZER] Common subexpression elimination not yet implemented\n");
-    }
-    
     printf("[OPTIMIZER] ✅ Production-grade optimization passes completed\n");
     return input_ast; // Return optimized AST (same reference, modified in-place)
 }


### PR DESCRIPTION
## Summary
- define an optimization pass descriptor and track registered passes in the optimization context
- populate the optimization registry during context initialization and add helpers for toggling passes
- refactor optimize_typed_ast to iterate enabled passes and aggregate statistics generically