### PR TITLE
Refine fused loop detection and add coverage

### DIFF
--- a/makefile
+++ b/makefile
@@ -244,6 +244,7 @@ ORUS = orus$(SUFFIX)
 UNIT_TEST_RUNNER = test_runner$(SUFFIX)
 BYTECODE_TEST_BIN = $(BUILDDIR)/tests/test_jump_patch
 SOURCE_MAP_TEST_BIN = $(BUILDDIR)/tests/test_source_mapping
+FUSED_LOOP_TEST_BIN = $(BUILDDIR)/tests/test_codegen_fused_loops
 SCOPE_TRACKING_TEST_BIN = $(BUILDDIR)/tests/test_scope_tracking
 PEEPHOLE_TEST_BIN = $(BUILDDIR)/tests/test_constant_propagation
 TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
@@ -418,6 +419,9 @@ _test-run: $(ORUS)
 	@echo "\033[36m=== Source Mapping Tests ===\033[0m"
 	@$(MAKE) source-map-tests
 	@echo ""
+	@echo "\033[36m=== Fused Counter Loop Codegen Tests ===\033[0m"
+	@$(MAKE) fused-loop-tests
+	@echo ""
 	@echo "\033[36m=== Scope Tracking Tests ===\033[0m"
 	@$(MAKE) scope-tracking-tests
 	@echo ""
