### PR TITLE
Refactor fused loop emission

### DIFF
--- a/makefile
+++ b/makefile
@@ -250,6 +250,7 @@ TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
 TYPED_REGISTER_TEST_BIN = $(BUILDDIR)/tests/test_vm_typed_registers
 REGISTER_ALLOCATOR_TEST_BIN = $(BUILDDIR)/tests/test_register_allocator
 INC_CMP_JMP_TEST_BIN = $(BUILDDIR)/tests/test_vm_inc_cmp_jmp
+FUSED_LOOP_TEST_BIN = $(BUILDDIR)/tests/test_fused_loop_bytecode
 ADD_I32_IMM_TEST_BIN = $(BUILDDIR)/tests/test_vm_add_i32_imm
 BUILTIN_INPUT_TEST_BIN = $(BUILDDIR)/tests/test_builtin_input
 CONSTANT_FOLD_TEST_BIN = $(BUILDDIR)/tests/test_constant_folding
@@ -266,7 +267,7 @@ BUILTIN_RANGE_ORUS_FAIL_TESTS = \
     tests/builtins/range_float_step.orus \
     tests/builtins/range_overflow_stop.orus
 
-.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests inc-cmp-jmp-tests add-i32-imm-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
+.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests inc-cmp-jmp-tests fused-loop-bytecode-tests add-i32-imm-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
 
 all: build-info $(ORUS)
 
@@ -436,6 +437,9 @@ _test-run: $(ORUS)
 	@echo "\033[36m=== OP_INC_CMP_JMP Tests ===\033[0m"
 	@$(MAKE) inc-cmp-jmp-tests
 	@echo ""
+	@echo "\033[36m=== Fused Loop Bytecode Tests ===\033[0m"
+	@$(MAKE) fused-loop-bytecode-tests
+	@echo ""
 	@echo "\033[36m=== OP_ADD_I32_IMM Tests ===\033[0m"
 	@$(MAKE) add-i32-imm-tests
 	@echo ""
@@ -534,6 +538,15 @@ $(INC_CMP_JMP_TEST_BIN): tests/unit/test_vm_inc_cmp_jmp.c $(COMPILER_OBJS) $(VM_
 inc-cmp-jmp-tests: $(INC_CMP_JMP_TEST_BIN)
 	@echo "Running OP_INC_CMP_JMP regression tests..."
 	@./$(INC_CMP_JMP_TEST_BIN)
+
+$(FUSED_LOOP_TEST_BIN): tests/unit/test_fused_loop_bytecode.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling fused loop bytecode tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+fused-loop-bytecode-tests: $(FUSED_LOOP_TEST_BIN)
+	@echo "Running fused loop bytecode tests..."
+	@./$(FUSED_LOOP_TEST_BIN)
 
 $(ADD_I32_IMM_TEST_BIN): tests/unit/test_vm_add_i32_imm.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/src/compiler/backend/codegen/statements.c
+++ b/src/compiler/backend/codegen/statements.c
@@ -1753,6 +1753,217 @@ static void patch_continue_statements(CompilerContext* ctx, int continue_target)
     }
 }
 
