### PR TITLE
Optimize OP_INC_CMP_JMP typed fast paths and add tests

### DIFF
--- a/include/vm/vm_comparison.h
+++ b/include/vm/vm_comparison.h
@@ -316,43 +316,43 @@ static inline void vm_store_i32_typed_hot(uint16_t id, int32_t value) {
     }
 }
 
-// static inline void vm_store_i64_typed_hot(uint16_t id, int64_t value) {
-//     if (!vm_typed_reg_in_range(id)) {
-//         vm_set_register_safe(id, I64_VAL(value));
-//         return;
-//     }
+static inline void vm_store_i64_typed_hot(uint16_t id, int64_t value) {
+    if (!vm_typed_reg_in_range(id)) {
+        vm_set_register_safe(id, I64_VAL(value));
+        return;
+    }
 
-//     bool skip_boxed_write = vm_mark_typed_register_dirty(id, REG_TYPE_I64);
-//     vm.typed_regs.i64_regs[id] = value;
-//     vm.typed_regs.dirty[id] = skip_boxed_write;
+    bool skip_boxed_write = vm_mark_typed_register_dirty(id, REG_TYPE_I64);
+    vm.typed_regs.i64_regs[id] = value;
+    vm.typed_regs.dirty[id] = skip_boxed_write;
 
-//     if (id < REGISTER_COUNT) {
-//         if (!skip_boxed_write) {
-//             vm.registers[id] = I64_VAL(value);
-//         }
-//     } else {
-//         set_register(&vm.register_file, id, I64_VAL(value));
-//     }
-// }
+    if (id < REGISTER_COUNT) {
+        if (!skip_boxed_write) {
+            vm.registers[id] = I64_VAL(value);
+        }
+    } else {
+        set_register(&vm.register_file, id, I64_VAL(value));
+    }
+}
 
