### PR TITLE
Handle wide ranges in counting sort test

### DIFF
--- a/tests/algorithms/phase1/counting_sort.orus
+++ b/tests/algorithms/phase1/counting_sort.orus
@@ -9,7 +9,7 @@ mut COUNTING_RANGE_SLOTS = 0
 mut COUNTING_COUNT_UPDATES = 0
 mut COUNTING_OUTPUT_WRITES = 0
 
-fn counting_sort(label, values):
+fn counting_sort(label: string, values: [i32]):
     COUNTING_EXTENT_SCANS = 0
     COUNTING_RANGE_SLOTS = 0
     COUNTING_COUNT_UPDATES = 0
@@ -20,12 +20,12 @@ fn counting_sort(label, values):
         print("counting_sort", label, "range_size:", COUNTING_RANGE_SLOTS, "extent_scans:", COUNTING_EXTENT_SCANS, "count_updates:", COUNTING_COUNT_UPDATES, "output_writes:", COUNTING_OUTPUT_WRITES)
         return values
 
-    mut min_value = values[0]
-    mut max_value = values[0]
+    mut min_value: i64 = values[0] as i64
+    mut max_value: i64 = values[0] as i64
 
     mut i: i32 = 1
     while i < length:
-        current = values[i]
+        current: i64 = values[i] as i64
         if current < min_value:
             min_value = current
         if current > max_value:
@@ -33,10 +33,17 @@ fn counting_sort(label, values):
         COUNTING_EXTENT_SCANS = COUNTING_EXTENT_SCANS + 1
         i = i + 1
 
-    range_size = (max_value - min_value) + 1
-    if range_size <= 0:
+    mut range_size_span: i64 = max_value - min_value
+    if range_size_span < (0 as i64):
         print("counting_sort", label, "range_size:", COUNTING_RANGE_SLOTS, "extent_scans:", COUNTING_EXTENT_SCANS, "count_updates:", COUNTING_COUNT_UPDATES, "output_writes:", COUNTING_OUTPUT_WRITES)
         return values
+
+    range_size_span = range_size_span + 1
+    if range_size_span > (2147483647 as i64):
+        print("counting_sort", label, "range_size:", COUNTING_RANGE_SLOTS, "extent_scans:", COUNTING_EXTENT_SCANS, "count_updates:", COUNTING_COUNT_UPDATES, "output_writes:", COUNTING_OUTPUT_WRITES)
+        return values
+
+    range_size: i32 = range_size_span as i32
 
     COUNTING_RANGE_SLOTS = range_size
 
@@ -48,8 +55,8 @@ fn counting_sort(label, values):
 
     mut idx: i32 = 0
     while idx < length:
-        value = values[idx]
-        counts[value - min_value] = counts[value - min_value] + 1
+        value_offset: i32 = ((values[idx] as i64) - min_value) as i32
+        counts[value_offset] = counts[value_offset] + 1
         COUNTING_COUNT_UPDATES = COUNTING_COUNT_UPDATES + 1
         idx = idx + 1
 
@@ -58,7 +65,7 @@ fn counting_sort(label, values):
     while count_index < len(counts):
         mut freq = counts[count_index]
         while freq > 0:
-            push(output, count_index + min_value)
+            push(output, ((count_index as i64) + min_value) as i32)
             COUNTING_OUTPUT_WRITES = COUNTING_OUTPUT_WRITES + 1
             freq = freq - 1
         count_index = count_index + 1


### PR DESCRIPTION
## Summary
- annotate the phase 1 counting sort helper with explicit types so large ranges remain well-typed
- promote the min/max bookkeeping to i64 arithmetic and guard against overflow when sizing the frequency table
- ensure index math uses the widened span before casting back to i32 for array access and emission

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e24a242a748325979681325aed6a56