### PR TITLE
Add overflow guard for OP_ADD_I32_IMM and extend coverage

### DIFF
--- a/makefile
+++ b/makefile
@@ -250,6 +250,7 @@ TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
 TYPED_REGISTER_TEST_BIN = $(BUILDDIR)/tests/test_vm_typed_registers
 REGISTER_ALLOCATOR_TEST_BIN = $(BUILDDIR)/tests/test_register_allocator
 INC_CMP_JMP_TEST_BIN = $(BUILDDIR)/tests/test_vm_inc_cmp_jmp
+ADD_I32_IMM_TEST_BIN = $(BUILDDIR)/tests/test_vm_add_i32_imm
 BUILTIN_INPUT_TEST_BIN = $(BUILDDIR)/tests/test_builtin_input
 CONSTANT_FOLD_TEST_BIN = $(BUILDDIR)/tests/test_constant_folding
 BUILTIN_SORTED_ORUS_TESTS = \
@@ -265,7 +266,7 @@ BUILTIN_RANGE_ORUS_FAIL_TESTS = \
     tests/builtins/range_float_step.orus \
     tests/builtins/range_overflow_stop.orus
 
-.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests inc-cmp-jmp-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
+.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests inc-cmp-jmp-tests add-i32-imm-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
 
 all: build-info $(ORUS)
 
@@ -435,6 +436,9 @@ _test-run: $(ORUS)
 	@echo "\033[36m=== OP_INC_CMP_JMP Tests ===\033[0m"
 	@$(MAKE) inc-cmp-jmp-tests
 	@echo ""
+	@echo "\033[36m=== OP_ADD_I32_IMM Tests ===\033[0m"
+	@$(MAKE) add-i32-imm-tests
+	@echo ""
 	@echo "\033[36m=== Register Allocator Tests ===\033[0m"
 	@$(MAKE) register-allocator-tests
 	@echo ""
@@ -530,6 +534,15 @@ $(INC_CMP_JMP_TEST_BIN): tests/unit/test_vm_inc_cmp_jmp.c $(COMPILER_OBJS) $(VM_
 inc-cmp-jmp-tests: $(INC_CMP_JMP_TEST_BIN)
 	@echo "Running OP_INC_CMP_JMP regression tests..."
 	@./$(INC_CMP_JMP_TEST_BIN)
+
+$(ADD_I32_IMM_TEST_BIN): tests/unit/test_vm_add_i32_imm.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling OP_ADD_I32_IMM regression tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+add-i32-imm-tests: $(ADD_I32_IMM_TEST_BIN)
+	@echo "Running OP_ADD_I32_IMM regression tests..."
+	@./$(ADD_I32_IMM_TEST_BIN)
 
 $(REGISTER_ALLOCATOR_TEST_BIN): tests/unit/test_register_allocator.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -3595,7 +3595,12 @@ InterpretResult vm_run_dispatch(void) {
             VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operand must be i32");
         }
 
-        int32_t result = AS_I32(src_value) + imm;
+        int32_t current = AS_I32(src_value);
+        int32_t result;
+        if (__builtin_add_overflow(current, imm, &result)) {
+            VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Integer overflow");
+        }
+
         vm_store_i32_typed_hot(dst, result);
 
         DISPATCH_TYPED();

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -3082,7 +3082,12 @@ InterpretResult vm_run_dispatch(void) {
                         VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(), "Operand must be i32");
                     }
 
-                    int32_t result = AS_I32(src_value) + imm;
+                    int32_t current = AS_I32(src_value);
+                    int32_t result;
+                    if (__builtin_add_overflow(current, imm, &result)) {
+                        VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Integer overflow");
+                    }
+
                     vm_store_i32_typed_hot(dst, result);
                     break;
                 }

