### PR TITLE
Fix typed AST lifecycle leaks

### DIFF
--- a/include/compiler/typed_ast.h
+++ b/include/compiler/typed_ast.h
@@ -282,6 +282,7 @@ struct TypedASTNode {
 TypedASTNode* create_typed_ast_node(ASTNode* original);
 void free_typed_ast_node(TypedASTNode* node);
 TypedASTNode* copy_typed_ast_node(TypedASTNode* node);
+void typed_ast_release_orphans(void);
 
 // Type resolution functions
 bool resolve_node_type(TypedASTNode* node, TypeEnv* env);

--- a/src/type/type_inference.c
+++ b/src/type/type_inference.c
@@ -4829,6 +4829,7 @@ void cleanup_type_inference(void) {
         arena = next;
     }
     type_arena = NULL;
+    typed_ast_release_orphans();
 }
 
 Type* instantiate(Type* type, TypeInferer* inferer) {


### PR DESCRIPTION
## Summary
- add a registry for typed AST nodes so any orphaned allocations are released during cleanup
- free duplicated loop variable metadata when destroying typed AST nodes
- trigger the typed AST cleanup from the type inference shutdown path