+typedef void (*FusedLoopBodyEmitter)(CompilerContext* ctx, void* user_data);
+
+typedef struct {
+    TypedASTNode* loop_node;
+    ScopeFrame** loop_frame_ptr;
+    int loop_frame_index;
+    int loop_start;
+    bool patch_continue_sites;
+    bool update_continue_target;
+    TypedASTNode* limit_node;
+    int typed_hint_limit_reg;
+    bool limit_reg_is_temp;
+    bool adjusted_limit_is_temp;
+} FusedLoopEmitMetadata;
+
+static bool emit_fused_numeric_loop(CompilerContext* ctx,
+                                    int loop_reg,
+                                    int limit_reg,
+                                    int adjusted_limit_reg,
+                                    FusedLoopBodyEmitter body_emitter,
+                                    void* body_data,
+                                    FusedLoopEmitMetadata* metadata) {
+    if (!ctx || !metadata || !metadata->loop_node || !metadata->loop_frame_ptr) {
+        return false;
+    }
+
+    ScopeFrame* frame = metadata->loop_frame_ptr ? *metadata->loop_frame_ptr : NULL;
+    int loop_start = metadata->loop_start;
+
+    bool use_adjusted_limit = adjusted_limit_reg >= 0;
+    int guard_limit_reg = use_adjusted_limit ? adjusted_limit_reg : limit_reg;
+    int guard_copy_reg = -1;
+
+    if (!use_adjusted_limit && metadata->limit_reg_is_temp && ctx->allocator) {
+        guard_copy_reg = compiler_alloc_temp(ctx->allocator);
+        if (guard_copy_reg == -1) {
+            ctx->has_compilation_errors = true;
+            if (frame) {
+                leave_loop_context(ctx, frame, ctx->bytecode ? ctx->bytecode->count : loop_start);
+                *metadata->loop_frame_ptr = NULL;
+            }
+            return false;
+        }
+
+        set_location_from_node(ctx, metadata->limit_node ? metadata->limit_node
+                                                         : metadata->loop_node);
+        emit_byte_to_buffer(ctx->bytecode, OP_MOVE_I32);
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)guard_copy_reg);
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)guard_limit_reg);
+        guard_limit_reg = guard_copy_reg;
+    }
+
+    if (guard_limit_reg < 0) {
+        ctx->has_compilation_errors = true;
+        if (frame) {
+            leave_loop_context(ctx, frame, ctx->bytecode ? ctx->bytecode->count : loop_start);
+            *metadata->loop_frame_ptr = NULL;
+        }
+        if (guard_copy_reg >= 0 && ctx->allocator) {
+            compiler_free_temp(ctx->allocator, guard_copy_reg);
+        }
+        return false;
+    }
+
+    if (metadata->limit_node) {
+        ensure_i32_typed_register(ctx, guard_limit_reg, metadata->limit_node);
+    }
+
+    metadata->typed_hint_limit_reg = guard_limit_reg;
+
+    if (ctx->allocator && metadata->typed_hint_limit_reg >= 0) {
+        compiler_set_typed_residency_hint(ctx->allocator, metadata->typed_hint_limit_reg, true);
+    }
+
+    set_location_from_node(ctx, metadata->loop_node);
+    emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+    emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_reg);
+    emit_byte_to_buffer(ctx->bytecode, (uint8_t)guard_limit_reg);
+    int guard_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+    if (guard_patch < 0) {
+        ctx->has_compilation_errors = true;
+        if (ctx->allocator && metadata->typed_hint_limit_reg >= 0) {
+            compiler_set_typed_residency_hint(ctx->allocator, metadata->typed_hint_limit_reg, false);
+        }
+        if (guard_copy_reg >= 0 && ctx->allocator) {
+            compiler_free_temp(ctx->allocator, guard_copy_reg);
+        }
+        if (frame) {
+            leave_loop_context(ctx, frame, ctx->bytecode ? ctx->bytecode->count : loop_start);
+            *metadata->loop_frame_ptr = NULL;
+        }
+        return false;
+    }
+
+    if (body_emitter) {
+        body_emitter(ctx, body_data);
+    }
+
+    if (metadata->loop_frame_index >= 0) {
+        frame = get_scope_frame_by_index(ctx, metadata->loop_frame_index);
+        if (metadata->loop_frame_ptr) {
+            *metadata->loop_frame_ptr = frame;
+        }
+    }
+
+    int continue_target = ctx->bytecode ? ctx->bytecode->count : 0;
+    if (metadata->update_continue_target) {
+        update_loop_continue_target(ctx, frame, continue_target);
+    }
+    if (metadata->patch_continue_sites) {
+        patch_continue_statements(ctx, continue_target);
+    }
+
+    set_location_from_node(ctx, metadata->loop_node);
+    emit_byte_to_buffer(ctx->bytecode, OP_INC_CMP_JMP);
+    emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_reg);
+    emit_byte_to_buffer(ctx->bytecode, (uint8_t)guard_limit_reg);
+    int back_off = loop_start - (ctx->bytecode->count + 2);
+    emit_byte_to_buffer(ctx->bytecode, (uint8_t)(back_off & 0xFF));
+    emit_byte_to_buffer(ctx->bytecode, (uint8_t)((back_off >> 8) & 0xFF));
+
+    int end_target = ctx->bytecode ? ctx->bytecode->count : 0;
+    ctx->current_loop_end = end_target;
+    if (frame) {
+        frame->end_offset = end_target;
+    }
+
+    patch_break_statements(ctx, end_target);
+
+    if (!patch_jump(ctx->bytecode, guard_patch, end_target)) {
+        ctx->has_compilation_errors = true;
+        if (frame) {
+            leave_loop_context(ctx, frame, end_target);
+            if (metadata->loop_frame_ptr) {
+                *metadata->loop_frame_ptr = NULL;
+            }
+        }
+        if (ctx->allocator && metadata->typed_hint_limit_reg >= 0) {
+            compiler_set_typed_residency_hint(ctx->allocator, metadata->typed_hint_limit_reg, false);
+        }
+        return false;
+    }
+
+    leave_loop_context(ctx, frame, end_target);
+    if (metadata->loop_frame_ptr) {
+        *metadata->loop_frame_ptr = NULL;
+    }
+
+    if (ctx->allocator && metadata->typed_hint_limit_reg >= 0) {
+        compiler_set_typed_residency_hint(ctx->allocator, metadata->typed_hint_limit_reg, false);
+    }
+
+    if (guard_copy_reg >= 0 && ctx->allocator) {
+        compiler_free_temp(ctx->allocator, guard_copy_reg);
+    }
+
+    return true;
+}
+
+typedef struct {
+    TypedASTNode* body;
+    bool body_is_block;
+    int body_statement_count;
+    bool has_increment;
+} FusedWhileBodyData;
+
+static void emit_fused_while_body(CompilerContext* ctx, void* user_data) {
+    if (!ctx || !user_data) {
+        return;
+    }
+
+    FusedWhileBodyData* data = (FusedWhileBodyData*)user_data;
+    TypedASTNode* body = data->body;
+    if (!body) {
+        return;
+    }
+
+    if (data->body_is_block && data->body_statement_count > 0 &&
+        body->original && body->original->type == NODE_BLOCK) {
+        int limit = data->body_statement_count - 1;
+        if (limit < 0) {
+            limit = 0;
+        }
+        for (int i = 0; i < limit; i++) {
+            TypedASTNode* stmt = body->typed.block.statements[i];
+            if (stmt) {
+                compile_statement(ctx, stmt);
+            }
+        }
+    } else if (!data->body_is_block && !data->has_increment && body) {
+        compile_statement(ctx, body);
+    }
+}
+
+typedef struct {
+    TypedASTNode* body;
+} FusedForRangeBodyData;
+
+static void emit_fused_for_range_body(CompilerContext* ctx, void* user_data) {
+    if (!ctx || !user_data) {
+        return;
+    }
+
+    FusedForRangeBodyData* data = (FusedForRangeBodyData*)user_data;
+    if (!data->body) {
+        return;
+    }
+
+    compile_block_with_scope(ctx, data->body, true);
+}
+
 void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
     if (!ctx || !while_stmt) return;
 
