### PR TITLE
Ensure fused loop guards use dedicated registers

### DIFF
--- a/makefile
+++ b/makefile
@@ -245,6 +245,7 @@ UNIT_TEST_RUNNER = test_runner$(SUFFIX)
 BYTECODE_TEST_BIN = $(BUILDDIR)/tests/test_jump_patch
 SOURCE_MAP_TEST_BIN = $(BUILDDIR)/tests/test_source_mapping
 SCOPE_TRACKING_TEST_BIN = $(BUILDDIR)/tests/test_scope_tracking
+FOR_LOOP_GUARD_TEST_BIN = $(BUILDDIR)/tests/test_for_loop_bytecode
 PEEPHOLE_TEST_BIN = $(BUILDDIR)/tests/test_constant_propagation
 TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
 TYPED_REGISTER_TEST_BIN = $(BUILDDIR)/tests/test_vm_typed_registers
@@ -421,6 +422,9 @@ _test-run: $(ORUS)
 	@echo "\033[36m=== Scope Tracking Tests ===\033[0m"
 	@$(MAKE) scope-tracking-tests
 	@echo ""
+	@echo "\033[36m=== For Loop Bytecode Tests ===\033[0m"
+	@$(MAKE) for-loop-bytecode-tests
+	@echo ""
 	@echo "\033[36m=== Peephole Constant Propagation Tests ===\033[0m"
 	@$(MAKE) peephole-tests
 	@echo ""
@@ -489,6 +493,15 @@ $(SCOPE_TRACKING_TEST_BIN): tests/unit/test_scope_stack.c $(COMPILER_OBJS) $(VM_
 scope-tracking-tests: $(SCOPE_TRACKING_TEST_BIN)
 	@echo "Running scope tracking tests..."
 	@./$(SCOPE_TRACKING_TEST_BIN)
+
+$(FOR_LOOP_GUARD_TEST_BIN): tests/unit/test_for_loop_bytecode.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling for-loop bytecode tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+for-loop-bytecode-tests: $(FOR_LOOP_GUARD_TEST_BIN)
+	@echo "Running for-loop bytecode tests..."
+	@./$(FOR_LOOP_GUARD_TEST_BIN)
 
 $(PEEPHOLE_TEST_BIN): tests/unit/test_constant_propagation.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/src/compiler/backend/codegen/statements.c
+++ b/src/compiler/backend/codegen/statements.c
@@ -1849,12 +1849,40 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
         DEBUG_CODEGEN_PRINT("While loop start at offset %d\n", loop_start_fused);
 
         int typed_hint_limit_reg = -1;
-        int fused_limit_guard_reg = fused_info.use_adjusted_limit ? fused_limit_temp_reg : fused_limit_reg;
-        if (fused_limit_guard_reg >= 0) {
-            ensure_i32_typed_register(ctx, fused_limit_guard_reg,
-                                      fused_info.use_adjusted_limit ? fused_limit_node : fused_limit_node);
+        int fused_limit_source_reg = fused_info.use_adjusted_limit ? fused_limit_temp_reg : fused_limit_reg;
+        int fused_limit_guard_reg = -1;
+        bool fused_limit_guard_is_temp = false;
+        bool fused_limit_guard_is_frame = false;
+        if (fused_limit_source_reg >= 0) {
+            ensure_i32_typed_register(ctx, fused_limit_source_reg, fused_limit_node);
         }
-        if (ctx->allocator && fused_limit_guard_reg >= 0) {
+
+        fused_limit_guard_reg = compiler_alloc_temp(ctx->allocator);
+        if (fused_limit_guard_reg != -1) {
+            fused_limit_guard_is_temp = true;
+        } else {
+            fused_limit_guard_reg = compiler_alloc_frame(ctx->allocator);
+            if (fused_limit_guard_reg == -1) {
+                if (fused_info.use_adjusted_limit && fused_limit_temp_is_temp &&
+                    fused_limit_temp_reg >= 0) {
+                    compiler_free_temp(ctx->allocator, fused_limit_temp_reg);
+                }
+                if (fused_limit_is_temp && fused_limit_reg >= 0) {
+                    compiler_free_temp(ctx->allocator, fused_limit_reg);
+                }
+                leave_loop_context(ctx, loop_frame_fused, ctx->bytecode->count);
+                ctx->has_compilation_errors = true;
+                return;
+            }
+            fused_limit_guard_is_frame = true;
+        }
+
+        set_location_from_node(ctx, while_stmt);
+        emit_byte_to_buffer(ctx->bytecode, OP_MOVE_I32);
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_limit_guard_reg);
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_limit_source_reg);
+
+        if (ctx->allocator) {
             compiler_set_typed_residency_hint(ctx->allocator, fused_limit_guard_reg, true);
             typed_hint_limit_reg = fused_limit_guard_reg;
         }
@@ -1862,20 +1890,13 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
         set_location_from_node(ctx, while_stmt);
         emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_loop_reg);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(fused_limit_temp_is_temp ? fused_limit_temp_reg : fused_limit_reg));
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_limit_guard_reg);
         int end_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
         if (end_patch < 0) {
             DEBUG_CODEGEN_PRINT("Error: Failed to allocate while-loop end placeholder\n");
             ctx->has_compilation_errors = true;
             leave_loop_context(ctx, loop_frame_fused, ctx->bytecode->count);
-            if (fused_info.use_adjusted_limit && fused_limit_temp_is_temp &&
-                fused_limit_temp_reg >= 0) {
-                compiler_free_temp(ctx->allocator, fused_limit_temp_reg);
-            }
-            if (fused_limit_is_temp && fused_limit_reg >= 0) {
-                compiler_free_temp(ctx->allocator, fused_limit_reg);
-            }
-            return;
+            goto fused_inc_cleanup;
         }
         if (fused_body_is_block && fused_block_count > 0 && while_body && while_body->original &&
             while_body->original->type == NODE_BLOCK) {
@@ -1901,10 +1922,12 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
         set_location_from_node(ctx, while_stmt);
         emit_byte_to_buffer(ctx->bytecode, OP_INC_CMP_JMP);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_loop_reg);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(fused_limit_temp_is_temp ? fused_limit_temp_reg : fused_limit_reg));
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_limit_guard_reg);
         int back_off = loop_start_fused - (ctx->bytecode->count + 2);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(back_off & 0xFF));
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)((back_off >> 8) & 0xFF));
+        // OP_INC_CMP_JMP reads its offset as a big-endian signed 16-bit value.
+        uint16_t encoded_back_off = (uint16_t)back_off;
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)((encoded_back_off >> 8) & 0xFF));
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(encoded_back_off & 0xFF));
 
         int end_target = ctx->bytecode->count;
         ctx->current_loop_end = end_target;