@@ -480,6 +484,15 @@ $(SOURCE_MAP_TEST_BIN): tests/unit/test_source_mapping.c $(COMPILER_OBJS) $(VM_O
 source-map-tests: $(SOURCE_MAP_TEST_BIN)
 	@echo "Running source mapping tests..."
 	@./$(SOURCE_MAP_TEST_BIN)
+
+$(FUSED_LOOP_TEST_BIN): tests/unit/test_codegen_fused_loops.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling fused loop codegen tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+fused-loop-tests: $(FUSED_LOOP_TEST_BIN)
+	@echo "Running fused loop codegen tests..."
+	@./$(FUSED_LOOP_TEST_BIN)
 
 $(SCOPE_TRACKING_TEST_BIN): tests/unit/test_scope_stack.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/src/compiler/backend/codegen/statements.c
+++ b/src/compiler/backend/codegen/statements.c
@@ -74,6 +74,7 @@ typedef struct {
     TypedASTNode* limit_node;
     TypedASTNode* step_node;
     TypedASTNode* increment_stmt;
+    int increment_index;
     TypedASTNode* body_node;
     bool body_is_block;
     int body_statement_count;
@@ -88,6 +89,9 @@ typedef struct {
     bool step_is_one;
     bool step_known_positive;
     bool step_known_negative;
+    bool step_is_constant;
+    int32_t step_constant;
+    bool descending;
 } FusedCounterLoopInfo;
 
 static void init_fused_counter_loop_info(FusedCounterLoopInfo* info) {
@@ -104,7 +108,107 @@ static void init_fused_counter_loop_info(FusedCounterLoopInfo* info) {
     info->limit_node = NULL;
     info->step_node = NULL;
     info->increment_stmt = NULL;
+    info->increment_index = -1;
     info->body_node = NULL;
+    info->step_constant = 0;
+}
+
+static bool node_matches_identifier(const TypedASTNode* node, const char* name);
+
+static bool extract_step_from_expression(const char* loop_var_name,
+                                         TypedASTNode* expr,
+                                         int32_t* out_step) {
+    if (!loop_var_name || !expr || !expr->original) {
+        return false;
+    }
+
+    ASTNode* original = expr->original;
+    switch (original->type) {
+        case NODE_BINARY: {
+            if (!original->binary.op) {
+                return false;
+            }
+
+            TypedASTNode* left = expr->typed.binary.left;
+            TypedASTNode* right = expr->typed.binary.right;
+            if (!left || !right) {
+                return false;
+            }
+
+            int32_t constant = 0;
+            if (strcmp(original->binary.op, "+") == 0) {
+                if (node_matches_identifier(left, loop_var_name) &&
+                    evaluate_constant_i32(right, &constant)) {
+                    *out_step = constant;
+                    return true;
+                }
+                if (node_matches_identifier(right, loop_var_name) &&
+                    evaluate_constant_i32(left, &constant)) {
+                    *out_step = constant;
+                    return true;
+                }
+            } else if (strcmp(original->binary.op, "-") == 0) {
+                if (node_matches_identifier(left, loop_var_name) &&
+                    evaluate_constant_i32(right, &constant)) {
+                    *out_step = -constant;
+                    return true;
+                }
+                if (node_matches_identifier(right, loop_var_name) &&
+                    evaluate_constant_i32(left, &constant)) {
+                    // Form like "constant - i" is not a simple counter update
+                    return false;
+                }
+            }
+            return false;
+        }
+        default:
+            return false;
+    }
+}
+
+static bool extract_counter_step(const char* loop_var_name,
+                                 TypedASTNode* stmt,
+                                 int32_t* out_step) {
+    if (!loop_var_name || !stmt || !stmt->original) {
+        return false;
+    }
+
+    ASTNode* original = stmt->original;
+    switch (original->type) {
+        case NODE_ASSIGN: {
+            if (!stmt->typed.assign.name ||
+                strcmp(stmt->typed.assign.name, loop_var_name) != 0) {
+                return false;
+            }
+            return extract_step_from_expression(loop_var_name,
+                                               stmt->typed.assign.value,
+                                               out_step);
+        }
+        case NODE_UNARY: {
+            if (!original->unary.op) {
+                return false;
+            }
+            TypedASTNode* operand = stmt->typed.unary.operand;
+            if (!operand) {
+                return false;
+            }
+            if (!node_matches_identifier(operand, loop_var_name)) {
+                return false;
+            }
+            if (strcmp(original->unary.op, "++") == 0) {
+                *out_step = 1;
+                return true;
+            }
+            if (strcmp(original->unary.op, "--") == 0) {
+                *out_step = -1;
+                return true;
+            }
+            return false;
+        }
+        default:
+            break;
+    }
+    return false;
 }
 
 static bool node_matches_identifier(const TypedASTNode* node, const char* name) {
@@ -113,6 +217,34 @@ static bool node_matches_identifier(const TypedASTNode* node, const char* name) 
     }
     const char* candidate = node->original->identifier.name;
     return candidate && strcmp(candidate, name) == 0;
+}
+
+static bool statement_mutates_identifier(const char* name, TypedASTNode* stmt) {
+    if (!name || !stmt || !stmt->original) {
+        return false;
+    }
+
+    switch (stmt->original->type) {
+        case NODE_ASSIGN:
+            if (stmt->typed.assign.name && strcmp(stmt->typed.assign.name, name) == 0) {
+                return true;
+            }
+            return false;
+        case NODE_UNARY: {
+            ASTNode* operand = stmt->typed.unary.operand ? stmt->typed.unary.operand->original : NULL;
+            if (!operand || operand->type != NODE_IDENTIFIER) {
+                return false;
+            }
+            const char* operand_name = operand->identifier.name;
+            if (!operand_name || strcmp(operand_name, name) != 0) {
+                return false;
+            }
+            const char* op = stmt->original->unary.op;
+            return op && (strcmp(op, "++") == 0 || strcmp(op, "--") == 0);
+        }
+        default:
+            return false;
+    }
 }
 
 static bool try_prepare_fused_counter_loop(CompilerContext* ctx,
@@ -136,7 +268,23 @@ static bool try_prepare_fused_counter_loop(CompilerContext* ctx,
         }
 
         const char* op = condition->original->binary.op;
-        if (!op || (strcmp(op, "<") != 0 && strcmp(op, "<=") != 0)) {
+        if (!op) {
+            return true;
+        }
+
+        bool descending = false;
+        bool inclusive = false;
+        if (strcmp(op, "<") == 0) {
+            inclusive = false;
+        } else if (strcmp(op, "<=") == 0) {
+            inclusive = true;
+        } else if (strcmp(op, ">") == 0) {
+            descending = true;
+            inclusive = false;
+        } else if (strcmp(op, ">=") == 0) {
+            descending = true;
+            inclusive = true;
+        } else {
             return true;
         }
 
@@ -170,68 +318,77 @@ static bool try_prepare_fused_counter_loop(CompilerContext* ctx,
         bool body_is_block = body->original && body->original->type == NODE_BLOCK;
         int body_count = 0;
         TypedASTNode* increment_stmt = NULL;
+        int increment_index = -1;
+        int32_t step_constant = 0;
+        bool found_increment = false;
+
         if (body_is_block) {
             body_count = body->typed.block.count;
             if (body_count <= 0) {
                 return true;
             }
-            increment_stmt = body->typed.block.statements[body_count - 1];
+            for (int i = body_count - 1; i >= 0; --i) {
+                TypedASTNode* candidate = body->typed.block.statements[i];
+                if (!candidate) {
+                    continue;
+                }
+                if (extract_counter_step(loop_var_name, candidate, &step_constant)) {
+                    increment_stmt = candidate;
+                    increment_index = i;
+                    found_increment = true;
+                    break;
+                }
+            }
         } else {
             body_count = body ? 1 : 0;
-            increment_stmt = body;
+            if (body && extract_counter_step(loop_var_name, body, &step_constant)) {
+                increment_stmt = body;
+                increment_index = 0;
+                found_increment = true;
+            }
         }
 
-        if (!increment_stmt || !increment_stmt->original ||
-            increment_stmt->original->type != NODE_ASSIGN ||
-            !increment_stmt->typed.assign.name ||
-            strcmp(increment_stmt->typed.assign.name, loop_var_name) != 0) {
+        if (!found_increment || !increment_stmt) {
             return true;
         }
 
-        TypedASTNode* value = increment_stmt->typed.assign.value;
-        if (!value || !value->original || value->original->type != NODE_BINARY) {
-            return true;
+        if (body_is_block) {
+            for (int i = increment_index + 1; i < body_count; ++i) {
+                TypedASTNode* trailing = body->typed.block.statements[i];
+                if (statement_mutates_identifier(loop_var_name, trailing)) {
+                    return true;
+                }
+            }
         }
 
-        const char* inc_op = value->original->binary.op;
-        if (!inc_op || strcmp(inc_op, "+") != 0) {
-            return true;
-        }
-
-        TypedASTNode* inc_left = value->typed.binary.left;
-        TypedASTNode* inc_right = value->typed.binary.right;
-        if (!inc_left || !inc_right) {
-            return true;
-        }
-
-        int32_t inc_constant = 0;
-        bool matches_increment = false;
-        if (node_matches_identifier(inc_left, loop_var_name) &&
-            evaluate_constant_i32(inc_right, &inc_constant) && inc_constant == 1) {
-            matches_increment = true;
-        } else if (node_matches_identifier(inc_right, loop_var_name) &&
-                   evaluate_constant_i32(inc_left, &inc_constant) && inc_constant == 1) {
-            matches_increment = true;
-        }
-
-        if (!matches_increment) {
-            return true;
+        if (descending) {
+            if (step_constant != -1) {
+                return true;
+            }
+        } else {
+            if (step_constant != 1) {
+                return true;
+            }
         }
 
         info->pattern_matched = true;
         info->can_fuse = true;
-        info->inclusive = (strcmp(op, "<=") == 0);
+        info->inclusive = inclusive;
         info->loop_var_name = loop_var_name;
         info->loop_var_node = left;
         info->limit_node = right;
         info->increment_stmt = increment_stmt;
+        info->increment_index = increment_index;
         info->body_node = body;
         info->body_is_block = body_is_block;
         info->body_statement_count = body_count;
         info->has_increment = true;
         info->step_is_one = true;
-        info->step_known_positive = true;
-        info->step_known_negative = false;
+        info->step_known_positive = !descending;
+        info->step_known_negative = descending;
+        info->step_is_constant = true;
+        info->step_constant = step_constant;
+        info->descending = descending;
 
         int limit_reg = compile_expression(ctx, right);
         if (limit_reg == -1) {
@@ -254,11 +411,11 @@ static bool try_prepare_fused_counter_loop(CompilerContext* ctx,
             emit_byte_to_buffer(ctx->bytecode, OP_ADD_I32_IMM);
             emit_byte_to_buffer(ctx->bytecode, (uint8_t)temp_reg);
             emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_reg);
-            int32_t one = 1;
-            emit_byte_to_buffer(ctx->bytecode, (uint8_t)(one & 0xFF));
-            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 8) & 0xFF));
-            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 16) & 0xFF));
-            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 24) & 0xFF));
+            int32_t adjust = descending ? -1 : 1;
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)(adjust & 0xFF));
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((adjust >> 8) & 0xFF));
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((adjust >> 16) & 0xFF));
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((adjust >> 24) & 0xFF));
             info->use_adjusted_limit = true;
             info->adjusted_limit_reg = temp_reg;
             info->adjusted_limit_is_temp = true;