@@ -1799,8 +2010,20 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
         int upvalue_index = -1;
         fused_symbol = resolve_symbol(ctx->symbols, fused_index_name);
         fused_loop_reg = resolve_variable_or_upvalue(ctx, fused_index_name, &is_upvalue, &upvalue_index);
-        if (!fused_symbol || !fused_symbol->is_mutable || !fused_symbol->type ||
-            fused_symbol->type->kind != TYPE_I32 || fused_loop_reg < 0 || is_upvalue) {
+
+        const Type* loop_type = get_effective_type(condition_node ? condition_node->typed.binary.left : NULL);
+        if (fused_symbol && fused_symbol->type) {
+            loop_type = fused_symbol->type;
+        }
+
+        bool loop_type_ok = loop_type && loop_type->kind == TYPE_I32;
+        const Type* limit_type = get_effective_type(fused_limit_node);
+        if (!loop_type_ok && limit_type && limit_type->kind == TYPE_I32) {
+            loop_type_ok = true;
+        }
+
+        if (!fused_symbol || !fused_symbol->is_mutable || !loop_type_ok ||
+            fused_loop_reg < 0 || is_upvalue) {
             use_fused_inc = false;
         }
     }
@@ -1846,28 +2069,38 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
             loop_frame_fused->label = while_stmt->original->whileStmt.label;
         }
 