@@ -1917,28 +1940,11 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
             DEBUG_CODEGEN_PRINT("Error: Failed to patch while-loop end jump to %d\n", end_target);
             ctx->has_compilation_errors = true;
             leave_loop_context(ctx, loop_frame_fused, end_target);
-            if (fused_limit_temp_is_temp) {
-                compiler_free_temp(ctx->allocator, fused_limit_temp_reg);
-            }
-            if (fused_limit_is_temp) {
-                compiler_free_temp(ctx->allocator, fused_limit_reg);
-            }
-            return;
+            goto fused_inc_cleanup;
         }
         DEBUG_CODEGEN_PRINT("Patched end jump to %d\n", end_target);
 
         leave_loop_context(ctx, loop_frame_fused, end_target);
-
-        if (ctx->allocator && typed_hint_limit_reg >= 0) {
-            compiler_set_typed_residency_hint(ctx->allocator, typed_hint_limit_reg, false);
-        }
-        if (fused_info.use_adjusted_limit && fused_limit_temp_is_temp &&
-            fused_limit_temp_reg >= 0) {
-            compiler_free_temp(ctx->allocator, fused_limit_temp_reg);
-        }
-        if (fused_limit_is_temp && fused_limit_reg >= 0) {
-            compiler_free_temp(ctx->allocator, fused_limit_reg);
-        }
 
         if (fused_symbol) {
             mark_symbol_as_loop_variable(fused_symbol);
@@ -1946,6 +1952,29 @@ void compile_while_statement(CompilerContext* ctx, TypedASTNode* while_stmt) {
         }
 
         DEBUG_CODEGEN_PRINT("While statement compilation completed (fused inc path)");
+fused_inc_cleanup:
+        if (ctx->allocator && typed_hint_limit_reg >= 0) {
+            compiler_set_typed_residency_hint(ctx->allocator, typed_hint_limit_reg, false);
+        }
+        if (fused_limit_guard_is_temp && fused_limit_guard_reg >= MP_TEMP_REG_START &&
+            fused_limit_guard_reg <= MP_TEMP_REG_END) {
+            compiler_free_temp(ctx->allocator, fused_limit_guard_reg);
+            fused_limit_guard_reg = -1;
+        }
+        if (fused_limit_guard_is_frame && fused_limit_guard_reg >= 0) {
+            compiler_free_register(ctx->allocator, fused_limit_guard_reg);
+            fused_limit_guard_reg = -1;
+        }
+        if (fused_info.use_adjusted_limit && fused_limit_temp_is_temp &&
+            fused_limit_temp_reg >= 0) {
+            compiler_free_temp(ctx->allocator, fused_limit_temp_reg);
+            fused_limit_temp_reg = -1;
+        }
+        if (fused_limit_is_temp && fused_limit_reg >= 0) {
+            compiler_free_temp(ctx->allocator, fused_limit_reg);
+            fused_limit_reg = -1;
+        }
+
         return;
     }
 
@@ -2080,8 +2109,15 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
     int end_reg = -1;
     int step_reg = -1;
     int loop_var_reg = -1;
