### PR TITLE
Refactor dual register banks and add allocator regression tests

### DIFF
--- a/include/compiler/register_allocator.h
+++ b/include/compiler/register_allocator.h
@@ -40,6 +40,18 @@ typedef enum RegisterStrategy {
     REG_STRATEGY_AUTO         // Compiler decides based on usage pattern
 } RegisterStrategy;
 
+// Kinds of register banks managed by the dual allocator
+typedef enum RegisterBankKind {
+    REG_BANK_INVALID = -1,
+    REG_BANK_TYPED_I32 = 0,
+    REG_BANK_TYPED_I64,
+    REG_BANK_TYPED_F64,
+    REG_BANK_TYPED_U32,
+    REG_BANK_TYPED_U64,
+    REG_BANK_TYPED_BOOL,
+    REG_BANK_COUNT
+} RegisterBankKind;
+
 // Register allocation record
 typedef struct RegisterAllocation {
     int logical_id;              // R0-R255 logical register ID (for standard)
@@ -86,7 +98,7 @@ bool compiler_is_register_free(DualRegisterAllocator* allocator, int reg);
 const char* compiler_register_type_name(int reg);
 
 // Typed/dual allocation helpers
-RegisterAllocation* compiler_alloc_typed(DualRegisterAllocator* allocator, RegisterType type);
+RegisterAllocation* compiler_alloc_typed(DualRegisterAllocator* allocator, RegisterBankKind bank_kind);
 RegisterAllocation* compiler_alloc_smart(DualRegisterAllocator* allocator,
                                          RegisterType type,
                                          bool is_arithmetic_hot_path);

--- a/makefile
+++ b/makefile
@@ -248,6 +248,7 @@ SCOPE_TRACKING_TEST_BIN = $(BUILDDIR)/tests/test_scope_tracking
 PEEPHOLE_TEST_BIN = $(BUILDDIR)/tests/test_constant_propagation
 TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
 TYPED_REGISTER_TEST_BIN = $(BUILDDIR)/tests/test_vm_typed_registers
+REGISTER_ALLOCATOR_TEST_BIN = $(BUILDDIR)/tests/test_register_allocator
 BUILTIN_INPUT_TEST_BIN = $(BUILDDIR)/tests/test_builtin_input
 BUILTIN_SORTED_ORUS_TESTS = \
     tests/builtins/sorted_runtime.orus
@@ -262,7 +263,7 @@ BUILTIN_RANGE_ORUS_FAIL_TESTS = \
     tests/builtins/range_float_step.orus \
     tests/builtins/range_overflow_stop.orus
 
-.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests peephole-tests cli-smoke-tests tagged-union-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
+.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
 
 all: build-info $(ORUS)
 
@@ -426,6 +427,9 @@ _test-run: $(ORUS)
 	@echo "\033[36m=== Typed Register Tests ===\033[0m"
 	@$(MAKE) typed-register-tests
 	@echo ""
+	@echo "\033[36m=== Register Allocator Tests ===\033[0m"
+	@$(MAKE) register-allocator-tests
+	@echo ""
 	@echo "\033[36m=== Builtin Input Tests ===\033[0m"
 	@$(MAKE) builtin-input-tests
 	@echo ""
@@ -500,6 +504,15 @@ $(TYPED_REGISTER_TEST_BIN): tests/unit/test_vm_typed_registers.c $(COMPILER_OBJS
 typed-register-tests: $(TYPED_REGISTER_TEST_BIN)
 	@echo "Running typed register coherence tests..."
 	@./$(TYPED_REGISTER_TEST_BIN)
+
+$(REGISTER_ALLOCATOR_TEST_BIN): tests/unit/test_register_allocator.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling register allocator tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+register-allocator-tests: $(REGISTER_ALLOCATOR_TEST_BIN)
+	@echo "Running register allocator tests..."
+	@./$(REGISTER_ALLOCATOR_TEST_BIN)
 
 $(BUILTIN_INPUT_TEST_BIN): tests/unit/test_builtin_input.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/tests/unit/test_register_allocator.c
+++ b/tests/unit/test_register_allocator.c
@@ -1,0 +1,86 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "compiler/register_allocator.h"
+
+#define ASSERT_TRUE(cond, message)                                                         \
+    do {                                                                                   \
+        if (!(cond)) {                                                                     \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", message, __FILE__, __LINE__); \
+            return false;                                                                  \
+        }                                                                                  \
+    } while (0)
+
+static bool test_typed_register_allocation_cycle(void) {
+    DualRegisterAllocator* allocator = compiler_create_allocator();
+    ASSERT_TRUE(allocator != NULL, "allocator should be created");
+
+    RegisterAllocation* first = compiler_alloc_typed(allocator, REG_BANK_TYPED_I32);
+    ASSERT_TRUE(first != NULL, "first typed allocation should succeed");
+    ASSERT_TRUE(first->strategy == REG_STRATEGY_TYPED, "first allocation should be typed");
+    ASSERT_TRUE(first->physical_type == REG_TYPE_I32, "first allocation should target i32 bank");
+
+    RegisterAllocation* second = compiler_alloc_typed(allocator, REG_BANK_TYPED_I32);
+    ASSERT_TRUE(second != NULL, "second typed allocation should succeed");
+    ASSERT_TRUE(second->physical_id != first->physical_id,
+                "second allocation should use a different physical register");
+
+    int released_id = first->physical_id;
+    compiler_free_allocation(allocator, first);
+
+    RegisterAllocation* third = compiler_alloc_typed(allocator, REG_BANK_TYPED_I32);
+    ASSERT_TRUE(third != NULL, "third typed allocation should succeed after freeing");
+    ASSERT_TRUE(third->physical_id == released_id,
+                "freed typed register should be reused on subsequent allocation");
+
+    compiler_free_allocation(allocator, second);
+    compiler_free_allocation(allocator, third);
+    compiler_destroy_allocator(allocator);
+    return true;
+}
+
+static bool test_distinct_banks_track_independently(void) {
+    DualRegisterAllocator* allocator = compiler_create_allocator();
+    ASSERT_TRUE(allocator != NULL, "allocator should be created");
+
+    RegisterAllocation* int_alloc = compiler_alloc_typed(allocator, REG_BANK_TYPED_I32);
+    RegisterAllocation* float_alloc = compiler_alloc_typed(allocator, REG_BANK_TYPED_F64);
+    ASSERT_TRUE(int_alloc != NULL && float_alloc != NULL, "typed allocations should succeed");
+    ASSERT_TRUE(int_alloc->physical_type == REG_TYPE_I32, "integer bank should tag i32 type");
+    ASSERT_TRUE(float_alloc->physical_type == REG_TYPE_F64, "float bank should tag f64 type");
+    ASSERT_TRUE(int_alloc->physical_id == 0, "integer bank should allocate from offset 0");
+    ASSERT_TRUE(float_alloc->physical_id == 0, "float bank should allocate independently from offset 0");
+
+    compiler_free_allocation(allocator, int_alloc);
+    compiler_free_allocation(allocator, float_alloc);
+    compiler_destroy_allocator(allocator);
+    return true;
+}
+
+int main(void) {
+    bool (*tests[])(void) = {
+        test_typed_register_allocation_cycle,
+        test_distinct_banks_track_independently,
+    };
+
+    const char* names[] = {
+        "Typed register allocation/free cycle reuses freed slots",
+        "Distinct register banks maintain independent indices",
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; i++) {
+        if (tests[i]()) {
+            printf("[PASS] %s\n", names[i]);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", names[i]);
+            return 1;
+        }
+    }
+
+    printf("%d/%d register allocator tests passed\n", passed, total);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- introduce register bank metadata and update the dual register allocator to allocate typed registers via a generic bank map
- expose the bank-kind based typed allocation API and adjust freeing logic to use the new bank helpers
- add dedicated unit tests and makefile wiring to exercise register allocator typed register allocation and reuse