### PR TITLE
Fix descending loop fast path semantics

### DIFF
--- a/makefile
+++ b/makefile
@@ -244,7 +244,7 @@ ORUS = orus$(SUFFIX)
 UNIT_TEST_RUNNER = test_runner$(SUFFIX)
 BYTECODE_TEST_BIN = $(BUILDDIR)/tests/test_jump_patch
 SOURCE_MAP_TEST_BIN = $(BUILDDIR)/tests/test_source_mapping
-FUSED_LOOP_TEST_BIN = $(BUILDDIR)/tests/test_codegen_fused_loops
+FUSED_LOOP_CODEGEN_TEST_BIN = $(BUILDDIR)/tests/test_codegen_fused_loops
 SCOPE_TRACKING_TEST_BIN = $(BUILDDIR)/tests/test_scope_tracking
 FUSED_WHILE_TEST_BIN = $(BUILDDIR)/tests/test_codegen_fused_while
 PEEPHOLE_TEST_BIN = $(BUILDDIR)/tests/test_constant_propagation
@@ -252,7 +252,7 @@ TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
 TYPED_REGISTER_TEST_BIN = $(BUILDDIR)/tests/test_vm_typed_registers
 REGISTER_ALLOCATOR_TEST_BIN = $(BUILDDIR)/tests/test_register_allocator
 INC_CMP_JMP_TEST_BIN = $(BUILDDIR)/tests/test_vm_inc_cmp_jmp
-FUSED_LOOP_TEST_BIN = $(BUILDDIR)/tests/test_fused_loop_bytecode
+FUSED_LOOP_BYTECODE_TEST_BIN = $(BUILDDIR)/tests/test_fused_loop_bytecode
 ADD_I32_IMM_TEST_BIN = $(BUILDDIR)/tests/test_vm_add_i32_imm
 BUILTIN_INPUT_TEST_BIN = $(BUILDDIR)/tests/test_builtin_input
 CONSTANT_FOLD_TEST_BIN = $(BUILDDIR)/tests/test_constant_folding
@@ -493,14 +493,14 @@ source-map-tests: $(SOURCE_MAP_TEST_BIN)
 	@echo "Running source mapping tests..."
 	@./$(SOURCE_MAP_TEST_BIN)
 
-$(FUSED_LOOP_TEST_BIN): tests/unit/test_codegen_fused_loops.c $(COMPILER_OBJS) $(VM_OBJS)
+$(FUSED_LOOP_CODEGEN_TEST_BIN): tests/unit/test_codegen_fused_loops.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)
 	@echo "Compiling fused loop codegen tests..."
 	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
 
-fused-loop-tests: $(FUSED_LOOP_TEST_BIN)
+fused-loop-tests: $(FUSED_LOOP_CODEGEN_TEST_BIN)
 	@echo "Running fused loop codegen tests..."
-	@./$(FUSED_LOOP_TEST_BIN)
+	@./$(FUSED_LOOP_CODEGEN_TEST_BIN)
 
 $(SCOPE_TRACKING_TEST_BIN): tests/unit/test_scope_stack.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)
@@ -565,14 +565,14 @@ inc-cmp-jmp-tests: $(INC_CMP_JMP_TEST_BIN)
 	@echo "Running OP_INC_CMP_JMP regression tests..."
 	@./$(INC_CMP_JMP_TEST_BIN)
 
-$(FUSED_LOOP_TEST_BIN): tests/unit/test_fused_loop_bytecode.c $(COMPILER_OBJS) $(VM_OBJS)
+$(FUSED_LOOP_BYTECODE_TEST_BIN): tests/unit/test_fused_loop_bytecode.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)
 	@echo "Compiling fused loop bytecode tests..."
 	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
 
-fused-loop-bytecode-tests: $(FUSED_LOOP_TEST_BIN)
+fused-loop-bytecode-tests: $(FUSED_LOOP_BYTECODE_TEST_BIN)
 	@echo "Running fused loop bytecode tests..."