@@ -295,6 +452,7 @@ static bool try_prepare_fused_counter_loop(CompilerContext* ctx,
         TypedASTNode* step_node = loop_node->typed.forRange.step;
         info->step_node = step_node;
         int32_t step_constant = 0;
+        bool step_constant_known = false;
         if (step_node) {
             int step_reg = compile_expression(ctx, step_node);
             if (step_reg == -1) {
@@ -308,15 +466,7 @@ static bool try_prepare_fused_counter_loop(CompilerContext* ctx,
             info->step_reg = step_reg;
             info->step_reg_is_temp = (step_reg >= MP_TEMP_REG_START && step_reg <= MP_TEMP_REG_END);
             if (evaluate_constant_i32(step_node, &step_constant)) {
-                if (step_constant >= 0) {
-                    info->step_known_positive = true;
-                }
-                if (step_constant < 0) {
-                    info->step_known_negative = true;
-                }
-                if (step_constant == 1) {
-                    info->step_is_one = true;
-                }
+                step_constant_known = true;
             }
         } else {
             int step_reg = compiler_alloc_temp(ctx->allocator);
@@ -331,22 +481,34 @@ static bool try_prepare_fused_counter_loop(CompilerContext* ctx,
             emit_load_constant(ctx, step_reg, I32_VAL(1));
             info->step_reg = step_reg;
             info->step_reg_is_temp = true;
-            info->step_known_positive = true;
-            info->step_is_one = true;
             step_constant = 1;
+            step_constant_known = true;
         }
 
-        if (!step_node || step_constant >= 0) {
-            info->step_known_positive = true;
-        }
-        if (step_constant < 0) {
-            info->step_known_negative = true;
-        }
-        if (step_constant == 1) {
-            info->step_is_one = true;
+        if (step_constant_known) {
+            info->step_is_constant = true;
+            info->step_constant = step_constant;
+            if (step_constant > 0) {
+                info->step_known_positive = true;
+            }
+            if (step_constant < 0) {
+                info->step_known_negative = true;
+            }
+            if (step_constant == 1 || step_constant == -1) {
+                info->step_is_one = true;
+            }
+        } else {
+            if (!step_node) {
+                info->step_known_positive = true;
+            }
         }
 
-        info->can_fuse = (info->step_known_positive && info->step_is_one);
+        info->descending = info->step_known_negative && !info->step_known_positive;
+        if (info->step_known_positive && info->step_known_negative) {
+            info->descending = false;
+        }
+
+        info->can_fuse = (info->step_is_one && info->step_is_constant);
 
         if (info->can_fuse && info->inclusive) {
             int temp_reg = compiler_alloc_temp(ctx->allocator);
@@ -367,11 +529,11 @@ static bool try_prepare_fused_counter_loop(CompilerContext* ctx,
             emit_byte_to_buffer(ctx->bytecode, OP_ADD_I32_IMM);
             emit_byte_to_buffer(ctx->bytecode, (uint8_t)temp_reg);
             emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_reg);
-            int32_t one = 1;
-            emit_byte_to_buffer(ctx->bytecode, (uint8_t)(one & 0xFF));
-            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 8) & 0xFF));
-            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 16) & 0xFF));
-            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 24) & 0xFF));
+            int32_t adjust = (info->descending ? -1 : 1);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)(adjust & 0xFF));
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((adjust >> 8) & 0xFF));
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((adjust >> 16) & 0xFF));
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)((adjust >> 24) & 0xFF));
             info->use_adjusted_limit = true;
             info->adjusted_limit_reg = temp_reg;
             info->adjusted_limit_is_temp = true;