-        DEBUG_CODEGEN_PRINT("While loop start at offset %d\n", loop_start_fused);
+        FusedWhileBodyData body_data = {
+            .body = while_body,
+            .body_is_block = fused_body_is_block,
+            .body_statement_count = fused_block_count,
+            .has_increment = fused_info.has_increment,
+        };
 
-        int typed_hint_limit_reg = -1;
-        int fused_limit_guard_reg = fused_info.use_adjusted_limit ? fused_limit_temp_reg : fused_limit_reg;
-        if (fused_limit_guard_reg >= 0) {
-            ensure_i32_typed_register(ctx, fused_limit_guard_reg,
-                                      fused_info.use_adjusted_limit ? fused_limit_node : fused_limit_node);
-        }
-        if (ctx->allocator && fused_limit_guard_reg >= 0) {
-            compiler_set_typed_residency_hint(ctx->allocator, fused_limit_guard_reg, true);
-            typed_hint_limit_reg = fused_limit_guard_reg;
-        }
+        int adjusted_limit_reg = fused_info.use_adjusted_limit ? fused_limit_temp_reg : -1;
+        int hint_reg = fused_info.use_adjusted_limit ? fused_limit_temp_reg : fused_limit_reg;
 
-        set_location_from_node(ctx, while_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_loop_reg);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(fused_limit_temp_is_temp ? fused_limit_temp_reg : fused_limit_reg));
-        int end_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
-        if (end_patch < 0) {
-            DEBUG_CODEGEN_PRINT("Error: Failed to allocate while-loop end placeholder\n");
-            ctx->has_compilation_errors = true;
-            leave_loop_context(ctx, loop_frame_fused, ctx->bytecode->count);
+        FusedLoopEmitMetadata metadata = {
+            .loop_node = while_stmt,
+            .loop_frame_ptr = &loop_frame_fused,
+            .loop_frame_index = loop_frame_index,
+            .loop_start = loop_start_fused,
+            .patch_continue_sites = false,
+            .update_continue_target = false,
+            .limit_node = fused_limit_node,
+            .typed_hint_limit_reg = hint_reg,
+            .limit_reg_is_temp = fused_limit_is_temp,
+            .adjusted_limit_is_temp = fused_limit_temp_is_temp,
+        };
+
+        bool fused_success = emit_fused_numeric_loop(ctx,
+                                                     fused_loop_reg,
+                                                     fused_limit_reg,
+                                                     adjusted_limit_reg,
+                                                     emit_fused_while_body,
+                                                     &body_data,
+                                                     &metadata);
+
+        if (!fused_success) {
             if (fused_info.use_adjusted_limit && fused_limit_temp_is_temp &&
                 fused_limit_temp_reg >= 0) {
                 compiler_free_temp(ctx->allocator, fused_limit_temp_reg);
@@ -1877,61 +2110,7 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
             }
             return;
         }
-        if (fused_body_is_block && fused_block_count > 0 && while_body && while_body->original &&
-            while_body->original->type == NODE_BLOCK) {
-            int limit = fused_block_count - 1;
-            if (limit < 0) {
-                limit = 0;
-            }
-            for (int i = 0; i < limit; i++) {
-                TypedASTNode* stmt = while_body->typed.block.statements[i];
-                if (stmt) {
-                    compile_statement(ctx, stmt);
-                }
-            }
-        } else if (!fused_body_is_block && fused_info.has_increment == false && while_body) {
-            // Non-block bodies without an increment should still be compiled normally.
-            compile_statement(ctx, while_body);
-        }
 
-        if (loop_frame_index >= 0) {
-            loop_frame_fused = get_scope_frame_by_index(ctx, loop_frame_index);
-        }
-
-        set_location_from_node(ctx, while_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_INC_CMP_JMP);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_loop_reg);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(fused_limit_temp_is_temp ? fused_limit_temp_reg : fused_limit_reg));
-        int back_off = loop_start_fused - (ctx->bytecode->count + 2);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(back_off & 0xFF));
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)((back_off >> 8) & 0xFF));
-
-        int end_target = ctx->bytecode->count;
-        ctx->current_loop_end = end_target;
-        if (loop_frame_fused) {
-            loop_frame_fused->end_offset = end_target;
-        }
-        patch_break_statements(ctx, end_target);
-
-        if (!patch_jump(ctx->bytecode, end_patch, end_target)) {
-            DEBUG_CODEGEN_PRINT("Error: Failed to patch while-loop end jump to %d\n", end_target);
-            ctx->has_compilation_errors = true;
-            leave_loop_context(ctx, loop_frame_fused, end_target);
-            if (fused_limit_temp_is_temp) {
-                compiler_free_temp(ctx->allocator, fused_limit_temp_reg);
-            }
-            if (fused_limit_is_temp) {
-                compiler_free_temp(ctx->allocator, fused_limit_reg);
-            }
-            return;
-        }
-        DEBUG_CODEGEN_PRINT("Patched end jump to %d\n", end_target);
-
-        leave_loop_context(ctx, loop_frame_fused, end_target);
-
-        if (ctx->allocator && typed_hint_limit_reg >= 0) {
-            compiler_set_typed_residency_hint(ctx->allocator, typed_hint_limit_reg, false);
-        }
         if (fused_info.use_adjusted_limit && fused_limit_temp_is_temp &&
             fused_limit_temp_reg >= 0) {
             compiler_free_temp(ctx->allocator, fused_limit_temp_reg);
@@ -2220,48 +2399,65 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
     ctx->current_loop_continue = -1;
     loop_frame->continue_offset = -1;
 
+    if (can_fuse_inc_cmp) {
+        FusedForRangeBodyData body_data = {
+            .body = for_stmt->typed.forRange.body,
+        };
+
+        int adjusted_limit_reg = limit_temp_reg >= 0 ? limit_temp_reg : -1;
+        int hint_reg = adjusted_limit_reg >= 0 ? adjusted_limit_reg : end_reg;
+
+        FusedLoopEmitMetadata metadata = {
+            .loop_node = for_stmt,
+            .loop_frame_ptr = &loop_frame,
+            .loop_frame_index = loop_frame_index,
+            .loop_start = loop_start,
+            .patch_continue_sites = true,
+            .update_continue_target = true,
+            .limit_node = fused_info.limit_node,
+            .typed_hint_limit_reg = hint_reg,
+            .limit_reg_is_temp = end_reg_is_temp,
+            .adjusted_limit_is_temp = limit_temp_reg_is_temp,
+        };
+
+        bool fused_ok = emit_fused_numeric_loop(ctx,
+                                                loop_var_reg,
+                                                end_reg,
+                                                adjusted_limit_reg,
+                                                emit_fused_for_range_body,
+                                                &body_data,
+                                                &metadata);
+        if (!fused_ok) {
+            goto cleanup;
+        }
+
+        loop_frame = NULL;
+        loop_frame_index = -1;
+        typed_hint_limit_reg = -1;
+        success = true;
+        goto cleanup;
+    }
+
     condition_reg = compiler_alloc_temp(ctx->allocator);
     if (condition_reg == -1) {
         ctx->has_compilation_errors = true;
         goto cleanup;
     }
 
-    // If we can use fused INC_CMP_JMP, prefer the precomputed adjusted limit when available
-    int limit_reg_used = end_reg;
-    if (can_fuse_inc_cmp && limit_temp_reg >= 0) {
-        limit_reg_used = limit_temp_reg;
+    if (ctx->allocator && end_reg >= 0) {
+        compiler_set_typed_residency_hint(ctx->allocator, end_reg, true);
+        typed_hint_limit_reg = end_reg;
     }
 
-    if (can_fuse_inc_cmp && limit_reg_used >= 0) {
-        ensure_i32_typed_register(ctx, limit_reg_used, fused_info.limit_node);
-    }
-
-    if (ctx->allocator && limit_reg_used >= 0) {
-        compiler_set_typed_residency_hint(ctx->allocator, limit_reg_used, true);
-        typed_hint_limit_reg = limit_reg_used;
-    }
-
-    int guard_patch = -1;
     set_location_from_node(ctx, for_stmt);
-    if (can_fuse_inc_cmp) {
-        emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_var_reg);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_reg_used);
-        guard_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
-        if (guard_patch < 0) {
-            ctx->has_compilation_errors = true;
-            goto cleanup;
-        }
+    if (for_stmt->typed.forRange.inclusive) {
+        emit_byte_to_buffer(ctx->bytecode, OP_LE_I32_TYPED);
     } else {
-        if (for_stmt->typed.forRange.inclusive) {
-            emit_byte_to_buffer(ctx->bytecode, OP_LE_I32_TYPED);
-        } else {
-            emit_byte_to_buffer(ctx->bytecode, OP_LT_I32_TYPED);
-        }
-        emit_byte_to_buffer(ctx->bytecode, condition_reg);
-        emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)end_reg);
+        emit_byte_to_buffer(ctx->bytecode, OP_LT_I32_TYPED);
     }