--- a/tests/unit/test_vm_add_i32_imm.c
+++ b/tests/unit/test_vm_add_i32_imm.c
@@ -1,0 +1,118 @@
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "vm/vm.h"
+#include "vm/vm_comparison.h"
+#include "vm/vm_dispatch.h"
+
+static void write_int32(Chunk* chunk, int32_t value) {
+    uint32_t encoded = (uint32_t)value;
+    writeChunk(chunk, (uint8_t)(encoded & 0xFF), 1, 0, "add_i32_imm");
+    writeChunk(chunk, (uint8_t)((encoded >> 8) & 0xFF), 1, 0, "add_i32_imm");
+    writeChunk(chunk, (uint8_t)((encoded >> 16) & 0xFF), 1, 0, "add_i32_imm");
+    writeChunk(chunk, (uint8_t)((encoded >> 24) & 0xFF), 1, 0, "add_i32_imm");
+}
+
+static void write_add_i32_imm_program(Chunk* chunk, uint8_t dst_reg, uint8_t src_reg, int32_t imm) {
+    writeChunk(chunk, OP_ADD_I32_IMM, 1, 0, "add_i32_imm");
+    writeChunk(chunk, dst_reg, 1, 0, "add_i32_imm");
+    writeChunk(chunk, src_reg, 1, 0, "add_i32_imm");
+    write_int32(chunk, imm);
+    writeChunk(chunk, OP_HALT, 1, 0, "add_i32_imm");
+}
+
+static bool test_add_i32_imm_success(void) {
+    initVM();
+
+    Chunk chunk;
+    initChunk(&chunk);
+    write_add_i32_imm_program(&chunk, 0, 0, 3);
+
+    vm_store_i32_typed_hot(0, 5);
+
+    vm.chunk = &chunk;
+    vm.ip = chunk.code;
+
+    InterpretResult result = vm_run_dispatch();
+
+    bool success = true;
+    if (result != INTERPRET_OK) {
+        fprintf(stderr, "Expected INTERPRET_OK for OP_ADD_I32_IMM, got %d\n", result);
+        success = false;
+        goto cleanup;
+    }
+
+    Value reg0 = vm_get_register_safe(0);
+    if (!(IS_I32(reg0) && AS_I32(reg0) == 8)) {
+        fprintf(stderr, "Expected register 0 to be 8 after addition, got type %d value %d\n",
+                reg0.type, IS_I32(reg0) ? AS_I32(reg0) : -1);
+        success = false;
+        goto cleanup;
+    }
+
+cleanup:
+    freeChunk(&chunk);
+    freeVM();
+    return success;
+}
+
+static bool test_add_i32_imm_overflow(void) {
+    initVM();
+
+    Chunk chunk;
+    initChunk(&chunk);
+    write_add_i32_imm_program(&chunk, 1, 0, 1);
+
+    vm_store_i32_typed_hot(0, INT32_MAX);
+
+    vm.chunk = &chunk;
+    vm.ip = chunk.code;
+
+    InterpretResult result = vm_run_dispatch();
+
+    bool success = true;
+    if (result != INTERPRET_RUNTIME_ERROR) {
+        fprintf(stderr, "Expected INTERPRET_RUNTIME_ERROR for overflow, got %d\n", result);
+        success = false;
+        goto cleanup;
+    }
+
+    if (!(IS_ERROR(vm.lastError) && AS_ERROR(vm.lastError)->type == ERROR_VALUE)) {
+        fprintf(stderr, "Expected ERROR_VALUE for overflow\n");
+        success = false;
+        goto cleanup;
+    }
+
+cleanup:
+    freeChunk(&chunk);
+    freeVM();
+    return success;
+}
+
+int main(void) {
+    struct {
+        const char* name;
+        bool (*fn)(void);
+    } tests[] = {
+        {"OP_ADD_I32_IMM adds immediate to register", test_add_i32_imm_success},
+        {"OP_ADD_I32_IMM detects overflow", test_add_i32_imm_overflow},
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; i++) {
+        bool ok = tests[i].fn();
+        if (ok) {
+            printf("[PASS] %s\n", tests[i].name);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", tests[i].name);
+        }
+    }
+
+    printf("%d/%d OP_ADD_I32_IMM tests passed\n", passed, total);
+    return passed == total ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add overflow detection to OP_ADD_I32_IMM in both dispatchers so counter adjustments report integer overflow instead of wrapping
- introduce a dedicated OP_ADD_I32_IMM regression test exercising normal and overflow paths
- hook the new test binary into the test driver alongside the existing loop opcode suite