@@ -1773,6 +1935,7 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
     TypedASTNode* fused_limit_node = fused_info.limit_node;
     bool fused_body_is_block = fused_info.body_is_block;
     int fused_block_count = fused_info.body_statement_count;
+    bool fused_descending = fused_info.descending;
 
     Symbol* fused_symbol = NULL;
     int fused_loop_reg = -1;
@@ -1799,8 +1962,7 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
         int upvalue_index = -1;
         fused_symbol = resolve_symbol(ctx->symbols, fused_index_name);
         fused_loop_reg = resolve_variable_or_upvalue(ctx, fused_index_name, &is_upvalue, &upvalue_index);
-        if (!fused_symbol || !fused_symbol->is_mutable || !fused_symbol->type ||
-            fused_symbol->type->kind != TYPE_I32 || fused_loop_reg < 0 || is_upvalue) {
+        if (!fused_symbol || !fused_symbol->is_mutable || fused_loop_reg < 0 || is_upvalue) {
             use_fused_inc = false;
         }
     }
@@ -1846,6 +2008,8 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
             loop_frame_fused->label = while_stmt->original->whileStmt.label;
         }
 
+        update_loop_continue_target(ctx, loop_frame_fused, -1);
+
         DEBUG_CODEGEN_PRINT("While loop start at offset %d\n", loop_start_fused);
 
         int typed_hint_limit_reg = -1;
@@ -1859,10 +2023,16 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
             typed_hint_limit_reg = fused_limit_guard_reg;
         }
 
+        uint8_t guard_left = fused_descending ?
+            (uint8_t)(fused_limit_temp_is_temp ? fused_limit_temp_reg : fused_limit_reg) :
+            (uint8_t)fused_loop_reg;
+        uint8_t guard_right = fused_descending ?
+            (uint8_t)fused_loop_reg :
+            (uint8_t)(fused_limit_temp_is_temp ? fused_limit_temp_reg : fused_limit_reg);
         set_location_from_node(ctx, while_stmt);
         emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_loop_reg);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(fused_limit_temp_is_temp ? fused_limit_temp_reg : fused_limit_reg));