+    emit_byte_to_buffer(ctx->bytecode, condition_reg);
+    emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
+    emit_byte_to_buffer(ctx->bytecode, (uint8_t)end_reg);
 
     if (!step_known_positive) {
         condition_neg_reg = compiler_alloc_temp(ctx->allocator);
@@ -2325,19 +2521,15 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
     }
 
     int end_patch = -1;
-    if (can_fuse_inc_cmp) {
-        end_patch = guard_patch;
-    } else {
-        set_location_from_node(ctx, for_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_BRANCH_TYPED);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)((loop_id >> 8) & 0xFF));
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(loop_id & 0xFF));
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)condition_reg);
-        end_patch = emit_jump_placeholder(ctx->bytecode, OP_BRANCH_TYPED);
-        if (end_patch < 0) {
-            ctx->has_compilation_errors = true;
-            goto cleanup;
-        }
+    set_location_from_node(ctx, for_stmt);
+    emit_byte_to_buffer(ctx->bytecode, OP_BRANCH_TYPED);
+    emit_byte_to_buffer(ctx->bytecode, (uint8_t)((loop_id >> 8) & 0xFF));
+    emit_byte_to_buffer(ctx->bytecode, (uint8_t)(loop_id & 0xFF));
+    emit_byte_to_buffer(ctx->bytecode, (uint8_t)condition_reg);
+    end_patch = emit_jump_placeholder(ctx->bytecode, OP_BRANCH_TYPED);
+    if (end_patch < 0) {
+        ctx->has_compilation_errors = true;
+        goto cleanup;
     }
 
     compile_block_with_scope(ctx, for_stmt->typed.forRange.body, true);
