### PR TITLE
Add print formatting runtime test and expand tutorial coverage

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -628,8 +628,10 @@ The Orus runtime ships with a rich set of built-ins so you can inspect values, g
 leaving the language. Built-ins behave like ordinary functions even though the VM implements them natively.
 
 - `print(...)` – statement form that writes the provided expressions separated by spaces and terminates with a newline. When the
-  first argument is a string literal you can embed `@` format specifiers like `@.2f`, `@x`, `@X`, `@b`, and `@o` to control how
-  the following value is rendered.
+  first argument is a string literal you can embed `@` format specifiers to control how the following value is rendered. Use
+  bare `@` for default rendering, `@.Nf` for fixed precision floats, and `@x` / `@X` / `@b` / `@o` for hexadecimal (lower/upper),
+  binary, and octal output. Combine as many specifiers as needed within the string; they consume arguments from left to right.
+  Write `@@` (or any specifier without a corresponding argument) to emit a literal `@` sequence in the output.
 - `len(array_or_string)` – returns the number of elements in an array or the number of bytes in a string.
 - `push(array, value)` / `pop(array)` – append to or remove from dynamic arrays.
 - `sorted(array)` – produces a new array whose elements are sorted without mutating the original.
@@ -645,6 +647,10 @@ leaving the language. Built-ins behave like ordinary functions even though the V
 ```orus
 pi = 3.14159
 print("Pi ~= @.2f", pi)
+
+value = 255
+print("formats -> dec=@ hex=@x HEX=@X bin=@b oct=@o", value, value, value, value, value)
+print("pi precise: @.4f trailing", pi)
 
 mut values: [i32] = []
 push(values, 3)

--- a/tests/builtins/print_format_runtime.orus
+++ b/tests/builtins/print_format_runtime.orus
@@ -1,0 +1,27 @@
+// Runtime exercise of print() formatting with @ specifiers.
+print("== print formatting ==")
+
+value = 255
+print("default decimal: @", value)
+print("binary: @b", value)
+print("octal: @o", value)
+print("hex lower: @x", value)
+print("hex upper: @X", value)
+
+mixed = 42
+print("mixed formats -> dec=@ hex=@x bin=@b", mixed, mixed, mixed)
+
+negative = -17
+print("negative default: @", negative)
+print("negative hex: @x", negative)
+
+pi = 3.1415926535
+print("float default: @", pi)
+print("float 0 decimals: @.0f", pi)
+print("float 3 decimals: @.3f", pi)
+print("float 6 decimals: @.6f", pi)
+
+print("literal @ without args: @@")
+print("literal spec sequence: @.2f shown with no value")
+
+print("== print formatting done ==")

--- a/tests/builtins/timestamp_runtime.orus
+++ b/tests/builtins/timestamp_runtime.orus
@@ -1,0 +1,27 @@
+// Demonstrate runtime usage of the timestamp() builtin.
+print("== timestamp builtin ==")
+
+start = timestamp()
+mut counter = 0
+while counter < 100_000:
+    counter += 1
+finish = timestamp()
+
+if finish >= start:
+    print("monotonic", true)
+else:
+    print("monotonic", false)
+
+elapsed = finish - start
+
+if elapsed >= 0.0:
+    print("elapsed", elapsed)
+else:
+    print("elapsed", -1.0)
+
+if istype(elapsed, "f64"):
+    print("elapsed type", typeof(elapsed))
+else:
+    print("elapsed type", "unexpected")
+
+print("== timestamp builtin done ==")

--- a/tests/builtins/type_inspection_runtime.orus
+++ b/tests/builtins/type_inspection_runtime.orus
@@ -1,0 +1,43 @@
+// Runtime checks for typeof() and istype() builtins.
+print("== runtime type inspection ==")
+
+fn check_type(label: string, value, expected: string):
+    actual = typeof(value)
+    if actual == expected:
+        print(label, "typeof ok", actual)
+    else:
+        print(label, "typeof mismatch", actual)
+    if istype(value, expected):
+        print(label, "istype ok")
+    else:
+        print(label, "istype mismatch")
+
+check_type("bool", true, "bool")
+check_type("i32", 42, "i32")
+check_type("f64", 3.25, "f64")
+check_type("string", "orus", "string")
+check_type("array", [1, 2, 3], "array")
+
+struct Point:
+    x: i32
+    y: i32
+
+point = Point{ x: 3, y: 4 }
+check_type("struct", point, "Point")
+
+enum Example:
+    Unit
+    Value(data: i32)
+
+check_type("enum unit", Example.Unit, "Example")
+check_type("enum payload", Example.Value(7), "Example")
+
+inner = typeof(99)
+check_type("typeof result", inner, "string")
+
+if istype(Example.Unit, "no-match"):
+    print("unexpected match", true)
+else:
+    print("no-match", false)
+
+print("== runtime type inspection done ==")


### PR DESCRIPTION
## Summary
- add a builtin runtime test that exercises print() @ format specifiers and literal escapes
- expand the tutorial explanation of string formatting with additional guidance and examples