### PR TITLE
Refine fused loop lowering and add regressions

### DIFF
--- a/src/compiler/backend/codegen/expressions.c
+++ b/src/compiler/backend/codegen/expressions.c
@@ -2339,6 +2339,45 @@ bool evaluate_constant_i32(TypedASTNode* node, int32_t* out_value) {
                     return false;
             }
         }
+        case NODE_BINARY: {
+            if (!original->binary.op) {
+                return false;
+            }
+            TypedASTNode* left = node->typed.binary.left;
+            TypedASTNode* right = node->typed.binary.right;
+            if (!left || !right) {
+                return false;
+            }
+            int32_t left_val = 0;
+            int32_t right_val = 0;
+            if (!evaluate_constant_i32(left, &left_val) ||
+                !evaluate_constant_i32(right, &right_val)) {
+                return false;
+            }
+            if (strcmp(original->binary.op, "+") == 0) {
+                *out_value = left_val + right_val;
+                return true;
+            } else if (strcmp(original->binary.op, "-") == 0) {
+                *out_value = left_val - right_val;
+                return true;
+            } else if (strcmp(original->binary.op, "*") == 0) {
+                *out_value = left_val * right_val;
+                return true;
+            } else if (strcmp(original->binary.op, "/") == 0) {
+                if (right_val == 0) {
+                    return false;
+                }
+                *out_value = left_val / right_val;
+                return true;
+            } else if (strcmp(original->binary.op, "%") == 0) {
+                if (right_val == 0) {
+                    return false;
+                }
+                *out_value = left_val % right_val;
+                return true;
+            }
+            return false;
+        }
         case NODE_UNARY: {
             if (!original->unary.op || strcmp(original->unary.op, "-") != 0) {
                 return false;

--- a/tests/control_flow/loop_fused_regressions.orus
+++ b/tests/control_flow/loop_fused_regressions.orus
@@ -1,0 +1,51 @@
+print("=== Fused Loop Regression Tests ===")
+
+base = 3
+derived_limit = base * 2
+mut while_index = 0
+mut while_sum = 0
+while while_index < derived_limit:
+    while_sum = while_sum + while_index
+    while_index = while_index + 1
+
+inclusive_limit = base + 4
+mut inclusive_index = 0
+mut inclusive_sum = 0
+while inclusive_index <= inclusive_limit:
+    inclusive_sum = inclusive_sum + inclusive_index
+    inclusive_index = inclusive_index + 1
+
+start_val = 2
+offset_val = 4
+derived_end = start_val + offset_val
+mut range_sum = 0
+for k in start_val..derived_end:
+    range_sum = range_sum + k
+
+inclusive_end = 3
+inclusive_range_end = inclusive_end + 2
+mut inclusive_range_sum = 0
+for m in 0..=inclusive_range_end:
+    inclusive_range_sum = inclusive_range_sum + m
+
+mut cached_step_sum = 0
+for n in 0..10..(0 + 1):
+    cached_step_sum = cached_step_sum + n
+
+cached_step = 1
+mut cached_identifier_step_sum = 0
+for p in 0..5..cached_step:
+    cached_identifier_step_sum = cached_identifier_step_sum + p
+
+if assert_eq("while derived limit sum", while_sum, 15):
+    print("ok", "while derived limit sum", while_sum)
+if assert_eq("while inclusive derived sum", inclusive_sum, 28):
+    print("ok", "while inclusive derived sum", inclusive_sum)
+if assert_eq("for derived limit sum", range_sum, 14):
+    print("ok", "for derived limit sum", range_sum)
+if assert_eq("for inclusive derived sum", inclusive_range_sum, 15):
+    print("ok", "for inclusive derived sum", inclusive_range_sum)
+if assert_eq("for cached step sum", cached_step_sum, 45):
+    print("ok", "for cached step sum", cached_step_sum)
+if assert_eq("for cached identifier step sum", cached_identifier_step_sum, 10):
+    print("ok", "for cached identifier step sum", cached_identifier_step_sum)


### PR DESCRIPTION
## Summary
- share fused counter loop preparation between while and for-range statements using typed analysis and single limit compilation
- extend constant evaluation to recognize simple binary expressions when folding cached loop bounds
- add a regression exercise for fused loops with derived limits, inclusive ranges, and cached steps

## Testing
- make release
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e2548e5e44832584411b2743a64bfe