-    int condition_reg = -1;
-    int condition_neg_reg = -1;
+    int positive_guard_limit_reg = -1;
+    bool positive_guard_limit_is_temp = false;
+    bool positive_guard_limit_is_frame = false;
+    int negative_guard_limit_reg = -1;
+    bool negative_guard_limit_is_temp = false;
+    bool negative_guard_limit_is_frame = false;
+    int fused_guard_limit_reg = -1;
+    bool fused_guard_limit_is_temp = false;
+    bool fused_guard_limit_is_frame = false;
     int step_nonneg_reg = -1;
     int zero_reg = -1;
     int limit_temp_reg = -1; // temp for inclusive fused limit (end+1)
@@ -2220,123 +2256,220 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
     ctx->current_loop_continue = -1;
     loop_frame->continue_offset = -1;
 
-    condition_reg = compiler_alloc_temp(ctx->allocator);
-    if (condition_reg == -1) {
-        ctx->has_compilation_errors = true;
-        goto cleanup;
-    }
-
     // If we can use fused INC_CMP_JMP, prefer the precomputed adjusted limit when available
     int limit_reg_used = end_reg;
-    if (can_fuse_inc_cmp && limit_temp_reg >= 0) {
-        limit_reg_used = limit_temp_reg;
+    int limit_source_reg = end_reg;
+    if (limit_temp_reg >= 0) {
+        limit_source_reg = limit_temp_reg;
     }
 
-    if (can_fuse_inc_cmp && limit_reg_used >= 0) {
-        ensure_i32_typed_register(ctx, limit_reg_used, fused_info.limit_node);
+    if (can_fuse_inc_cmp) {
+        if (limit_source_reg >= 0) {
+            ensure_i32_typed_register(ctx, limit_source_reg, fused_info.limit_node);
+        }
+
+        fused_guard_limit_reg = compiler_alloc_temp(ctx->allocator);
+        if (fused_guard_limit_reg != -1) {
+            fused_guard_limit_is_temp = true;
+        } else {
+            fused_guard_limit_reg = compiler_alloc_frame(ctx->allocator);
+            if (fused_guard_limit_reg == -1) {
+                ctx->has_compilation_errors = true;
+                goto cleanup;
+            }
+            fused_guard_limit_is_frame = true;
+        }
+
+        set_location_from_node(ctx, for_stmt);
+        emit_byte_to_buffer(ctx->bytecode, OP_MOVE_I32);
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)fused_guard_limit_reg);
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_source_reg);
+
+        limit_reg_used = fused_guard_limit_reg;
+
+        if (ctx->allocator) {
+            compiler_set_typed_residency_hint(ctx->allocator, limit_reg_used, true);
+            typed_hint_limit_reg = limit_reg_used;
+        }
+    } else {
+        if (end_reg >= 0) {
+            ensure_i32_typed_register(ctx, end_reg, fused_info.limit_node);
+        }
+        if (ctx->allocator && end_reg >= 0) {
+            compiler_set_typed_residency_hint(ctx->allocator, end_reg, true);
+            typed_hint_limit_reg = end_reg;
+        }
     }
 
