### PR TITLE
Make spill manager iteration read-only

### DIFF
--- a/include/vm/spill_manager.h
+++ b/include/vm/spill_manager.h
@@ -20,6 +20,8 @@
 // Forward declaration
 typedef struct SpillManager SpillManager;
 
+typedef void (*SpillEntryVisitor)(uint16_t register_id, const Value* value, void* user_data);
+
 // Phase 2: Spill manager lifecycle
 SpillManager* create_spill_manager(void);
 void free_spill_manager(SpillManager* manager);
@@ -30,6 +32,8 @@ bool set_spill_register_value(SpillManager* manager, uint16_t register_id, Value
 void reserve_spill_slot(SpillManager* manager, uint16_t register_id);
 bool unspill_register_value(SpillManager* manager, uint16_t register_id, Value* value);
 void remove_spilled_register(SpillManager* manager, uint16_t register_id);
+
+void spill_manager_visit_entries(const SpillManager* manager, SpillEntryVisitor visitor, void* user_data);
 
 // Phase 2: Pressure analysis
 bool needs_spilling(SpillManager* manager);

--- a/makefile
+++ b/makefile
@@ -250,6 +250,7 @@ FUSED_WHILE_TEST_BIN = $(BUILDDIR)/tests/test_codegen_fused_while
 PEEPHOLE_TEST_BIN = $(BUILDDIR)/tests/test_constant_propagation
 TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
 TYPED_REGISTER_TEST_BIN = $(BUILDDIR)/tests/test_vm_typed_registers
+SPILL_GC_TEST_BIN = $(BUILDDIR)/tests/test_vm_spill_gc_root
 REGISTER_ALLOCATOR_TEST_BIN = $(BUILDDIR)/tests/test_register_allocator
 INC_CMP_JMP_TEST_BIN = $(BUILDDIR)/tests/test_vm_inc_cmp_jmp
 FUSED_LOOP_BYTECODE_TEST_BIN = $(BUILDDIR)/tests/test_fused_loop_bytecode
@@ -269,7 +270,7 @@ BUILTIN_RANGE_ORUS_FAIL_TESTS = \
     tests/builtins/range_float_step.orus \
     tests/builtins/range_overflow_stop.orus
 
-.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests fused-while-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests inc-cmp-jmp-tests add-i32-imm-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
+.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests fused-while-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests spill-gc-tests inc-cmp-jmp-tests add-i32-imm-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
 
 all: build-info $(ORUS)
 
@@ -442,6 +443,9 @@ _test-run: $(ORUS)
 	@echo "\033[36m=== Typed Register Tests ===\033[0m"
 	@$(MAKE) typed-register-tests
 	@echo ""
+	@echo "\033[36m=== Spill GC Tests ===\033[0m"
+	@$(MAKE) spill-gc-tests
+	@echo ""
 	@echo "\033[36m=== OP_INC_CMP_JMP Tests ===\033[0m"
 	@$(MAKE) inc-cmp-jmp-tests
 	@echo ""
@@ -555,6 +559,15 @@ $(TYPED_REGISTER_TEST_BIN): tests/unit/test_vm_typed_registers.c $(COMPILER_OBJS
 typed-register-tests: $(TYPED_REGISTER_TEST_BIN)
 	@echo "Running typed register coherence tests..."
 	@./$(TYPED_REGISTER_TEST_BIN)
+
+$(SPILL_GC_TEST_BIN): tests/unit/test_vm_spill_gc_root.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling spill GC regression tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+spill-gc-tests: $(SPILL_GC_TEST_BIN)
+	@echo "Running spill GC regression tests..."
+	@./$(SPILL_GC_TEST_BIN)
 
 $(INC_CMP_JMP_TEST_BIN): tests/unit/test_vm_inc_cmp_jmp.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/src/vm/spill_manager.c
+++ b/src/vm/spill_manager.c
@@ -202,12 +202,25 @@ bool unspill_register_value(SpillManager* manager, uint16_t register_id, Value* 
 // Remove spilled register
 void remove_spilled_register(SpillManager* manager, uint16_t register_id) {
     SpillEntry* entry = find_spill_entry(manager->entries, manager->capacity, register_id);
-    
+
     if (entry->register_id == register_id && !entry->is_tombstone) {
         entry->is_tombstone = true;
         entry->register_id = 0;
         manager->count--;
         manager->tombstones++;
+    }
+}
+
+void spill_manager_visit_entries(const SpillManager* manager, SpillEntryVisitor visitor, void* user_data) {
+    if (!manager || !visitor) {
+        return;
+    }
+
+    for (size_t i = 0; i < manager->capacity; i++) {
+        const SpillEntry* entry = &manager->entries[i];
+        if (entry->register_id != 0 && !entry->is_tombstone) {
+            visitor(entry->register_id, &entry->value, user_data);
+        }
     }
 }
 

--- a/tests/unit/test_vm_spill_gc_root.c
+++ b/tests/unit/test_vm_spill_gc_root.c
@@ -1,0 +1,76 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "runtime/memory.h"
+#include "vm/register_file.h"
+#include "vm/vm.h"
+
+static bool test_gc_marks_spilled_registers(void) {
+    initVM();
+
+    const char* text = "spilled-root-value";
+    ObjString* str = allocateString(text, (int)strlen(text));
+    uint16_t spill_id = allocate_spilled_register(&vm.register_file, STRING_VAL(str));
+
+    bool found_before = false;
+    for (Obj* obj = vm.objects; obj != NULL; obj = obj->next) {
+        if (obj == (Obj*)str) {
+            found_before = true;
+            break;
+        }
+    }
+
+    collectGarbage();
+
+    bool found_after = false;
+    for (Obj* obj = vm.objects; obj != NULL; obj = obj->next) {
+        if (obj == (Obj*)str) {
+            found_after = true;
+            break;
+        }
+    }
+
+    Value* slot = get_register(&vm.register_file, spill_id);
+    Value retrieved = slot ? *slot : BOOL_VAL(false);
+
+    bool success = found_before && found_after && slot != NULL && IS_STRING(retrieved) && AS_STRING(retrieved) == str;
+
+    if (!success) {
+        fprintf(stderr,
+                "GC spill root regression failed: before=%d after=%d slot=%p type=%d\n",
+                found_before,
+                found_after,
+                (void*)slot,
+                retrieved.type);
+    }
+
+    freeVM();
+    return success;
+}
+
+int main(void) {
+    struct {
+        const char* name;
+        bool (*fn)(void);
+    } tests[] = {
+        {"GC preserves spilled registers", test_gc_marks_spilled_registers},
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; i++) {
+        bool ok = tests[i].fn();
+        if (ok) {
+            printf("[PASS] %s\n", tests[i].name);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", tests[i].name);
+        }
+    }
+
+    printf("%d/%d Spill GC tests passed\n", passed, total);
+    return passed == total ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add an iterator callback to the spill manager so clients can traverse active spill slots without mutating them
- mark all spilled register values as roots during garbage collection
- add a regression test and wiring in the build that verifies spilled register values survive a GC cycle