+        emit_byte_to_buffer(ctx->bytecode, guard_left);
+        emit_byte_to_buffer(ctx->bytecode, guard_right);
         int end_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
         if (end_patch < 0) {
             DEBUG_CODEGEN_PRINT("Error: Failed to allocate while-loop end placeholder\n");
@@ -1879,18 +2049,14 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
         }
         if (fused_body_is_block && fused_block_count > 0 && while_body && while_body->original &&
             while_body->original->type == NODE_BLOCK) {
-            int limit = fused_block_count - 1;
-            if (limit < 0) {
-                limit = 0;
-            }
-            for (int i = 0; i < limit; i++) {
+            for (int i = 0; i < fused_block_count; i++) {
                 TypedASTNode* stmt = while_body->typed.block.statements[i];
-                if (stmt) {
-                    compile_statement(ctx, stmt);
+                if (!stmt || stmt == fused_info.increment_stmt) {
+                    continue;
                 }
+                compile_statement(ctx, stmt);
             }
         } else if (!fused_body_is_block && fused_info.has_increment == false && while_body) {
-            // Non-block bodies without an increment should still be compiled normally.
             compile_statement(ctx, while_body);
         }
 
@@ -1898,10 +2064,19 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
             loop_frame_fused = get_scope_frame_by_index(ctx, loop_frame_index);
         }
 
+        int continue_target = ctx->bytecode->count;
+        update_loop_continue_target(ctx, loop_frame_fused, continue_target);
+        patch_continue_statements(ctx, continue_target);
+
         set_location_from_node(ctx, while_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_INC_CMP_JMP);
+        uint8_t limit_for_fused = (uint8_t)(fused_limit_temp_is_temp ? fused_limit_temp_reg : fused_limit_reg);
+        if (fused_descending) {
+            emit_byte_to_buffer(ctx->bytecode, OP_DEC_CMP_JMP);
+        } else {
+            emit_byte_to_buffer(ctx->bytecode, OP_INC_CMP_JMP);
+        }
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_loop_reg);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(fused_limit_temp_is_temp ? fused_limit_temp_reg : fused_limit_reg));
+        emit_byte_to_buffer(ctx->bytecode, limit_for_fused);
         int back_off = loop_start_fused - (ctx->bytecode->count + 2);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)(back_off & 0xFF));
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)((back_off >> 8) & 0xFF));
@@ -2143,6 +2318,7 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
 
     bool step_known_positive = fused_info.step_known_positive;
     bool step_known_negative = fused_info.step_known_negative;
+    bool fused_descending = fused_info.descending;
 
     limit_temp_reg = fused_info.use_adjusted_limit ? fused_info.adjusted_limit_reg : -1;
     limit_temp_reg_is_temp = fused_info.use_adjusted_limit ? fused_info.adjusted_limit_is_temp : false;
@@ -2244,9 +2420,11 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
     int guard_patch = -1;
     set_location_from_node(ctx, for_stmt);
     if (can_fuse_inc_cmp) {
+        uint8_t guard_left = fused_descending ? (uint8_t)limit_reg_used : (uint8_t)loop_var_reg;
+        uint8_t guard_right = fused_descending ? (uint8_t)loop_var_reg : (uint8_t)limit_reg_used;
         emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_var_reg);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_reg_used);
+        emit_byte_to_buffer(ctx->bytecode, guard_left);
+        emit_byte_to_buffer(ctx->bytecode, guard_right);
         guard_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
         if (guard_patch < 0) {
             ctx->has_compilation_errors = true;
@@ -2354,7 +2532,11 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
         patch_continue_statements(ctx, continue_target);
 
         set_location_from_node(ctx, for_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_INC_CMP_JMP);
+        if (fused_descending) {
+            emit_byte_to_buffer(ctx->bytecode, OP_DEC_CMP_JMP);
+        } else {
+            emit_byte_to_buffer(ctx->bytecode, OP_INC_CMP_JMP);
+        }
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_var_reg);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_reg_used);
         // back offset is relative to address after the 2-byte offset we emit now