-    if (ctx->allocator && limit_reg_used >= 0) {
-        compiler_set_typed_residency_hint(ctx->allocator, limit_reg_used, true);
-        typed_hint_limit_reg = limit_reg_used;
-    }
-
-    int guard_patch = -1;
+    int guard_patches[2] = {-1, -1};
+    int guard_patch_count = 0;
     set_location_from_node(ctx, for_stmt);
     if (can_fuse_inc_cmp) {
         emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_var_reg);
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_reg_used);
-        guard_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
-        if (guard_patch < 0) {
+        guard_patches[guard_patch_count] =
+            emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+        if (guard_patches[guard_patch_count] < 0) {
             ctx->has_compilation_errors = true;
             goto cleanup;
         }
+        guard_patch_count++;
     } else {
-        if (for_stmt->typed.forRange.inclusive) {
-            emit_byte_to_buffer(ctx->bytecode, OP_LE_I32_TYPED);
+        bool need_positive_guard = step_known_positive || !step_known_negative;
+        bool need_negative_guard = step_known_negative || !step_known_positive;
+
+        if (need_positive_guard) {
+            positive_guard_limit_reg = compiler_alloc_temp(ctx->allocator);
+            if (positive_guard_limit_reg != -1) {
+                positive_guard_limit_is_temp = true;
+            } else {
+                positive_guard_limit_reg = compiler_alloc_frame(ctx->allocator);
+                if (positive_guard_limit_reg == -1) {
+                    ctx->has_compilation_errors = true;
+                    goto cleanup;
+                }
+                positive_guard_limit_is_frame = true;
+            }
+
+            set_location_from_node(ctx, for_stmt);
+            if (for_stmt->typed.forRange.inclusive) {
+                if (limit_temp_reg >= 0) {
+                    emit_byte_to_buffer(ctx->bytecode, OP_MOVE_I32);
+                    emit_byte_to_buffer(ctx->bytecode, (uint8_t)positive_guard_limit_reg);
+                    emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_temp_reg);
+                } else {
+                    emit_byte_to_buffer(ctx->bytecode, OP_MOVE_I32);
+                    emit_byte_to_buffer(ctx->bytecode, (uint8_t)positive_guard_limit_reg);
+                    emit_byte_to_buffer(ctx->bytecode, (uint8_t)end_reg);
+                    emit_byte_to_buffer(ctx->bytecode, OP_ADD_I32_IMM);
+                    emit_byte_to_buffer(ctx->bytecode, (uint8_t)positive_guard_limit_reg);
+                    emit_byte_to_buffer(ctx->bytecode, (uint8_t)positive_guard_limit_reg);
+                    int32_t one = 1;
+                    emit_byte_to_buffer(ctx->bytecode, (uint8_t)(one & 0xFF));
+                    emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 8) & 0xFF));
+                    emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 16) & 0xFF));
+                    emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 24) & 0xFF));
+                }
+            } else {
+                emit_byte_to_buffer(ctx->bytecode, OP_MOVE_I32);
+                emit_byte_to_buffer(ctx->bytecode, (uint8_t)positive_guard_limit_reg);
+                emit_byte_to_buffer(ctx->bytecode, (uint8_t)end_reg);
+            }
+        }
+
+        if (need_negative_guard) {
+            negative_guard_limit_reg = compiler_alloc_temp(ctx->allocator);
+            if (negative_guard_limit_reg != -1) {
+                negative_guard_limit_is_temp = true;
+            } else {
+                negative_guard_limit_reg = compiler_alloc_frame(ctx->allocator);
+                if (negative_guard_limit_reg == -1) {
+                    ctx->has_compilation_errors = true;
+                    goto cleanup;
+                }
+                negative_guard_limit_is_frame = true;
+            }
+
+            set_location_from_node(ctx, for_stmt);
+            emit_byte_to_buffer(ctx->bytecode, OP_MOVE_I32);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)negative_guard_limit_reg);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)end_reg);
+            if (for_stmt->typed.forRange.inclusive) {
+                emit_byte_to_buffer(ctx->bytecode, OP_SUB_I32_IMM);
+                emit_byte_to_buffer(ctx->bytecode, (uint8_t)negative_guard_limit_reg);
+                emit_byte_to_buffer(ctx->bytecode, (uint8_t)negative_guard_limit_reg);
+                int32_t one = 1;
+                emit_byte_to_buffer(ctx->bytecode, (uint8_t)(one & 0xFF));
+                emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 8) & 0xFF));
+                emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 16) & 0xFF));
+                emit_byte_to_buffer(ctx->bytecode, (uint8_t)((one >> 24) & 0xFF));
+            }
+        }
+
+        if (need_positive_guard && !need_negative_guard) {
+            set_location_from_node(ctx, for_stmt);
+            emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_var_reg);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)positive_guard_limit_reg);
+            guard_patches[guard_patch_count] =
+                emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+            if (guard_patches[guard_patch_count] < 0) {
+                ctx->has_compilation_errors = true;
+                goto cleanup;
+            }
+            guard_patch_count++;
+        } else if (!need_positive_guard && need_negative_guard) {
+            set_location_from_node(ctx, for_stmt);
+            emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)negative_guard_limit_reg);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_var_reg);
+            guard_patches[guard_patch_count] =
+                emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+            if (guard_patches[guard_patch_count] < 0) {
+                ctx->has_compilation_errors = true;
+                goto cleanup;
+            }
+            guard_patch_count++;
         } else {
-            emit_byte_to_buffer(ctx->bytecode, OP_LT_I32_TYPED);
-        }
-        emit_byte_to_buffer(ctx->bytecode, condition_reg);
-        emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)end_reg);
-    }
+            if (step_nonneg_reg == -1) {
+                ctx->has_compilation_errors = true;
+                goto cleanup;
+            }
 
-    if (!step_known_positive) {
-        condition_neg_reg = compiler_alloc_temp(ctx->allocator);
-        if (condition_neg_reg == -1) {
-            ctx->has_compilation_errors = true;
-            goto cleanup;
-        }
+            int select_neg_patch = -1;
+            int skip_neg_patch = -1;
 
-        set_location_from_node(ctx, for_stmt);
-        if (for_stmt->typed.forRange.inclusive) {
-            emit_byte_to_buffer(ctx->bytecode, OP_GE_I32_TYPED);
-        } else {
-            emit_byte_to_buffer(ctx->bytecode, OP_GT_I32_TYPED);
-        }
-        emit_byte_to_buffer(ctx->bytecode, condition_neg_reg);
-        emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
-        emit_byte_to_buffer(ctx->bytecode, end_reg);
-    }
+            set_location_from_node(ctx, for_stmt);
+            emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_R);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)step_nonneg_reg);
+            select_neg_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_R);
+            if (select_neg_patch < 0) {
+                ctx->has_compilation_errors = true;
+                goto cleanup;
+            }
 