@@ -2349,40 +2541,25 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
     int continue_target = ctx->bytecode->count;
     update_loop_continue_target(ctx, loop_frame, continue_target);
 
-    if (can_fuse_inc_cmp) {
-        // Continue statements should jump here to execute fused inc+cmp+jmp
-        patch_continue_statements(ctx, continue_target);
+    set_location_from_node(ctx, for_stmt);
+    emit_byte_to_buffer(ctx->bytecode, OP_ADD_I32_TYPED);
+    emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
+    emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
+    emit_byte_to_buffer(ctx->bytecode, step_reg);
 
+    patch_continue_statements(ctx, continue_target);
+
+    int back_jump_distance = (ctx->bytecode->count + 2) - loop_start;
+    if (back_jump_distance >= 0 && back_jump_distance <= 255) {
         set_location_from_node(ctx, for_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_INC_CMP_JMP);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_var_reg);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_reg_used);
-        // back offset is relative to address after the 2-byte offset we emit now
-        int back_off = loop_start - (ctx->bytecode->count + 2);
-        // OP_INC_CMP_JMP reads offset as native int16 (little-endian on our targets)
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(back_off & 0xFF));
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)((back_off >> 8) & 0xFF));
+        emit_byte_to_buffer(ctx->bytecode, OP_LOOP_SHORT);
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)back_jump_distance);
     } else {
+        int back_jump_offset = loop_start - (ctx->bytecode->count + 3);
         set_location_from_node(ctx, for_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_ADD_I32_TYPED);
-        emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
-        emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
-        emit_byte_to_buffer(ctx->bytecode, step_reg);
-
-        patch_continue_statements(ctx, continue_target);
-
-        int back_jump_distance = (ctx->bytecode->count + 2) - loop_start;
-        if (back_jump_distance >= 0 && back_jump_distance <= 255) {
-            set_location_from_node(ctx, for_stmt);
-            emit_byte_to_buffer(ctx->bytecode, OP_LOOP_SHORT);
-            emit_byte_to_buffer(ctx->bytecode, (uint8_t)back_jump_distance);
-        } else {
-            int back_jump_offset = loop_start - (ctx->bytecode->count + 3);
-            set_location_from_node(ctx, for_stmt);
-            emit_byte_to_buffer(ctx->bytecode, OP_JUMP);
-            emit_byte_to_buffer(ctx->bytecode, (back_jump_offset >> 8) & 0xFF);
-            emit_byte_to_buffer(ctx->bytecode, back_jump_offset & 0xFF);
-        }
+        emit_byte_to_buffer(ctx->bytecode, OP_JUMP);
+        emit_byte_to_buffer(ctx->bytecode, (back_jump_offset >> 8) & 0xFF);
+        emit_byte_to_buffer(ctx->bytecode, back_jump_offset & 0xFF);
     }
 
     int end_target = ctx->bytecode->count;