--- a/tests/unit/test_codegen_fused_loops.c
+++ b/tests/unit/test_codegen_fused_loops.c
@@ -1,0 +1,429 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "compiler/compiler.h"
+#include "compiler/lexer.h"
+#include "compiler/parser.h"
+#include "compiler/typed_ast.h"
+#include "type/type.h"
+#include "vm/vm.h"
+
+#define ASSERT_TRUE(cond, message)                                                         \
+    do {                                                                                   \
+        if (!(cond)) {                                                                     \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", message, __FILE__, __LINE__); \
+            return false;                                                                  \
+        }                                                                                  \
+    } while (0)
+
+static void annotate_ast_with_file(ASTNode* node, const char* file_name) {
+    if (!node) {
+        return;
+    }
+
+    node->location.file = file_name;
+
+    switch (node->type) {
+        case NODE_PROGRAM:
+            for (int i = 0; i < node->program.count; ++i) {
+                annotate_ast_with_file(node->program.declarations[i], file_name);
+            }
+            break;
+        case NODE_VAR_DECL:
+            annotate_ast_with_file(node->varDecl.initializer, file_name);
+            annotate_ast_with_file(node->varDecl.typeAnnotation, file_name);
+            break;
+        case NODE_ASSIGN:
+            annotate_ast_with_file(node->assign.value, file_name);
+            break;
+        case NODE_BLOCK:
+            for (int i = 0; i < node->block.count; ++i) {
+                annotate_ast_with_file(node->block.statements[i], file_name);
+            }
+            break;
+        case NODE_WHILE:
+            annotate_ast_with_file(node->whileStmt.condition, file_name);
+            annotate_ast_with_file(node->whileStmt.body, file_name);
+            break;
+        case NODE_FOR_RANGE:
+            annotate_ast_with_file(node->forRange.start, file_name);
+            annotate_ast_with_file(node->forRange.end, file_name);
+            annotate_ast_with_file(node->forRange.step, file_name);
+            annotate_ast_with_file(node->forRange.body, file_name);
+            break;
+        case NODE_UNARY:
+            annotate_ast_with_file(node->unary.operand, file_name);
+            break;
+        default:
+            break;
+    }
+}
+
+static bool build_context_without_codegen(const char* source,
+                                          const char* file_name,
+                                          CompilerContext** out_ctx,
+                                          TypedASTNode** out_typed,
+                                          ASTNode** out_ast) {
+    ASTNode* ast = parseSource(source);
+    if (!ast) {
+        return false;
+    }
+
+    annotate_ast_with_file(ast, file_name);
+
+    init_type_inference();
+
+    TypeEnv* env = type_env_new(NULL);
+    if (!env) {
+        cleanup_type_inference();
+        freeAST(ast);
+        return false;
+    }
+
+    TypedASTNode* typed = generate_typed_ast(ast, env);
+    if (!typed) {
+        cleanup_type_inference();
+        freeAST(ast);
+        return false;
+    }
+
+    CompilerContext* ctx = init_compiler_context(typed);
+    if (!ctx) {
+        cleanup_type_inference();
+        free_typed_ast_node(typed);
+        freeAST(ast);
+        return false;
+    }
+
+    *out_ctx = ctx;
+    *out_typed = typed;
+    *out_ast = ast;
+    return true;
+}
+
+static void destroy_context(CompilerContext* ctx, TypedASTNode* typed, ASTNode* ast) {
+    free_compiler_context(ctx);
+    free_typed_ast_node(typed);
+    freeAST(ast);
+    cleanup_type_inference();
+}
+
+static bool chunk_contains_opcode(const BytecodeBuffer* bytecode, uint8_t opcode) {
+    if (!bytecode) {
+        return false;
+    }
+    for (int i = 0; i < bytecode->count; ++i) {
+        if (bytecode->instructions[i] == opcode) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool program_contains_opcode(const CompilerContext* ctx, uint8_t opcode) {
+    if (!ctx) {
+        return false;
+    }
+    if (chunk_contains_opcode(ctx->bytecode, opcode)) {
+        return true;
+    }
+    if (ctx->function_chunks) {
+        for (int i = 0; i < ctx->function_count; ++i) {
+            if (chunk_contains_opcode(ctx->function_chunks[i], opcode)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static TypedASTNode* find_first_node_by_type(TypedASTNode* node, NodeType target) {
+    if (!node || !node->original) {
+        return NULL;
+    }
+    if (node->original->type == target) {
+        return node;
+    }
+
+    switch (node->original->type) {
+        case NODE_PROGRAM:
+            for (int i = 0; i < node->typed.program.count; ++i) {
+                TypedASTNode* found = find_first_node_by_type(node->typed.program.declarations[i], target);
+                if (found) {
+                    return found;
+                }
+            }
+            break;
+        case NODE_BLOCK:
+            for (int i = 0; i < node->typed.block.count; ++i) {
+                TypedASTNode* found = find_first_node_by_type(node->typed.block.statements[i], target);
+                if (found) {
+                    return found;
+                }
+            }
+            break;
+        case NODE_VAR_DECL:
+            return find_first_node_by_type(node->typed.varDecl.initializer, target);
+        case NODE_WHILE:
+            return find_first_node_by_type(node->typed.whileStmt.body, target);
+        case NODE_FUNCTION:
+            if (node->typed.function.body) {
+                return find_first_node_by_type(node->typed.function.body, target);
+            }
+            break;
+        case NODE_FOR_RANGE:
+            return find_first_node_by_type(node->typed.forRange.body, target);
+        default:
+            break;
+    }
+    return NULL;
+}
+
+static bool test_while_loop_compound_increment_fuses(void) {
+    static const char* source =
+        "fn main():\n"
+        "    mut i: i32 = 0\n"
+        "    limit: i32 = 4\n"
+        "    while i < limit:\n"
+        "        i += 1\n"
+        "        pass\n";
+
+    CompilerContext* ctx = NULL;
+    TypedASTNode* typed = NULL;
+    ASTNode* ast = NULL;
+
+    if (!build_context_without_codegen(source, "compound_increment.orus", &ctx, &typed, &ast)) {
+        return false;
+    }
+
+    bool compiled = compile_to_bytecode(ctx);
+    ASSERT_TRUE(compiled, "compilation should succeed");
+
+    ASSERT_TRUE(program_contains_opcode(ctx, OP_INC_CMP_JMP),
+                "expected OP_INC_CMP_JMP in bytecode for += loop");
+
+    destroy_context(ctx, typed, ast);
+    return true;
+}
+
+static bool replace_increment_with_unary(TypedASTNode* root) {
+    TypedASTNode* while_node = find_first_node_by_type(root, NODE_WHILE);
+    if (!while_node) {
+        return false;
+    }
+
+    TypedASTNode* body = while_node->typed.whileStmt.body;
+    bool body_is_block = body && body->original && body->original->type == NODE_BLOCK;
+    TypedASTNode** target_slot = NULL;
+    ASTNode** target_ast_slot = NULL;
+
+    if (body_is_block) {
+        if (body->typed.block.count <= 0) {
+            return false;
+        }
+        int last_index = body->typed.block.count - 1;
+        target_slot = &body->typed.block.statements[last_index];
+        if (!target_slot) {
+            return false;
+        }
+        if (body->original && body->original->type == NODE_BLOCK &&
+            last_index < body->original->block.count) {
+            target_ast_slot = &body->original->block.statements[last_index];
+        }
+    } else {
+        if (!body) {
+            return false;
+        }
+        target_slot = &while_node->typed.whileStmt.body;
+        if (while_node->original && while_node->original->type == NODE_WHILE) {
+            target_ast_slot = &while_node->original->whileStmt.body;
+        }
+    }
+
+    if (!target_slot || !*target_slot) {
+        return false;
+    }
+
+    TypedASTNode* last_stmt = *target_slot;
+
+    TypedASTNode* condition = while_node->typed.whileStmt.condition;
+    if (!condition || !condition->original || condition->original->type != NODE_BINARY) {
+        return false;
+    }
+
+    ASTNode* condition_left = condition->original->binary.left;
+    if (!condition_left || condition_left->type != NODE_IDENTIFIER) {
+        return false;
+    }
+    const char* loop_name = condition_left->identifier.name;
+    if (!loop_name) {
+        return false;
+    }
+
+    ASTNode* unary_ast = (ASTNode*)calloc(1, sizeof(ASTNode));
+    ASTNode* operand_ast = (ASTNode*)calloc(1, sizeof(ASTNode));
+    TypedASTNode* unary_typed = (TypedASTNode*)calloc(1, sizeof(TypedASTNode));
+    TypedASTNode* operand_typed = (TypedASTNode*)calloc(1, sizeof(TypedASTNode));
+    if (!unary_ast || !operand_ast || !unary_typed || !operand_typed) {
+        free(unary_ast);
+        free(operand_ast);
+        free(unary_typed);
+        free(operand_typed);
+        return false;
+    }
+
+    operand_ast->type = NODE_IDENTIFIER;
+    char* loop_name_copy = NULL;
+    if (loop_name) {
+        size_t len = strlen(loop_name);
+        loop_name_copy = (char*)malloc(len + 1);
+        if (loop_name_copy) {
+            memcpy(loop_name_copy, loop_name, len + 1);
+        }
+    }
+    if (!loop_name_copy) {
+        free(unary_ast);
+        free(operand_ast);
+        free(unary_typed);
+        free(operand_typed);
+        return false;
+    }
+
+    operand_ast->identifier.name = loop_name_copy;
+    operand_ast->location = last_stmt->original ? last_stmt->original->location : condition_left->location;
+
+    operand_typed->original = operand_ast;
+    operand_typed->resolvedType = getPrimitiveType(TYPE_I32);
+    operand_typed->typeResolved = true;
+
+    unary_ast->type = NODE_UNARY;
+    unary_ast->unary.op = "++";
+    unary_ast->unary.operand = operand_ast;
+    unary_ast->location = last_stmt->original ? last_stmt->original->location : condition_left->location;
+
+    unary_typed->original = unary_ast;
+    unary_typed->resolvedType = getPrimitiveType(TYPE_I32);
+    unary_typed->typeResolved = true;
+    unary_typed->typed.unary.operand = operand_typed;
+
+    *target_slot = unary_typed;
+    if (target_ast_slot) {
+        *target_ast_slot = unary_ast;
+    }
+    return true;
+}
+
+static bool test_while_loop_unary_increment_fuses(void) {
+    static const char* source =
+        "fn main():\n"
+        "    mut i: i32 = 0\n"
+        "    limit: i32 = 3\n"
+        "    while i < limit:\n"
+        "        i += 1\n";
+
+    CompilerContext* ctx = NULL;
+    TypedASTNode* typed = NULL;
+    ASTNode* ast = NULL;
+
+    if (!build_context_without_codegen(source, "unary_increment.orus", &ctx, &typed, &ast)) {
+        return false;
+    }
+
+    ASSERT_TRUE(replace_increment_with_unary(typed), "failed to replace increment with unary node");
+
+    bool compiled = compile_to_bytecode(ctx);
+    ASSERT_TRUE(compiled, "compilation should succeed after unary rewrite");
+
+    ASSERT_TRUE(program_contains_opcode(ctx, OP_INC_CMP_JMP),
+                "expected OP_INC_CMP_JMP in bytecode for unary ++ loop");
+
+    destroy_context(ctx, typed, ast);
+    return true;
+}
+
+static bool test_reverse_range_fuses(void) {
+    static const char* source =
+        "fn main():\n"
+        "    mut total: i32 = 0\n"
+        "    for i in 5..1..-1:\n"
+        "        total = total + i\n"
+        "    return total\n";
+
+    CompilerContext* ctx = NULL;
+    TypedASTNode* typed = NULL;
+    ASTNode* ast = NULL;
+
+    if (!build_context_without_codegen(source, "reverse_range.orus", &ctx, &typed, &ast)) {
+        return false;
+    }
+
+    bool compiled = compile_to_bytecode(ctx);
+    ASSERT_TRUE(compiled, "compilation should succeed for reverse range");
+
+    ASSERT_TRUE(program_contains_opcode(ctx, OP_DEC_CMP_JMP),
+                "expected OP_DEC_CMP_JMP in bytecode for reverse range loop");
+
+    destroy_context(ctx, typed, ast);
+    return true;
+}
+
+static bool test_descending_while_loop_fuses(void) {
+    static const char* source =
+        "fn main():\n"
+        "    mut i: i32 = 5\n"
+        "    while i > 0:\n"
+        "        pass\n"
+        "        i -= 1\n";
+
+    CompilerContext* ctx = NULL;
+    TypedASTNode* typed = NULL;
+    ASTNode* ast = NULL;
+
+    if (!build_context_without_codegen(source, "descending_while.orus", &ctx, &typed, &ast)) {
+        return false;
+    }
+
+    bool compiled = compile_to_bytecode(ctx);
+    ASSERT_TRUE(compiled, "compilation should succeed for descending while loop");
+
+    ASSERT_TRUE(program_contains_opcode(ctx, OP_DEC_CMP_JMP),
+                "expected OP_DEC_CMP_JMP in bytecode for while loop with -= 1");
+
+    destroy_context(ctx, typed, ast);
+    return true;
+}
+
+int main(void) {
+    int passed = 0;
+    int total = 4;
+
+    if (test_while_loop_compound_increment_fuses()) {
+        passed++;
+    } else {
+        fprintf(stderr, "test_while_loop_compound_increment_fuses failed\n");
+    }
+
+    if (test_while_loop_unary_increment_fuses()) {
+        passed++;
+    } else {
+        fprintf(stderr, "test_while_loop_unary_increment_fuses failed\n");
+    }
+
+    if (test_reverse_range_fuses()) {
+        passed++;
+    } else {
+        fprintf(stderr, "test_reverse_range_fuses failed\n");
+    }
+
+    if (test_descending_while_loop_fuses()) {
+        passed++;
+    } else {
+        fprintf(stderr, "test_descending_while_loop_fuses failed\n");
+    }
+
+    printf("%d/%d fused loop codegen tests passed\n", passed, total);
+    return (passed == total) ? 0 : 1;
+}
+


### PR DESCRIPTION
## Summary
- normalize fused loop analysis to understand compound and unary increments, track stride metadata, and support descending loops in while/for-range codegen
- ensure fused while loops patch continue jumps and reuse guard logic for descending counters
- add fused loop codegen unit tests and wire them into the `make test` suite