-// static inline void vm_store_u32_typed_hot(uint16_t id, uint32_t value) {
-//     if (!vm_typed_reg_in_range(id)) {
-//         vm_set_register_safe(id, U32_VAL(value));
-//         return;
-//     }
+static inline void vm_store_u32_typed_hot(uint16_t id, uint32_t value) {
+    if (!vm_typed_reg_in_range(id)) {
+        vm_set_register_safe(id, U32_VAL(value));
+        return;
+    }
 
-//     bool skip_boxed_write = vm_mark_typed_register_dirty(id, REG_TYPE_U32);
-//     vm.typed_regs.u32_regs[id] = value;
-//     vm.typed_regs.dirty[id] = skip_boxed_write;
+    bool skip_boxed_write = vm_mark_typed_register_dirty(id, REG_TYPE_U32);
+    vm.typed_regs.u32_regs[id] = value;
+    vm.typed_regs.dirty[id] = skip_boxed_write;
 
-//     if (id < REGISTER_COUNT) {
-//         if (!skip_boxed_write) {
-//             vm.registers[id] = U32_VAL(value);
-//         }
-//     } else {
-//         set_register(&vm.register_file, id, U32_VAL(value));
-//     }
-// }
+    if (id < REGISTER_COUNT) {
+        if (!skip_boxed_write) {
+            vm.registers[id] = U32_VAL(value);
+        }
+    } else {
+        set_register(&vm.register_file, id, U32_VAL(value));
+    }
+}
 
 static inline void vm_store_u64_typed_hot(uint16_t id, uint64_t value) {
     if (!vm_typed_reg_in_range(id)) {
@@ -372,60 +372,6 @@ static inline void vm_store_u64_typed_hot(uint16_t id, uint64_t value) {
         set_register(&vm.register_file, id, U64_VAL(value));
     }
 }
-
-static inline void vm_store_i64_typed_hot(uint16_t id, int64_t value) {
-    if (!vm_typed_reg_in_range(id)) {
-        vm_set_register_safe(id, I64_VAL(value));
-        return;
-    }
-
-    vm.typed_regs.i64_regs[id] = value;
-    vm.typed_regs.reg_types[id] = REG_TYPE_I64;
-    vm.typed_regs.dirty[id] = true;
-
-    Value boxed = I64_VAL(value);
-    if (id < REGISTER_COUNT) {
-        vm.registers[id] = boxed;
-    } else {
-        set_register(&vm.register_file, id, boxed);
-    }
-}
-
-static inline void vm_store_u32_typed_hot(uint16_t id, uint32_t value) {
-    if (!vm_typed_reg_in_range(id)) {
-        vm_set_register_safe(id, U32_VAL(value));
-        return;
-    }
-
-    vm.typed_regs.u32_regs[id] = value;
-    vm.typed_regs.reg_types[id] = REG_TYPE_U32;
-    vm.typed_regs.dirty[id] = true;
-
-    Value boxed = U32_VAL(value);
-    if (id < REGISTER_COUNT) {
-        vm.registers[id] = boxed;
-    } else {
-        set_register(&vm.register_file, id, boxed);
-    }
-}
-
-// static inline void vm_store_u64_typed_hot(uint16_t id, uint64_t value) {
-//     if (!vm_typed_reg_in_range(id)) {
-//         vm_set_register_safe(id, U64_VAL(value));
-//         return;
-//     }
-
-//     vm.typed_regs.u64_regs[id] = value;
-//     vm.typed_regs.reg_types[id] = REG_TYPE_U64;
-//     vm.typed_regs.dirty[id] = true;
-
-//     Value boxed = U64_VAL(value);
-//     if (id < REGISTER_COUNT) {
-//         vm.registers[id] = boxed;
-//     } else {
-//         set_register(&vm.register_file, id, boxed);
-//     }
-// }
 
 static inline void store_i64_register(uint16_t id, int64_t value) {
     if (vm_typed_reg_in_range(id)) {

--- a/makefile
+++ b/makefile
@@ -249,6 +249,7 @@ PEEPHOLE_TEST_BIN = $(BUILDDIR)/tests/test_constant_propagation
 TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
 TYPED_REGISTER_TEST_BIN = $(BUILDDIR)/tests/test_vm_typed_registers
 REGISTER_ALLOCATOR_TEST_BIN = $(BUILDDIR)/tests/test_register_allocator
+INC_CMP_JMP_TEST_BIN = $(BUILDDIR)/tests/test_vm_inc_cmp_jmp
 BUILTIN_INPUT_TEST_BIN = $(BUILDDIR)/tests/test_builtin_input
 CONSTANT_FOLD_TEST_BIN = $(BUILDDIR)/tests/test_constant_folding
 BUILTIN_SORTED_ORUS_TESTS = \
@@ -264,7 +265,7 @@ BUILTIN_RANGE_ORUS_FAIL_TESTS = \
     tests/builtins/range_float_step.orus \
     tests/builtins/range_overflow_stop.orus
 
-.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
+.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests inc-cmp-jmp-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
 
 all: build-info $(ORUS)
 
@@ -431,6 +432,9 @@ _test-run: $(ORUS)
 	@echo "\033[36m=== Typed Register Tests ===\033[0m"
 	@$(MAKE) typed-register-tests
 	@echo ""
+	@echo "\033[36m=== OP_INC_CMP_JMP Tests ===\033[0m"
+	@$(MAKE) inc-cmp-jmp-tests
+	@echo ""
 	@echo "\033[36m=== Register Allocator Tests ===\033[0m"
 	@$(MAKE) register-allocator-tests
 	@echo ""
@@ -517,6 +521,15 @@ $(TYPED_REGISTER_TEST_BIN): tests/unit/test_vm_typed_registers.c $(COMPILER_OBJS
 typed-register-tests: $(TYPED_REGISTER_TEST_BIN)
 	@echo "Running typed register coherence tests..."
 	@./$(TYPED_REGISTER_TEST_BIN)
+
+$(INC_CMP_JMP_TEST_BIN): tests/unit/test_vm_inc_cmp_jmp.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling OP_INC_CMP_JMP regression tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+inc-cmp-jmp-tests: $(INC_CMP_JMP_TEST_BIN)
+	@echo "Running OP_INC_CMP_JMP regression tests..."
+	@./$(INC_CMP_JMP_TEST_BIN)
 
 $(REGISTER_ALLOCATOR_TEST_BIN): tests/unit/test_register_allocator.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -3617,6 +3617,60 @@ InterpretResult vm_run_dispatch(void) {
         int16_t offset = *(int16_t*)vm.ip;
         vm.ip += 2;
 
+        int32_t counter_i32;
+        int32_t limit_i32;
+        if (vm_try_read_i32_typed(reg, &counter_i32) &&
+            vm_try_read_i32_typed(limit_reg, &limit_i32)) {
+            int32_t incremented;
+            if (__builtin_add_overflow(counter_i32, 1, &incremented)) {
+                VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Integer overflow");
+            }
+            vm_store_i32_typed_hot(reg, incremented);
+            if (incremented < limit_i32) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
+        }
+
+        int64_t counter_i64;
+        int64_t limit_i64;
+        if (vm_try_read_i64_typed(reg, &counter_i64) &&
+            vm_try_read_i64_typed(limit_reg, &limit_i64)) {
+            int64_t incremented;
+            if (__builtin_add_overflow(counter_i64, (int64_t)1, &incremented)) {
+                VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Integer overflow");
+            }
+            vm_store_i64_typed_hot(reg, incremented);
+            if (incremented < limit_i64) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
+        }
+
+        uint32_t counter_u32;
+        uint32_t limit_u32;
+        if (vm_try_read_u32_typed(reg, &counter_u32) &&
+            vm_try_read_u32_typed(limit_reg, &limit_u32)) {
+            uint32_t incremented = counter_u32 + (uint32_t)1;
+            vm_store_u32_typed_hot(reg, incremented);
+            if (incremented < limit_u32) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
+        }
+
+        uint64_t counter_u64;
+        uint64_t limit_u64;
+        if (vm_try_read_u64_typed(reg, &counter_u64) &&
+            vm_try_read_u64_typed(limit_reg, &limit_u64)) {
+            uint64_t incremented = counter_u64 + (uint64_t)1;
+            vm_store_u64_typed_hot(reg, incremented);
+            if (incremented < limit_u64) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
+        }
+
         Value counter = vm_get_register_safe(reg);
         Value limit = vm_get_register_safe(limit_reg);
 
@@ -3626,7 +3680,7 @@ InterpretResult vm_run_dispatch(void) {
             if (__builtin_add_overflow(current, 1, &incremented)) {
                 VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Integer overflow");
             }
-            store_i32_register(reg, incremented);
+            vm_store_i32_typed_hot(reg, incremented);
             if (incremented < AS_I32(limit)) {
                 vm.ip += offset;
             }
@@ -3639,7 +3693,7 @@ InterpretResult vm_run_dispatch(void) {
             if (__builtin_add_overflow(current, (int64_t)1, &incremented)) {
                 VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Integer overflow");
             }
-            store_i64_register(reg, incremented);
+            vm_store_i64_typed_hot(reg, incremented);
             if (incremented < AS_I64(limit)) {
                 vm.ip += offset;
             }
@@ -3647,8 +3701,8 @@ InterpretResult vm_run_dispatch(void) {
         }
 
         if (IS_U32(counter) && IS_U32(limit)) {
-            uint32_t incremented = AS_U32(counter) + 1u;
-            store_u32_register(reg, incremented);
+            uint32_t incremented = AS_U32(counter) + (uint32_t)1;
+            vm_store_u32_typed_hot(reg, incremented);
             if (incremented < AS_U32(limit)) {
                 vm.ip += offset;
             }
@@ -3656,8 +3710,8 @@ InterpretResult vm_run_dispatch(void) {
         }
 
         if (IS_U64(counter) && IS_U64(limit)) {
-            uint64_t incremented = AS_U64(counter) + 1u;
-            store_u64_register(reg, incremented);
+            uint64_t incremented = AS_U64(counter) + (uint64_t)1;
+            vm_store_u64_typed_hot(reg, incremented);
             if (incremented < AS_U64(limit)) {
                 vm.ip += offset;
             }

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -3096,6 +3096,62 @@ InterpretResult vm_run_dispatch(void) {
                     uint8_t limit_reg = READ_BYTE();
                     int16_t offset = READ_SHORT();
 
+                    int32_t counter_i32;
+                    int32_t limit_i32;
+                    if (vm_try_read_i32_typed(reg, &counter_i32) &&
+                        vm_try_read_i32_typed(limit_reg, &limit_i32)) {
+                        int32_t incremented;
+                        if (__builtin_add_overflow(counter_i32, 1, &incremented)) {
+                            VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(),
+                                            "Integer overflow");
+                        }
+                        vm_store_i32_typed_hot(reg, incremented);
+                        if (incremented < limit_i32) {
+                            vm.ip += offset;
+                        }
+                        break;
+                    }
+
+                    int64_t counter_i64;
+                    int64_t limit_i64;
+                    if (vm_try_read_i64_typed(reg, &counter_i64) &&
+                        vm_try_read_i64_typed(limit_reg, &limit_i64)) {
+                        int64_t incremented;
+                        if (__builtin_add_overflow(counter_i64, (int64_t)1, &incremented)) {
+                            VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(),
+                                            "Integer overflow");
+                        }
+                        vm_store_i64_typed_hot(reg, incremented);
+                        if (incremented < limit_i64) {
+                            vm.ip += offset;
+                        }
+                        break;
+                    }
+
+                    uint32_t counter_u32;
+                    uint32_t limit_u32;
+                    if (vm_try_read_u32_typed(reg, &counter_u32) &&
+                        vm_try_read_u32_typed(limit_reg, &limit_u32)) {
+                        uint32_t incremented = counter_u32 + (uint32_t)1;
+                        vm_store_u32_typed_hot(reg, incremented);
+                        if (incremented < limit_u32) {
+                            vm.ip += offset;
+                        }
+                        break;
+                    }
+
+                    uint64_t counter_u64;
+                    uint64_t limit_u64;
+                    if (vm_try_read_u64_typed(reg, &counter_u64) &&
+                        vm_try_read_u64_typed(limit_reg, &limit_u64)) {
+                        uint64_t incremented = counter_u64 + (uint64_t)1;
+                        vm_store_u64_typed_hot(reg, incremented);
+                        if (incremented < limit_u64) {
+                            vm.ip += offset;
+                        }
+                        break;
+                    }
+
                     Value counter = vm_get_register_safe(reg);
                     Value limit = vm_get_register_safe(limit_reg);
 
@@ -3106,7 +3162,7 @@ InterpretResult vm_run_dispatch(void) {
                             VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(),
                                             "Integer overflow");
                         }
-                        store_i32_register(reg, incremented);
+                        vm_store_i32_typed_hot(reg, incremented);
                         if (incremented < AS_I32(limit)) {
                             vm.ip += offset;
                         }
@@ -3120,7 +3176,7 @@ InterpretResult vm_run_dispatch(void) {
                             VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(),
                                             "Integer overflow");
                         }
-                        store_i64_register(reg, incremented);
+                        vm_store_i64_typed_hot(reg, incremented);
                         if (incremented < AS_I64(limit)) {
                             vm.ip += offset;
                         }
@@ -3128,8 +3184,8 @@ InterpretResult vm_run_dispatch(void) {
                     }
 
                     if (IS_U32(counter) && IS_U32(limit)) {
-                        uint32_t incremented = AS_U32(counter) + 1u;
-                        store_u32_register(reg, incremented);
+                        uint32_t incremented = AS_U32(counter) + (uint32_t)1;
+                        vm_store_u32_typed_hot(reg, incremented);
                         if (incremented < AS_U32(limit)) {
                             vm.ip += offset;
                         }
@@ -3137,8 +3193,8 @@ InterpretResult vm_run_dispatch(void) {
                     }
 
                     if (IS_U64(counter) && IS_U64(limit)) {
-                        uint64_t incremented = AS_U64(counter) + 1u;
-                        store_u64_register(reg, incremented);
+                        uint64_t incremented = AS_U64(counter) + (uint64_t)1;
+                        vm_store_u64_typed_hot(reg, incremented);
                         if (incremented < AS_U64(limit)) {
                             vm.ip += offset;
                         }

--- a/tests/unit/test_vm_inc_cmp_jmp.c
+++ b/tests/unit/test_vm_inc_cmp_jmp.c
@@ -1,0 +1,264 @@
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "vm/vm.h"
+#include "vm/vm_comparison.h"
+#include "vm/vm_dispatch.h"
+
+static void write_short(Chunk* chunk, int16_t value) {
+    uint16_t encoded = (uint16_t)value;
+    writeChunk(chunk, (uint8_t)(encoded & 0xFF), 1, 0, "inc_cmp_jmp");
+    writeChunk(chunk, (uint8_t)(encoded >> 8), 1, 0, "inc_cmp_jmp");
+}
+
+static void write_inc_cmp_jmp_program(Chunk* chunk, uint8_t counter_reg, uint8_t limit_reg, int16_t offset) {
+    writeChunk(chunk, OP_INC_CMP_JMP, 1, 0, "inc_cmp_jmp");
+    writeChunk(chunk, counter_reg, 1, 0, "inc_cmp_jmp");
+    writeChunk(chunk, limit_reg, 1, 0, "inc_cmp_jmp");
+    write_short(chunk, offset);
+    writeChunk(chunk, OP_HALT, 1, 0, "inc_cmp_jmp");
+}
+
+static bool test_inc_cmp_jmp_i32_loop(void) {
+    initVM();
+
+    Chunk chunk;
+    initChunk(&chunk);
+    write_inc_cmp_jmp_program(&chunk, 0, 1, (int16_t)-5);
+
+    vm_store_i32_typed_hot(0, 0);
+    vm_store_i32_typed_hot(1, 5);
+
+    vm.chunk = &chunk;
+    vm.ip = chunk.code;
+
+    InterpretResult result = vm_run_dispatch();
+
+    bool success = true;
+    if (result != INTERPRET_OK) {
+        fprintf(stderr, "Expected INTERPRET_OK for i32 loop, got %d\n", result);
+        success = false;
+        goto cleanup;
+    }
+
+    Value counter = vm_get_register_safe(0);
+    if (!(IS_I32(counter) && AS_I32(counter) == 5)) {
+        fprintf(stderr, "Expected counter to reach 5 for i32 loop, got type %d value %d\n",
+                counter.type, IS_I32(counter) ? AS_I32(counter) : -1);
+        success = false;
+        goto cleanup;
+    }
+
+cleanup:
+    freeChunk(&chunk);
+    freeVM();
+    return success;
+}
+
+static bool test_inc_cmp_jmp_u32_loop(void) {
+    initVM();
+
+    Chunk chunk;
+    initChunk(&chunk);
+    write_inc_cmp_jmp_program(&chunk, 0, 1, (int16_t)-5);
+
+    vm_store_u32_typed_hot(0, 0u);
+    vm_store_u32_typed_hot(1, 4u);
+
+    vm.chunk = &chunk;
+    vm.ip = chunk.code;
+
+    InterpretResult result = vm_run_dispatch();
+
+    bool success = true;
+    if (result != INTERPRET_OK) {
+        fprintf(stderr, "Expected INTERPRET_OK for u32 loop, got %d\n", result);
+        success = false;
+        goto cleanup;
+    }
+
+    Value counter = vm_get_register_safe(0);
+    if (!(IS_U32(counter) && AS_U32(counter) == 4u)) {
+        fprintf(stderr, "Expected counter to reach 4 for u32 loop, got type %d value %u\n",
+                counter.type, IS_U32(counter) ? AS_U32(counter) : 0u);
+        success = false;
+        goto cleanup;
+    }
+
+cleanup:
+    freeChunk(&chunk);
+    freeVM();
+    return success;
+}
+
+static bool test_inc_cmp_jmp_i64_loop(void) {
+    initVM();
+
+    Chunk chunk;
+    initChunk(&chunk);
+    write_inc_cmp_jmp_program(&chunk, 0, 1, (int16_t)-5);
+
+    vm_store_i64_typed_hot(0, 0);
+    vm_store_i64_typed_hot(1, 3);
+
+    vm.chunk = &chunk;
+    vm.ip = chunk.code;
+
+    InterpretResult result = vm_run_dispatch();
+
+    bool success = true;
+    if (result != INTERPRET_OK) {
+        fprintf(stderr, "Expected INTERPRET_OK for i64 loop, got %d\n", result);
+        success = false;
+        goto cleanup;
+    }
+
+    Value counter = vm_get_register_safe(0);
+    if (!(IS_I64(counter) && AS_I64(counter) == 3)) {
+        fprintf(stderr, "Expected counter to reach 3 for i64 loop, got type %d value %lld\n",
+                counter.type, IS_I64(counter) ? (long long)AS_I64(counter) : -1LL);
+        success = false;
+        goto cleanup;
+    }
+
+cleanup:
+    freeChunk(&chunk);
+    freeVM();
+    return success;
+}
+
+static bool test_inc_cmp_jmp_u64_loop(void) {
+    initVM();
+
+    Chunk chunk;
+    initChunk(&chunk);
+    write_inc_cmp_jmp_program(&chunk, 0, 1, (int16_t)-5);
+
+    vm_store_u64_typed_hot(0, 1u);
+    vm_store_u64_typed_hot(1, 3u);
+
+    vm.chunk = &chunk;
+    vm.ip = chunk.code;
+
+    InterpretResult result = vm_run_dispatch();
+
+    bool success = true;
+    if (result != INTERPRET_OK) {
+        fprintf(stderr, "Expected INTERPRET_OK for u64 loop, got %d\n", result);
+        success = false;
+        goto cleanup;
+    }
+
+    Value counter = vm_get_register_safe(0);
+    if (!(IS_U64(counter) && AS_U64(counter) == 3u)) {
+        fprintf(stderr, "Expected counter to reach 3 for u64 loop, got type %d value %llu\n",
+                counter.type, IS_U64(counter) ? (unsigned long long)AS_U64(counter) : 0ULL);
+        success = false;
+        goto cleanup;
+    }
+
+cleanup:
+    freeChunk(&chunk);
+    freeVM();
+    return success;
+}
+
+static bool test_inc_cmp_jmp_i32_overflow(void) {
+    initVM();
+
+    Chunk chunk;
+    initChunk(&chunk);
+    write_inc_cmp_jmp_program(&chunk, 0, 1, (int16_t)-5);
+
+    vm_store_i32_typed_hot(0, INT32_MAX);
+    vm_store_i32_typed_hot(1, INT32_MAX);
+
+    vm.chunk = &chunk;
+    vm.ip = chunk.code;
+
+    InterpretResult result = vm_run_dispatch();
+
+    bool success = true;
+    if (result != INTERPRET_RUNTIME_ERROR) {
+        fprintf(stderr, "Expected runtime error for i32 overflow, got %d\n", result);
+        success = false;
+        goto cleanup;
+    }
+
+    if (!(IS_ERROR(vm.lastError) && AS_ERROR(vm.lastError)->type == ERROR_VALUE)) {
+        fprintf(stderr, "Expected ERROR_VALUE for i32 overflow\n");
+        success = false;
+        goto cleanup;
+    }
+
+cleanup:
+    freeChunk(&chunk);
+    freeVM();
+    return success;
+}
+
+static bool test_inc_cmp_jmp_i64_overflow(void) {
+    initVM();
+
+    Chunk chunk;
+    initChunk(&chunk);
+    write_inc_cmp_jmp_program(&chunk, 0, 1, (int16_t)-5);
+
+    vm_store_i64_typed_hot(0, INT64_MAX);
+    vm_store_i64_typed_hot(1, INT64_MAX);
+
+    vm.chunk = &chunk;
+    vm.ip = chunk.code;
+
+    InterpretResult result = vm_run_dispatch();
+
+    bool success = true;
+    if (result != INTERPRET_RUNTIME_ERROR) {
+        fprintf(stderr, "Expected runtime error for i64 overflow, got %d\n", result);
+        success = false;
+        goto cleanup;
+    }
+
+    if (!(IS_ERROR(vm.lastError) && AS_ERROR(vm.lastError)->type == ERROR_VALUE)) {
+        fprintf(stderr, "Expected ERROR_VALUE for i64 overflow\n");
+        success = false;
+        goto cleanup;
+    }
+
+cleanup:
+    freeChunk(&chunk);
+    freeVM();
+    return success;
+}
+
+int main(void) {
+    struct {
+        const char* name;
+        bool (*fn)(void);
+    } tests[] = {
+        {"OP_INC_CMP_JMP increments i32", test_inc_cmp_jmp_i32_loop},
+        {"OP_INC_CMP_JMP increments u32", test_inc_cmp_jmp_u32_loop},
+        {"OP_INC_CMP_JMP increments i64", test_inc_cmp_jmp_i64_loop},
+        {"OP_INC_CMP_JMP increments u64", test_inc_cmp_jmp_u64_loop},
+        {"OP_INC_CMP_JMP detects i32 overflow", test_inc_cmp_jmp_i32_overflow},
+        {"OP_INC_CMP_JMP detects i64 overflow", test_inc_cmp_jmp_i64_overflow},
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; i++) {
+        if (tests[i].fn()) {
+            printf("[PASS] %s\n", tests[i].name);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", tests[i].name);
+            return 1;
+        }
+    }
+
+    printf("%d/%d OP_INC_CMP_JMP tests passed\n", passed, total);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure OP_INC_CMP_JMP uses typed register fast paths before falling back to boxed reads in both switch and computed-goto dispatchers
- add hot-path store helpers for i64/u32/u64 to match the existing i32 helper and update OP_INC_CMP_JMP to use them
- wire new OP_INC_CMP_JMP regression coverage into the unit test suite and include i32/u32/i64/u64 and overflow scenarios

## Testing
- make release
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e25483e24c83259551247e08f14645