### PR TITLE
Handle fused loop back edge overflow

### DIFF
--- a/tests/unit/test_fused_loop_bytecode.c
+++ b/tests/unit/test_fused_loop_bytecode.c
@@ -1,6 +1,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+#include <limits.h>
 
 #include "compiler/compiler.h"
 #include "compiler/parser.h"
@@ -180,6 +182,62 @@ static bool test_fused_loop_bytecode_identity(void) {
     return true;
 }
 
+static bool test_fused_loop_back_edge_fallback(void) {
+    const int repeat_count = 2048;
+    const char* header =
+        "mut limit = 100000\n"
+        "mut i = 0\n"
+        "mut acc = 0\n"
+        "while i < limit:\n";
+    const char* body_line = "    acc = acc + i + limit + acc + i + limit\n";
+    const char* increment_line = "    i = i + 1\n";
+
+    size_t total_length = strlen(header) + (size_t)repeat_count * strlen(body_line) +
+                          strlen(increment_line) + 1;
+    char* source = (char*)malloc(total_length);
+    ASSERT_TRUE(source != NULL, "failed to allocate large loop source");
+
+    char* cursor = source;
+    size_t header_len = strlen(header);
+    memcpy(cursor, header, header_len);
+    cursor += header_len;
+    size_t body_len = strlen(body_line);
+    for (int i = 0; i < repeat_count; ++i) {
+        memcpy(cursor, body_line, body_len);
+        cursor += body_len;
+    }
+    size_t inc_len = strlen(increment_line);
+    memcpy(cursor, increment_line, inc_len);
+    cursor += inc_len;
+    *cursor = '\0';
+
+    CompilerContext* ctx = NULL;
+    TypedASTNode* typed = NULL;
+    ASTNode* ast = NULL;
+
+    bool build_ok = build_context_from_source(source, "fused_while_large.orus",
+                                              &ctx, &typed, &ast);
+    free(source);
+    ASSERT_TRUE(build_ok, "failed to compile large fused while source");
+
+    BytecodeBuffer* bc = ctx->bytecode;
+    ASSERT_TRUE(bc != NULL, "bytecode buffer missing for large while");
+    ASSERT_TRUE(bc->count > (INT16_MAX + 1024), "bytecode not large enough to test back edge");
+
+    bool has_fused_increment = false;
+    for (int i = 0; i < bc->count; ++i) {
+        if (bc->instructions[i] == OP_INC_CMP_JMP || bc->instructions[i] == OP_DEC_CMP_JMP) {
+            has_fused_increment = true;
+            break;
+        }
+    }
+
+    destroy_context(ctx, typed, ast);
+
+    ASSERT_TRUE(!has_fused_increment, "compiler emitted fused increment for oversized loop");
+    return true;
+}
+
 int main(void) {
     debug_init();
 
@@ -188,6 +246,7 @@ int main(void) {
         bool (*fn)(void);
     } tests[] = {
         {"fused while/for bytecode identity", test_fused_loop_bytecode_identity},
+        {"fused while falls back when back edge exceeds INT16", test_fused_loop_back_edge_fallback},
     };
 
     int passed = 0;


### PR DESCRIPTION
## Summary
- ensure `emit_fused_numeric_loop` abandons fused emission when the computed back-edge offset cannot fit in a signed 16-bit immediate and restore any temporary resources
- teach the fused `while` lowering path to roll back and fall through to the generic implementation when the fused back-edge offset would overflow
- add a regression unit test that exercises a large fused `while` body and confirms the compiler emits the generic loop form instead of wrapping the offset