-    int select_neg_patch = -1;
-    int skip_neg_patch = -1;
+            set_location_from_node(ctx, for_stmt);
+            emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_var_reg);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)positive_guard_limit_reg);
+            guard_patches[guard_patch_count] =
+                emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+            if (guard_patches[guard_patch_count] < 0) {
+                ctx->has_compilation_errors = true;
+                goto cleanup;
+            }
+            guard_patch_count++;
 
-    if (step_known_negative) {
-        set_location_from_node(ctx, for_stmt);
-        emit_move(ctx, condition_reg, condition_neg_reg);
-    } else if (!step_known_positive) {
-        if (step_nonneg_reg == -1) {
-            ctx->has_compilation_errors = true;
-            goto cleanup;
-        }
+            set_location_from_node(ctx, for_stmt);
+            emit_byte_to_buffer(ctx->bytecode, OP_JUMP);
+            skip_neg_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP);
+            if (skip_neg_patch < 0) {
+                ctx->has_compilation_errors = true;
+                goto cleanup;
+            }
 
-        set_location_from_node(ctx, for_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_R);
-        emit_byte_to_buffer(ctx->bytecode, step_nonneg_reg);
-        select_neg_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_R);
-        if (select_neg_patch < 0) {
-            ctx->has_compilation_errors = true;
-            goto cleanup;
-        }
+            if (!patch_jump(ctx->bytecode, select_neg_patch, ctx->bytecode->count)) {
+                ctx->has_compilation_errors = true;
+                goto cleanup;
+            }
 
-        set_location_from_node(ctx, for_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_JUMP);
-        skip_neg_patch = emit_jump_placeholder(ctx->bytecode, OP_JUMP);
-        if (skip_neg_patch < 0) {
-            ctx->has_compilation_errors = true;
-            goto cleanup;
-        }
+            set_location_from_node(ctx, for_stmt);
+            emit_byte_to_buffer(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)negative_guard_limit_reg);
+            emit_byte_to_buffer(ctx->bytecode, (uint8_t)loop_var_reg);
+            guard_patches[guard_patch_count] =
+                emit_jump_placeholder(ctx->bytecode, OP_JUMP_IF_NOT_I32_TYPED);
+            if (guard_patches[guard_patch_count] < 0) {
+                ctx->has_compilation_errors = true;
+                goto cleanup;
+            }
+            guard_patch_count++;
 
-        if (!patch_jump(ctx->bytecode, select_neg_patch, ctx->bytecode->count)) {
-            ctx->has_compilation_errors = true;
-            goto cleanup;
-        }
-
-        set_location_from_node(ctx, for_stmt);
-        emit_move(ctx, condition_reg, condition_neg_reg);
-
-        if (!patch_jump(ctx->bytecode, skip_neg_patch, ctx->bytecode->count)) {
-            ctx->has_compilation_errors = true;
-            goto cleanup;
-        }
-    }
-
-    int end_patch = -1;
-    if (can_fuse_inc_cmp) {
-        end_patch = guard_patch;
-    } else {
-        set_location_from_node(ctx, for_stmt);
-        emit_byte_to_buffer(ctx->bytecode, OP_BRANCH_TYPED);
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)((loop_id >> 8) & 0xFF));
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(loop_id & 0xFF));
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)condition_reg);
-        end_patch = emit_jump_placeholder(ctx->bytecode, OP_BRANCH_TYPED);
-        if (end_patch < 0) {
-            ctx->has_compilation_errors = true;
-            goto cleanup;
+            if (!patch_jump(ctx->bytecode, skip_neg_patch, ctx->bytecode->count)) {
+                ctx->has_compilation_errors = true;
+                goto cleanup;
+            }
         }
     }
 
@@ -2359,17 +2492,18 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
         emit_byte_to_buffer(ctx->bytecode, (uint8_t)limit_reg_used);
         // back offset is relative to address after the 2-byte offset we emit now
         int back_off = loop_start - (ctx->bytecode->count + 2);