--- a/tests/unit/test_fused_loop_bytecode.c
+++ b/tests/unit/test_fused_loop_bytecode.c
@@ -1,0 +1,208 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "compiler/compiler.h"
+#include "compiler/parser.h"
+#include "compiler/typed_ast.h"
+#include "compiler/error_reporter.h"
+#include "debug/debug_config.h"
+#include "type/type.h"
+#include "vm/vm_constants.h"
+
+#define ASSERT_TRUE(cond, message)                                                      \
+    do {                                                                               \
+        if (!(cond)) {                                                                 \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", message, __FILE__, __LINE__); \
+            return false;                                                              \
+        }                                                                              \
+    } while (0)
+
+static bool build_context_from_source(const char* source,
+                                      const char* file_name,
+                                      CompilerContext** out_ctx,
+                                      TypedASTNode** out_typed,
+                                      ASTNode** out_ast) {
+    ASTNode* ast = parseSource(source);
+    if (!ast) {
+        return false;
+    }
+
+    ast->location.file = file_name;
+
+    init_type_inference();
+
+    TypeEnv* env = type_env_new(NULL);
+    if (!env) {
+        cleanup_type_inference();
+        freeAST(ast);
+        return false;
+    }
+
+    TypedASTNode* typed = generate_typed_ast(ast, env);
+    if (!typed) {
+        cleanup_type_inference();
+        freeAST(ast);
+        return false;
+    }
+
+    CompilerContext* ctx = init_compiler_context(typed);
+    if (!ctx) {
+        cleanup_type_inference();
+        free_typed_ast_node(typed);
+        freeAST(ast);
+        return false;
+    }
+
+    if (!compile_to_bytecode(ctx)) {
+        free_compiler_context(ctx);
+        cleanup_type_inference();
+        free_typed_ast_node(typed);
+        freeAST(ast);
+        return false;
+    }
+
+    *out_ctx = ctx;
+    *out_typed = typed;
+    *out_ast = ast;
+    return true;
+}
+
+static void destroy_context(CompilerContext* ctx, TypedASTNode* typed, ASTNode* ast) {
+    free_compiler_context(ctx);
+    free_typed_ast_node(typed);
+    freeAST(ast);
+    cleanup_type_inference();
+}
+
+static bool extract_guard_and_inc(BytecodeBuffer* bytecode,
+                                  uint8_t guard_out[5],
+                                  uint8_t inc_out[5]) {
+    ASSERT_TRUE(bytecode != NULL, "bytecode buffer must exist");
+    ASSERT_TRUE(bytecode->instructions != NULL, "bytecode must contain instructions");
+
+    int guard_index = -1;
+    int inc_index = -1;
+
+    for (int i = 0; i < bytecode->count; i++) {
+        if (bytecode->instructions[i] == OP_JUMP_IF_NOT_I32_TYPED) {
+            guard_index = i;
+            break;
+        }
+    }
+
+    for (int i = 0; i < bytecode->count; i++) {
+        if (bytecode->instructions[i] == OP_INC_CMP_JMP) {
+            inc_index = i;
+            break;
+        }
+    }
+
+    ASSERT_TRUE(guard_index >= 0, "failed to find fused guard opcode");
+    ASSERT_TRUE(inc_index >= 0, "failed to find fused increment opcode");
+    ASSERT_TRUE(guard_index + 5 <= bytecode->count, "guard instruction truncated");
+    ASSERT_TRUE(inc_index + 5 <= bytecode->count, "increment instruction truncated");
+
+    memcpy(guard_out, &bytecode->instructions[guard_index], 5);
+    memcpy(inc_out, &bytecode->instructions[inc_index], 5);
+    return true;
+}
+
+static bool test_fused_loop_bytecode_identity(void) {
+    static const char* while_source =
+        "mut limit = 10\n"
+        "mut i = 0\n"
+        "while i < limit:\n"
+        "    i = i + 1\n";
+
+    static const char* for_source =
+        "mut limit = 10\n"
+        "for i in 0..limit:\n"
+        "    i = i";
+
+    CompilerContext* while_ctx = NULL;
+    TypedASTNode* while_typed = NULL;
+    ASTNode* while_ast = NULL;
+
+    CompilerContext* for_ctx = NULL;
+    TypedASTNode* for_typed = NULL;
+    ASTNode* for_ast = NULL;
+
+    if (!build_context_from_source(while_source, "fused_while.orus",
+                                   &while_ctx, &while_typed, &while_ast)) {
+        return false;
+    }
+
+    if (!build_context_from_source(for_source, "fused_for.orus",
+                                   &for_ctx, &for_typed, &for_ast)) {
+        destroy_context(while_ctx, while_typed, while_ast);
+        return false;
+    }
+
+    BytecodeBuffer* while_bc = while_ctx->bytecode;
+    BytecodeBuffer* for_bc = for_ctx->bytecode;
+
+    uint8_t while_guard[5];
+    uint8_t while_inc[5];
+    uint8_t for_guard[5];
+    uint8_t for_inc[5];
+
+    bool extracted_while = extract_guard_and_inc(while_bc, while_guard, while_inc);
+    bool extracted_for = extract_guard_and_inc(for_bc, for_guard, for_inc);
+
+    destroy_context(for_ctx, for_typed, for_ast);
+    destroy_context(while_ctx, while_typed, while_ast);
+
+    ASSERT_TRUE(extracted_while, "failed to extract fused while sequence");
+    ASSERT_TRUE(extracted_for, "failed to extract fused for sequence");
+
+    ASSERT_TRUE(while_guard[0] == OP_JUMP_IF_NOT_I32_TYPED,
+                "while guard opcode mismatch");
+    ASSERT_TRUE(while_inc[0] == OP_INC_CMP_JMP, "while increment opcode mismatch");
+    ASSERT_TRUE(while_guard[1] == while_inc[1],
+                "while loop register inconsistent between guard and increment");
+    ASSERT_TRUE(while_guard[2] == while_inc[2],
+                "while limit register inconsistent between guard and increment");
+
+    ASSERT_TRUE(for_guard[0] == OP_JUMP_IF_NOT_I32_TYPED,
+                "for guard opcode mismatch");
+    ASSERT_TRUE(for_inc[0] == OP_INC_CMP_JMP, "for increment opcode mismatch");
+    ASSERT_TRUE(for_guard[1] == for_inc[1],
+                "for loop register inconsistent between guard and increment");
+    ASSERT_TRUE(for_guard[2] == for_inc[2],
+                "for limit register inconsistent between guard and increment");
+
+    ASSERT_TRUE(while_guard[0] == for_guard[0],
+                "guard opcode differs between while and for loops");
+    ASSERT_TRUE(while_inc[0] == for_inc[0],
+                "increment opcode differs between while and for loops");
+
+    return true;
+}
+
+int main(void) {
+    debug_init();
+
+    struct {
+        const char* name;
+        bool (*fn)(void);
+    } tests[] = {
+        {"fused while/for bytecode identity", test_fused_loop_bytecode_identity},
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; ++i) {
+        if (tests[i].fn()) {
+            printf("[PASS] %s\n", tests[i].name);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", tests[i].name);
+            return 1;
+        }
+    }
+
+    printf("%d/%d fused loop bytecode tests passed\n", passed, total);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extract a shared `emit_fused_numeric_loop` helper so both fused while and for-range compilation reuse the same guard/body/epilogue logic
- route the fused while/for-range emitters through the helper to preserve scope bookkeeping and continue/break patching
- add a fused loop bytecode regression test and hook it into the test harness