-	@./$(FUSED_LOOP_TEST_BIN)
+	@./$(FUSED_LOOP_BYTECODE_TEST_BIN)
 
 $(ADD_I32_IMM_TEST_BIN): tests/unit/test_vm_add_i32_imm.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -3767,18 +3767,113 @@ InterpretResult vm_run_dispatch(void) {
 
     LABEL_OP_DEC_CMP_JMP: {
         uint8_t reg = *vm.ip++;
-        uint8_t zero_test = *vm.ip++;
+        uint8_t limit_reg = *vm.ip++;
         int16_t offset = *(int16_t*)vm.ip;
         vm.ip += 2;
 
-        // Fused decrement + compare + conditional jump
-        int32_t decremented = vm.typed_regs.i32_regs[reg] - 1;
-        vm_store_i32_typed_hot(reg, decremented);
-        if (decremented > vm.typed_regs.i32_regs[zero_test]) {
-            vm.ip += offset;
+        int32_t counter_i32;
+        int32_t limit_i32;
+        if (vm_try_read_i32_typed(reg, &counter_i32) &&
+            vm_try_read_i32_typed(limit_reg, &limit_i32)) {
+            int32_t decremented;
+            if (__builtin_sub_overflow(counter_i32, 1, &decremented)) {
+                VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Integer overflow");
+            }
+            vm_store_i32_typed_hot(reg, decremented);
+            if (decremented > limit_i32) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
         }
 
-        DISPATCH_TYPED();
+        int64_t counter_i64;
+        int64_t limit_i64;
+        if (vm_try_read_i64_typed(reg, &counter_i64) &&
+            vm_try_read_i64_typed(limit_reg, &limit_i64)) {
+            int64_t decremented;
+            if (__builtin_sub_overflow(counter_i64, (int64_t)1, &decremented)) {
+                VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Integer overflow");
+            }
+            vm_store_i64_typed_hot(reg, decremented);
+            if (decremented > limit_i64) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
+        }
+
+        uint32_t counter_u32;
+        uint32_t limit_u32;
+        if (vm_try_read_u32_typed(reg, &counter_u32) &&
+            vm_try_read_u32_typed(limit_reg, &limit_u32)) {
+            uint32_t decremented = counter_u32 - (uint32_t)1;
+            vm_store_u32_typed_hot(reg, decremented);
+            if (decremented > limit_u32) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
+        }
+
+        uint64_t counter_u64;
+        uint64_t limit_u64;
+        if (vm_try_read_u64_typed(reg, &counter_u64) &&
+            vm_try_read_u64_typed(limit_reg, &limit_u64)) {
+            uint64_t decremented = counter_u64 - (uint64_t)1;
+            vm_store_u64_typed_hot(reg, decremented);
+            if (decremented > limit_u64) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
+        }
+
+        Value counter = vm_get_register_safe(reg);
+        Value limit = vm_get_register_safe(limit_reg);
+
+        if (IS_I32(counter) && IS_I32(limit)) {
+            int32_t current = AS_I32(counter);
+            int32_t decremented;
+            if (__builtin_sub_overflow(current, 1, &decremented)) {
+                VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Integer overflow");
+            }
+            vm_store_i32_typed_hot(reg, decremented);
+            if (decremented > AS_I32(limit)) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
+        }
+
+        if (IS_I64(counter) && IS_I64(limit)) {
+            int64_t current = AS_I64(counter);
+            int64_t decremented;
+            if (__builtin_sub_overflow(current, (int64_t)1, &decremented)) {
+                VM_ERROR_RETURN(ERROR_VALUE, CURRENT_LOCATION(), "Integer overflow");
+            }
+            vm_store_i64_typed_hot(reg, decremented);
+            if (decremented > AS_I64(limit)) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
+        }
+
+        if (IS_U32(counter) && IS_U32(limit)) {
+            uint32_t decremented = AS_U32(counter) - (uint32_t)1;
+            vm_store_u32_typed_hot(reg, decremented);
+            if (decremented > AS_U32(limit)) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
+        }
+
+        if (IS_U64(counter) && IS_U64(limit)) {
+            uint64_t decremented = AS_U64(counter) - (uint64_t)1;
+            vm_store_u64_typed_hot(reg, decremented);
+            if (decremented > AS_U64(limit)) {
+                vm.ip += offset;
+            }
+            DISPATCH_TYPED();
+        }
+
+        VM_ERROR_RETURN(ERROR_TYPE, CURRENT_LOCATION(),
+                        "Operands must be homogeneous integers");
     }
 
     LABEL_OP_MUL_ADD_I32: {


### PR DESCRIPTION
## Summary
- expand OP_DEC_CMP_JMP handling in both dispatch loops to support all integer widths with overflow checks and boxed fallbacks
- tighten fused while-loop detection to reject bodies that mutate the counter outside the canonical increment while tolerating trailing no-op pass statements