-        // OP_INC_CMP_JMP reads offset as native int16 (little-endian on our targets)
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(back_off & 0xFF));
-        emit_byte_to_buffer(ctx->bytecode, (uint8_t)((back_off >> 8) & 0xFF));
+        // OP_INC_CMP_JMP reads offset as a big-endian signed 16-bit value
+        uint16_t encoded_back_off = (uint16_t)back_off;
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)((encoded_back_off >> 8) & 0xFF));
+        emit_byte_to_buffer(ctx->bytecode, (uint8_t)(encoded_back_off & 0xFF));
     } else {
+        patch_continue_statements(ctx, continue_target);
+
         set_location_from_node(ctx, for_stmt);
         emit_byte_to_buffer(ctx->bytecode, OP_ADD_I32_TYPED);
         emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
         emit_byte_to_buffer(ctx->bytecode, loop_var_reg);
         emit_byte_to_buffer(ctx->bytecode, step_reg);
-
-        patch_continue_statements(ctx, continue_target);
 
         int back_jump_distance = (ctx->bytecode->count + 2) - loop_start;
         if (back_jump_distance >= 0 && back_jump_distance <= 255) {
@@ -2388,9 +2522,11 @@ void compile_for_range_statement(CompilerContext* ctx, TypedASTNode* for_stmt) {
     int end_target = ctx->bytecode->count;
     ctx->current_loop_end = end_target;
 
-    if (!patch_jump(ctx->bytecode, end_patch, end_target)) {
-        ctx->has_compilation_errors = true;
-        goto cleanup;
+    for (int i = 0; i < guard_patch_count; i++) {
+        if (!patch_jump(ctx->bytecode, guard_patches[i], end_target)) {
+            ctx->has_compilation_errors = true;
+            goto cleanup;
+        }
     }
 
     patch_break_statements(ctx, end_target);
@@ -2420,13 +2556,33 @@ cleanup:
         }
     }
 
-    if (condition_reg >= MP_TEMP_REG_START && condition_reg <= MP_TEMP_REG_END) {
-        compiler_free_temp(ctx->allocator, condition_reg);
-        condition_reg = -1;
+    if (fused_guard_limit_is_temp && fused_guard_limit_reg >= MP_TEMP_REG_START &&
+        fused_guard_limit_reg <= MP_TEMP_REG_END) {
+        compiler_free_temp(ctx->allocator, fused_guard_limit_reg);
+        fused_guard_limit_reg = -1;
     }
-    if (condition_neg_reg >= MP_TEMP_REG_START && condition_neg_reg <= MP_TEMP_REG_END) {
-        compiler_free_temp(ctx->allocator, condition_neg_reg);
-        condition_neg_reg = -1;
+    if (fused_guard_limit_is_frame && fused_guard_limit_reg >= 0) {
+        compiler_free_register(ctx->allocator, fused_guard_limit_reg);
+        fused_guard_limit_reg = -1;
+    }
+
+    if (positive_guard_limit_is_temp && positive_guard_limit_reg >= MP_TEMP_REG_START &&
+        positive_guard_limit_reg <= MP_TEMP_REG_END) {
+        compiler_free_temp(ctx->allocator, positive_guard_limit_reg);
+        positive_guard_limit_reg = -1;
+    }
+    if (positive_guard_limit_is_frame && positive_guard_limit_reg >= 0) {
+        compiler_free_register(ctx->allocator, positive_guard_limit_reg);
+        positive_guard_limit_reg = -1;
+    }
+    if (negative_guard_limit_is_temp && negative_guard_limit_reg >= MP_TEMP_REG_START &&
+        negative_guard_limit_reg <= MP_TEMP_REG_END) {
+        compiler_free_temp(ctx->allocator, negative_guard_limit_reg);
+        negative_guard_limit_reg = -1;
+    }
+    if (negative_guard_limit_is_frame && negative_guard_limit_reg >= 0) {
+        compiler_free_register(ctx->allocator, negative_guard_limit_reg);
+        negative_guard_limit_reg = -1;
     }
     if (step_nonneg_reg >= MP_TEMP_REG_START && step_nonneg_reg <= MP_TEMP_REG_END) {
         compiler_free_temp(ctx->allocator, step_nonneg_reg);

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -3657,8 +3657,7 @@ InterpretResult vm_run_dispatch(void) {
     LABEL_OP_INC_CMP_JMP: {
         uint8_t reg = *vm.ip++;
         uint8_t limit_reg = *vm.ip++;
-        int16_t offset = *(int16_t*)vm.ip;
-        vm.ip += 2;
+        int16_t offset = (int16_t)READ_SHORT();
 
         int32_t counter_i32;
         int32_t limit_i32;

--- a/tests/unit/test_for_loop_bytecode.c
+++ b/tests/unit/test_for_loop_bytecode.c
@@ -1,0 +1,264 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "compiler/compiler.h"
+#include "compiler/parser.h"
+#include "compiler/typed_ast.h"
+#include "compiler/error_reporter.h"
+#include "debug/debug_config.h"
+#include "type/type.h"
+#include "vm/vm.h"
+
+#define ASSERT_TRUE(cond, message)                                                         \
+    do {                                                                                   \
+        if (!(cond)) {                                                                     \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", message, __FILE__, __LINE__); \
+            return false;                                                                  \
+        }                                                                                  \
+    } while (0)
+
+typedef struct {
+    CompilerContext* ctx;
+    TypedASTNode* typed;
+    ASTNode* ast;
+} CompiledProgram;
+
+static bool compile_program(const char* source, const char* filename, CompiledProgram* out) {
+    memset(out, 0, sizeof(*out));
+
+    ASTNode* ast = parseSource(source);
+    if (!ast) {
+        return false;
+    }
+    ast->location.file = filename;
+
+    init_type_inference();
+    TypeEnv* env = type_env_new(NULL);
+    if (!env) {
+        cleanup_type_inference();
+        freeAST(ast);
+        return false;
+    }
+
+    TypedASTNode* typed = generate_typed_ast(ast, env);
+    if (!typed) {
+        cleanup_type_inference();
+        freeAST(ast);
+        return false;
+    }
+
+    CompilerContext* ctx = init_compiler_context(typed);
+    if (!ctx) {
+        cleanup_type_inference();
+        free_typed_ast_node(typed);
+        freeAST(ast);
+        return false;
+    }
+
+    if (!compile_to_bytecode(ctx)) {
+        free_compiler_context(ctx);
+        cleanup_type_inference();
+        free_typed_ast_node(typed);
+        freeAST(ast);
+        return false;
+    }
+
+    out->ctx = ctx;
+    out->typed = typed;
+    out->ast = ast;
+    return true;
+}
+
+static void destroy_program(CompiledProgram* program) {
+    if (!program) {
+        return;
+    }
+    free_compiler_context(program->ctx);
+    free_typed_ast_node(program->typed);
+    freeAST(program->ast);
+    cleanup_type_inference();
+}
+
+static int find_opcode(BytecodeBuffer* bytecode, uint8_t opcode, int start) {
+    for (int i = start; i < bytecode->count; ++i) {
+        if (bytecode->instructions[i] == opcode) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static bool contains_opcode(BytecodeBuffer* bytecode, uint8_t opcode) {
+    return find_opcode(bytecode, opcode, 0) >= 0;
+}
+
+static int jump_target(BytecodeBuffer* bytecode, int index) {
+    uint8_t opcode = bytecode->instructions[index];
+    if (opcode == OP_JUMP) {
+        int16_t offset = (int16_t)((bytecode->instructions[index + 1] << 8) |
+                                   bytecode->instructions[index + 2]);
+        return index + 3 + offset;
+    }
+    if (opcode == OP_JUMP_IF_NOT_I32_TYPED) {
+        int16_t offset = (int16_t)((bytecode->instructions[index + 3] << 8) |
+                                   bytecode->instructions[index + 4]);
+        return index + 5 + offset;
+    }
+    if (opcode == OP_JUMP_IF_NOT_R) {
+        int16_t offset = (int16_t)((bytecode->instructions[index + 2] << 8) |
+                                   bytecode->instructions[index + 3]);
+        return index + 4 + offset;
+    }
+    if (opcode == OP_LOOP_SHORT) {
+        uint8_t back = bytecode->instructions[index + 1];
+        return index + 2 - back;
+    }
+    if (opcode == OP_LOOP) {
+        int16_t distance = (int16_t)((bytecode->instructions[index + 1] << 8) |
+                                     bytecode->instructions[index + 2]);
+        return index + 3 - distance;
+    }
+    return -1;
+}
+
+static bool verify_back_edge(BytecodeBuffer* bytecode, int search_start, int guard_index) {
+    int loop_idx = find_opcode(bytecode, OP_LOOP_SHORT, search_start);
+    if (loop_idx < 0) {
+        loop_idx = find_opcode(bytecode, OP_JUMP, search_start);
+        while (loop_idx >= 0) {
+            int target = jump_target(bytecode, loop_idx);
+            if (target >= 0 && target <= guard_index) {
+                return true;
+            }
+            loop_idx = find_opcode(bytecode, OP_JUMP, loop_idx + 1);
+        }
+        return false;
+    }
+    int target = jump_target(bytecode, loop_idx);
+    return target >= 0 && target <= guard_index;
+}
+
+static bool test_positive_step_guard(void) {
+    static const char* source =
+        "for i in 0..10..2:\n"
+        "    pass\n";
+
+    CompiledProgram program;
+    if (!compile_program(source, "positive_step.orus", &program)) {
+        return false;
+    }
+
+    BytecodeBuffer* bytecode = program.ctx->bytecode;
+
+    ASSERT_TRUE(!contains_opcode(bytecode, OP_BRANCH_TYPED), "Fallback loop should avoid OP_BRANCH_TYPED");
+
+    int guard_index = find_opcode(bytecode, OP_JUMP_IF_NOT_I32_TYPED, 0);
+    ASSERT_TRUE(guard_index >= 0, "Guard should use OP_JUMP_IF_NOT_I32_TYPED");
+
+    int increment_index = find_opcode(bytecode, OP_ADD_I32_TYPED, guard_index + 1);
+    ASSERT_TRUE(increment_index >= 0, "Loop increment should use OP_ADD_I32_TYPED");
+
+    ASSERT_TRUE(verify_back_edge(bytecode, increment_index + 1, guard_index),
+                "Back edge should return to guard using OP_LOOP_SHORT/OP_JUMP");
+
+    destroy_program(&program);
+    return true;
+}
+
+static bool test_continue_targets_increment(void) {
+    static const char* source =
+        "for i in 0..10..2:\n"
+        "    if i == 4:\n"
+        "        continue\n";
+
+    CompiledProgram program;
+    if (!compile_program(source, "continue.orus", &program)) {
+        return false;
+    }
+
+    BytecodeBuffer* bytecode = program.ctx->bytecode;
+
+    ASSERT_TRUE(!contains_opcode(bytecode, OP_BRANCH_TYPED), "Continue loop should avoid OP_BRANCH_TYPED");
+
+    int guard_index = find_opcode(bytecode, OP_JUMP_IF_NOT_I32_TYPED, 0);
+    ASSERT_TRUE(guard_index >= 0, "Guard should use OP_JUMP_IF_NOT_I32_TYPED");
+
+    int increment_index = find_opcode(bytecode, OP_ADD_I32_TYPED, guard_index + 1);
+    ASSERT_TRUE(increment_index >= 0, "Loop increment should use OP_ADD_I32_TYPED");
+
+    int continue_jump_index = -1;
+    for (int i = guard_index + 1; i < bytecode->count; ++i) {
+        if (bytecode->instructions[i] == OP_JUMP) {
+            int target = jump_target(bytecode, i);
+            if (target == increment_index) {
+                continue_jump_index = i;
+                break;
+            }
+        }
+    }
+
+    ASSERT_TRUE(continue_jump_index >= 0, "Continue jump should land on loop increment");
+    ASSERT_TRUE(verify_back_edge(bytecode, increment_index + 1, guard_index),
+                "Continue loop should retain back edge to guard");
+
+    destroy_program(&program);
+    return true;
+}
+
+static bool test_negative_step_guard(void) {
+    static const char* source =
+        "for i in 10..0..-2:\n"
+        "    pass\n";
+
+    CompiledProgram program;
+    if (!compile_program(source, "negative_step.orus", &program)) {
+        return false;
+    }
+
+    BytecodeBuffer* bytecode = program.ctx->bytecode;
+
+    ASSERT_TRUE(!contains_opcode(bytecode, OP_BRANCH_TYPED), "Negative step loop should avoid OP_BRANCH_TYPED");
+
+    int guard_index = find_opcode(bytecode, OP_JUMP_IF_NOT_I32_TYPED, 0);
+    ASSERT_TRUE(guard_index >= 0, "Guard should use OP_JUMP_IF_NOT_I32_TYPED");
+
+    int increment_index = find_opcode(bytecode, OP_ADD_I32_TYPED, guard_index + 1);
+    ASSERT_TRUE(increment_index >= 0, "Negative step loop should still emit OP_ADD_I32_TYPED for the counter");
+
+    ASSERT_TRUE(verify_back_edge(bytecode, increment_index + 1, guard_index),
+                "Negative step loop should jump back to the guard");
+
+    destroy_program(&program);
+    return true;
+}
+
+int main(void) {
+    debug_init();
+
+    struct {
+        const char* name;
+        bool (*fn)(void);
+    } tests[] = {
+        {"non-fused positive step guard", test_positive_step_guard},
+        {"continue targets increment before guard", test_continue_targets_increment},
+        {"non-fused negative step guard", test_negative_step_guard},
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; ++i) {
+        if (tests[i].fn()) {
+            printf("[PASS] %s\n", tests[i].name);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", tests[i].name);
+            return 1;
+        }
+    }
+
+    printf("%d/%d for-loop bytecode tests passed\n", passed, total);
+    return 0;
+}

--- a/tests/unit/test_vm_inc_cmp_jmp.c
+++ b/tests/unit/test_vm_inc_cmp_jmp.c
@@ -9,8 +9,8 @@
 
 static void write_short(Chunk* chunk, int16_t value) {
     uint16_t encoded = (uint16_t)value;
-    writeChunk(chunk, (uint8_t)(encoded & 0xFF), 1, 0, "inc_cmp_jmp");
     writeChunk(chunk, (uint8_t)(encoded >> 8), 1, 0, "inc_cmp_jmp");
+    writeChunk(chunk, (uint8_t)(encoded & 0xFF), 1, 0, "inc_cmp_jmp");
 }
 
 static void write_inc_cmp_jmp_program(Chunk* chunk, uint8_t counter_reg, uint8_t limit_reg, int16_t offset) {


### PR DESCRIPTION
## Summary
- replace for-range fallback branch boolean guard with typed jump comparisons, handling positive, negative, and dynamic steps
- redirect continue patching to align with typed guard emission and update cleanup for new guard registers
- add for-loop bytecode regression tests and integrate them into the test harness; adjust VM dispatch to read fused offsets via READ_SHORT
- allocate dedicated guard registers for fused for/while loops, copying limits into protected storage and clearing residency hints on all exits
- update OP_INC_CMP_JMP regression helper to emit big-endian offsets consistent with the dispatcher

## Testing
- make release
- make test


------
https://chatgpt.com/codex/tasks/task_e_68e2737044bc8325ab2dd5035c02e5b1