### PR TITLE
Preserve typed register caches across frame swaps

### DIFF
--- a/include/vm/vm_comparison.h
+++ b/include/vm/vm_comparison.h
@@ -13,14 +13,11 @@
 #include "../../src/vm/core/vm_internal.h"
 #include "vm/register_file.h"
 
-#define VM_TYPED_REGISTER_LIMIT \
-    ((uint16_t)(sizeof(((TypedRegisters*)0)->i32_regs) / sizeof(int32_t)))
+#define VM_TYPED_REGISTER_LIMIT ((uint16_t)TYPED_REGISTER_WINDOW_SIZE)
 
 // Frame-aware register access helpers shared across dispatch implementations
 
-static inline uint16_t vm_typed_register_capacity(void) {
-    return (uint16_t)(sizeof(vm.typed_regs.i32_regs) / sizeof(vm.typed_regs.i32_regs[0]));
-}
+static inline uint16_t vm_typed_register_capacity(void) { return VM_TYPED_REGISTER_LIMIT; }
 
 static inline bool vm_typed_reg_in_range(uint16_t id) {
     return id < VM_TYPED_REGISTER_LIMIT;

--- a/src/vm/core/vm_core.c
+++ b/src/vm/core/vm_core.c
@@ -41,12 +41,26 @@ void initVM(void) {
     }
 
     memset(&vm.typed_regs, 0, sizeof(TypedRegisters));
-    for (int i = 0; i < 32; i++) {
-        vm.typed_regs.heap_regs[i] = BOOL_VAL(false); // Default value instead of NIL_VAL
+    memset(&vm.typed_regs.root_window, 0, sizeof(TypedRegisterWindow));
+    for (int i = 0; i < TYPED_REGISTER_WINDOW_SIZE; i++) {
+        vm.typed_regs.root_window.heap_regs[i] = BOOL_VAL(false);
+        vm.typed_regs.root_window.reg_types[i] = REG_TYPE_NONE;
+        vm.typed_regs.root_window.dirty[i] = false;
     }
-    for (int i = 0; i < 256; i++) {
-        vm.typed_regs.reg_types[i] = REG_TYPE_NONE;
-    }
+    vm.typed_regs.root_window.next = NULL;
+    vm.typed_regs.active_window = &vm.typed_regs.root_window;
+    vm.typed_regs.free_windows = NULL;
+    vm.typed_regs.window_version = 0;
+    vm.typed_regs.active_depth = 0;
+    vm.typed_regs.i32_regs = vm.typed_regs.root_window.i32_regs;
+    vm.typed_regs.i64_regs = vm.typed_regs.root_window.i64_regs;
+    vm.typed_regs.u32_regs = vm.typed_regs.root_window.u32_regs;
+    vm.typed_regs.u64_regs = vm.typed_regs.root_window.u64_regs;
+    vm.typed_regs.f64_regs = vm.typed_regs.root_window.f64_regs;
+    vm.typed_regs.bool_regs = vm.typed_regs.root_window.bool_regs;
+    vm.typed_regs.heap_regs = vm.typed_regs.root_window.heap_regs;
+    vm.typed_regs.dirty = vm.typed_regs.root_window.dirty;
+    vm.typed_regs.reg_types = vm.typed_regs.root_window.reg_types;
     for (int i = 0; i < UINT8_COUNT; i++) {
         vm.globals[i] = BOOL_VAL(false); // Default value instead of NIL_VAL
         vm.globalTypes[i] = NULL;

--- a/src/vm/core/vm_memory.c
+++ b/src/vm/core/vm_memory.c
@@ -355,6 +355,18 @@ static void mark_spill_entry(uint16_t register_id, Value* value, void* user_data
     }
 }
 
+static void mark_typed_window(TypedRegisterWindow* window) {
+    if (!window) {
+        return;
+    }
+
+    for (int i = 0; i < TYPED_REGISTER_WINDOW_SIZE; i++) {
+        if (window->reg_types[i] == REG_TYPE_HEAP) {
+            markValue(window->heap_regs[i]);
+        }
+    }
+}
+
 static void markRoots() {
     for (int i = 0; i < REGISTER_COUNT; i++) {
         markValue(vm.registers[i]);
@@ -368,7 +380,10 @@ static void markRoots() {
         for (int i = 0; i < TEMP_REGISTERS; i++) {
             markValue(frame->temps[i]);
         }
+        mark_typed_window(frame->typed_window);
     }
+
+    mark_typed_window(&vm.typed_regs.root_window);
 
     // Mark temporary registers for the root context when no frame is active.
     for (int i = 0; i < TEMP_REGISTERS; i++) {

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -1003,7 +1003,7 @@ InterpretResult vm_run_dispatch(void) {
 
     LABEL_OP_DEC_I32_R: {
             uint8_t reg = READ_BYTE();
-            const uint8_t typed_limit = (uint8_t)(sizeof(vm.typed_regs.i32_regs) / sizeof(vm.typed_regs.i32_regs[0]));
+            const uint8_t typed_limit = (uint8_t)TYPED_REGISTER_WINDOW_SIZE;
 
             if (reg < typed_limit && vm.typed_regs.reg_types[reg] == REG_TYPE_I32) {
     #if USE_FAST_ARITH

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -542,7 +542,7 @@ InterpretResult vm_run_dispatch(void) {
 
                 case OP_DEC_I32_R: {
                     uint8_t reg = READ_BYTE();
-                    const uint8_t typed_limit = (uint8_t)(sizeof(vm.typed_regs.i32_regs) / sizeof(vm.typed_regs.i32_regs[0]));
+                    const uint8_t typed_limit = (uint8_t)TYPED_REGISTER_WINDOW_SIZE;
 
                     if (reg < typed_limit && vm.typed_regs.reg_types[reg] == REG_TYPE_I32) {
     #if USE_FAST_ARITH

--- a/src/vm/register_file.c
+++ b/src/vm/register_file.c
@@ -22,128 +22,111 @@
 bool is_spilled_register(uint16_t id);
 bool is_module_register(uint16_t id);
 
+static void typed_window_reset(TypedRegisterWindow* window) {
+    if (!window) {
+        return;
+    }
+
+    memset(window, 0, sizeof(*window));
+    for (uint16_t i = 0; i < TYPED_REGISTER_WINDOW_SIZE; ++i) {
+        window->heap_regs[i] = BOOL_VAL(false);
+        window->reg_types[i] = REG_TYPE_NONE;
+        window->dirty[i] = false;
+    }
+    window->next = NULL;
+}
+
+static void typed_window_copy_slot(TypedRegisterWindow* dst, const TypedRegisterWindow* src, uint16_t index) {
+    dst->i32_regs[index] = src->i32_regs[index];
+    dst->i64_regs[index] = src->i64_regs[index];
+    dst->u32_regs[index] = src->u32_regs[index];
+    dst->u64_regs[index] = src->u64_regs[index];
+    dst->f64_regs[index] = src->f64_regs[index];
+    dst->bool_regs[index] = src->bool_regs[index];
+    dst->heap_regs[index] = src->heap_regs[index];
+    dst->reg_types[index] = src->reg_types[index];
+    dst->dirty[index] = src->dirty[index];
+}
+
+static void typed_window_sync_shared_ranges(TypedRegisterWindow* dst, const TypedRegisterWindow* src) {
+    if (!dst || !src) {
+        return;
+    }
+
+    for (uint16_t i = 0; i < FRAME_REG_START && i < TYPED_REGISTER_WINDOW_SIZE; ++i) {
+        typed_window_copy_slot(dst, src, i);
+    }
+
+    uint16_t module_end = MODULE_REG_START + MODULE_REGISTERS;
+    if (MODULE_REG_START < TYPED_REGISTER_WINDOW_SIZE) {
+        if (module_end > TYPED_REGISTER_WINDOW_SIZE) {
+            module_end = TYPED_REGISTER_WINDOW_SIZE;
+        }
+        for (uint16_t i = MODULE_REG_START; i < module_end; ++i) {
+            typed_window_copy_slot(dst, src, i);
+        }
+    }
+}
+
+static void typed_registers_bind_window(TypedRegisterWindow* window) {
+    if (!window) {
+        window = &vm.typed_regs.root_window;
+    }
+
+    vm.typed_regs.active_window = window;
+    vm.typed_regs.i32_regs = window->i32_regs;
+    vm.typed_regs.i64_regs = window->i64_regs;
+    vm.typed_regs.u32_regs = window->u32_regs;
+    vm.typed_regs.u64_regs = window->u64_regs;
+    vm.typed_regs.f64_regs = window->f64_regs;
+    vm.typed_regs.bool_regs = window->bool_regs;
+    vm.typed_regs.heap_regs = window->heap_regs;
+    vm.typed_regs.dirty = window->dirty;
+    vm.typed_regs.reg_types = window->reg_types;
+}
+
+static TypedRegisterWindow* typed_registers_acquire_window(void) {
+    TypedRegisterWindow* window = vm.typed_regs.free_windows;
+    if (window) {
+        vm.typed_regs.free_windows = window->next;
+    } else {
+        window = (TypedRegisterWindow*)malloc(sizeof(TypedRegisterWindow));
+        if (!window) {
+            return NULL;
+        }
+    }
+
+    typed_window_reset(window);
+    return window;
+}
+
+static void typed_registers_release_window(TypedRegisterWindow* window) {
+    if (!window) {
+        return;
+    }
+
+    typed_window_reset(window);
+    window->next = vm.typed_regs.free_windows;
+    vm.typed_regs.free_windows = window;
+}
+
 static void clear_typed_frame_registers(void) {
-    uint16_t capacity = (uint16_t)(sizeof(vm.typed_regs.reg_types) /
-                                   sizeof(vm.typed_regs.reg_types[0]));
-
-    uint16_t frame_end = FRAME_REG_START + FRAME_REGISTERS;
-    if (frame_end > capacity) {
-        frame_end = capacity;
-    }
-    for (uint16_t id = FRAME_REG_START; id < frame_end; ++id) {
-        switch (vm.typed_regs.reg_types[id]) {
-            case REG_TYPE_I32:
-                vm.typed_regs.i32_regs[id] = 0;
-                break;
-            case REG_TYPE_I64:
-                vm.typed_regs.i64_regs[id] = 0;
-                break;
-            case REG_TYPE_U32:
-                vm.typed_regs.u32_regs[id] = 0;
-                break;
-            case REG_TYPE_U64:
-                vm.typed_regs.u64_regs[id] = 0;
-                break;
-            case REG_TYPE_F64:
-                vm.typed_regs.f64_regs[id] = 0.0;
-                break;
-            case REG_TYPE_BOOL:
-                vm.typed_regs.bool_regs[id] = false;
-                break;
-            default:
-                break;
-        }
-        vm.typed_regs.reg_types[id] = REG_TYPE_NONE;
-        vm.typed_regs.dirty[id] = false;
+    TypedRegisterWindow* window = vm.typed_regs.active_window;
+    if (!window) {
+        return;
     }
 
-    uint16_t temp_end = TEMP_REG_START + TEMP_REGISTERS;
-    if (temp_end > capacity) {
-        temp_end = capacity;
-    }
-    for (uint16_t id = TEMP_REG_START; id < temp_end; ++id) {
-        switch (vm.typed_regs.reg_types[id]) {
-            case REG_TYPE_I32:
-                vm.typed_regs.i32_regs[id] = 0;
-                break;
-            case REG_TYPE_I64:
-                vm.typed_regs.i64_regs[id] = 0;
-                break;
-            case REG_TYPE_U32:
-                vm.typed_regs.u32_regs[id] = 0;
-                break;
-            case REG_TYPE_U64:
-                vm.typed_regs.u64_regs[id] = 0;
-                break;
-            case REG_TYPE_F64:
-                vm.typed_regs.f64_regs[id] = 0.0;
-                break;
-            case REG_TYPE_BOOL:
-                vm.typed_regs.bool_regs[id] = false;
-                break;
-            default:
-                break;
-        }
-        vm.typed_regs.reg_types[id] = REG_TYPE_NONE;
-        vm.typed_regs.dirty[id] = false;
-    }
-}
-
-static void snapshot_typed_frame_state(CallFrame* frame) {
-    for (uint16_t idx = 0; idx < FRAME_REGISTERS; ++idx) {
-        uint16_t reg_id = FRAME_REG_START + idx;
-        frame->saved_i32[idx] = vm.typed_regs.i32_regs[reg_id];
-        frame->saved_i64[idx] = vm.typed_regs.i64_regs[reg_id];
-        frame->saved_u32[idx] = vm.typed_regs.u32_regs[reg_id];
-        frame->saved_u64[idx] = vm.typed_regs.u64_regs[reg_id];
-        frame->saved_f64[idx] = vm.typed_regs.f64_regs[reg_id];
-        frame->saved_bool[idx] = vm.typed_regs.bool_regs[reg_id];
-        frame->saved_heap[idx] = vm.typed_regs.heap_regs[reg_id];
-        frame->saved_types[idx] = vm.typed_regs.reg_types[reg_id];
-        frame->saved_dirty[idx] = vm.typed_regs.dirty[reg_id];
-    }
-
-    for (uint16_t idx = 0; idx < TEMP_REGISTERS; ++idx) {
-        uint16_t offset = FRAME_REGISTERS + idx;
-        uint16_t reg_id = TEMP_REG_START + idx;
-        frame->saved_i32[offset] = vm.typed_regs.i32_regs[reg_id];
-        frame->saved_i64[offset] = vm.typed_regs.i64_regs[reg_id];
-        frame->saved_u32[offset] = vm.typed_regs.u32_regs[reg_id];
-        frame->saved_u64[offset] = vm.typed_regs.u64_regs[reg_id];
-        frame->saved_f64[offset] = vm.typed_regs.f64_regs[reg_id];
-        frame->saved_bool[offset] = vm.typed_regs.bool_regs[reg_id];
-        frame->saved_heap[offset] = vm.typed_regs.heap_regs[reg_id];
-        frame->saved_types[offset] = vm.typed_regs.reg_types[reg_id];
-        frame->saved_dirty[offset] = vm.typed_regs.dirty[reg_id];
-    }
-}
-
-static void restore_typed_frame_state(const CallFrame* frame) {
-    for (uint16_t idx = 0; idx < FRAME_REGISTERS; ++idx) {
-        uint16_t reg_id = FRAME_REG_START + idx;
-        vm.typed_regs.i32_regs[reg_id] = frame->saved_i32[idx];
-        vm.typed_regs.i64_regs[reg_id] = frame->saved_i64[idx];
-        vm.typed_regs.u32_regs[reg_id] = frame->saved_u32[idx];
-        vm.typed_regs.u64_regs[reg_id] = frame->saved_u64[idx];
-        vm.typed_regs.f64_regs[reg_id] = frame->saved_f64[idx];
-        vm.typed_regs.bool_regs[reg_id] = frame->saved_bool[idx];
-        vm.typed_regs.heap_regs[reg_id] = frame->saved_heap[idx];
-        vm.typed_regs.reg_types[reg_id] = frame->saved_types[idx];
-        vm.typed_regs.dirty[reg_id] = frame->saved_dirty[idx];
-    }
-
-    for (uint16_t idx = 0; idx < TEMP_REGISTERS; ++idx) {
-        uint16_t offset = FRAME_REGISTERS + idx;
-        uint16_t reg_id = TEMP_REG_START + idx;
-        vm.typed_regs.i32_regs[reg_id] = frame->saved_i32[offset];
-        vm.typed_regs.i64_regs[reg_id] = frame->saved_i64[offset];
-        vm.typed_regs.u32_regs[reg_id] = frame->saved_u32[offset];
-        vm.typed_regs.u64_regs[reg_id] = frame->saved_u64[offset];
-        vm.typed_regs.f64_regs[reg_id] = frame->saved_f64[offset];
-        vm.typed_regs.bool_regs[reg_id] = frame->saved_bool[offset];
-        vm.typed_regs.heap_regs[reg_id] = frame->saved_heap[offset];
-        vm.typed_regs.reg_types[reg_id] = frame->saved_types[offset];
-        vm.typed_regs.dirty[reg_id] = frame->saved_dirty[offset];
+    uint16_t limit = MODULE_REG_START < TYPED_REGISTER_WINDOW_SIZE ? MODULE_REG_START : TYPED_REGISTER_WINDOW_SIZE;
+    for (uint16_t i = FRAME_REG_START; i < limit; ++i) {
+        window->i32_regs[i] = 0;
+        window->i64_regs[i] = 0;
+        window->u32_regs[i] = 0;
+        window->u64_regs[i] = 0;
+        window->f64_regs[i] = 0.0;
+        window->bool_regs[i] = false;
+        window->heap_regs[i] = BOOL_VAL(false);
+        window->reg_types[i] = REG_TYPE_NONE;
+        window->dirty[i] = false;
     }
 }
 
@@ -293,7 +276,6 @@ CallFrame* allocate_frame(RegisterFile* rf) {
     memset(frame, 0, sizeof(CallFrame));
 
     frame->parent = rf->current_frame;
-    frame->next = rf->frame_stack;
     frame->frame_base = FRAME_REG_START;
     frame->temp_base = TEMP_REG_START;
     frame->temp_count = TEMP_REGISTERS;
@@ -309,13 +291,28 @@ CallFrame* allocate_frame(RegisterFile* rf) {
     frame->resultRegister = FRAME_REG_START;
     frame->parameterBaseRegister = FRAME_REG_START;
     frame->functionIndex = UINT16_MAX;
-    
+
+    TypedRegisterWindow* parent_window =
+        vm.typed_regs.active_window ? vm.typed_regs.active_window : &vm.typed_regs.root_window;
+    TypedRegisterWindow* new_window = typed_registers_acquire_window();
+    if (!new_window) {
+        free(frame);
+        return NULL;
+    }
+
+    typed_window_sync_shared_ranges(new_window, parent_window);
+    frame->typed_window = new_window;
+    frame->previous_typed_window = parent_window;
+    frame->typed_window_version = ++vm.typed_regs.window_version;
+
     // Update register file
+    frame->next = rf->frame_stack;
     rf->frame_stack = frame;
     rf->current_frame = frame;
     rf->temps = frame->temps;
 
-    snapshot_typed_frame_state(frame);
+    typed_registers_bind_window(new_window);
+    vm.typed_regs.active_depth++;
     clear_typed_frame_registers();
 
     return frame;
@@ -326,7 +323,16 @@ void deallocate_frame(RegisterFile* rf) {
 
     CallFrame* frame = rf->current_frame;
 
-    restore_typed_frame_state(frame);
+    TypedRegisterWindow* parent_window =
+        frame->previous_typed_window ? frame->previous_typed_window : &vm.typed_regs.root_window;
+    TypedRegisterWindow* window_to_release = frame->typed_window;
+
+    typed_window_sync_shared_ranges(parent_window, window_to_release);
+    typed_registers_bind_window(parent_window);
+    if (vm.typed_regs.active_depth > 0) {
+        vm.typed_regs.active_depth--;
+    }
+    typed_registers_release_window(window_to_release);
 
     // Update register file
     rf->current_frame = frame->parent;
@@ -389,11 +395,21 @@ void free_register_file(RegisterFile* rf) {
         free_register_cache(rf->cache);
         rf->cache = NULL;
     }
-    
+
     if (rf->metadata) {
         free(rf->metadata);
         rf->metadata = NULL;
     }
+
+    TypedRegisterWindow* window = vm.typed_regs.free_windows;
+    while (window) {
+        TypedRegisterWindow* next = window->next;
+        free(window);
+        window = next;
+    }
+    vm.typed_regs.free_windows = NULL;
+    typed_registers_bind_window(&vm.typed_regs.root_window);
+    vm.typed_regs.active_depth = 0;
 }
 
 // Frame register allocation for compiler

--- a/tests/unit/test_vm_typed_registers.c
+++ b/tests/unit/test_vm_typed_registers.c
@@ -4,6 +4,7 @@
 #include "vm/vm.h"
 #include "vm/vm_comparison.h"
 #include "vm/vm_dispatch.h"
+#include "vm/register_file.h"
 #include "runtime/memory.h"
 
 #define ASSERT_TRUE(cond, message)                                                         \
@@ -236,12 +237,85 @@ static bool test_array_iterator_preserves_typed_loop_variable(void) {
     return true;
 }
 
+static bool test_nested_frames_preserve_typed_windows(void) {
+    initVM();
+
+    CallFrame* parent = allocate_frame(&vm.register_file);
+    ASSERT_TRUE(parent != NULL, "allocate_frame should return parent frame");
+
+    const uint16_t reg = FRAME_REG_START;
+    vm_store_i64_typed_hot(reg, 17);
+    ASSERT_TRUE(parent->typed_window != NULL, "Parent frame should own typed window");
+    ASSERT_TRUE(parent->typed_window->i64_regs[reg] == 17,
+                "Parent typed window should capture initial value");
+
+    CallFrame* child = allocate_frame(&vm.register_file);
+    ASSERT_TRUE(child != NULL, "allocate_frame should return child frame");
+    ASSERT_TRUE(child->typed_window != parent->typed_window,
+                "Child frame should receive distinct typed window");
+
+    vm_store_i64_typed_hot(reg, 99);
+    ASSERT_TRUE(vm.typed_regs.i64_regs[reg] == 99,
+                "Active typed window should reflect child writes");
+    ASSERT_TRUE(parent->typed_window->i64_regs[reg] == 17,
+                "Parent typed window should remain untouched during child execution");
+
+    deallocate_frame(&vm.register_file);
+    ASSERT_TRUE(vm.typed_regs.i64_regs[reg] == 17,
+                "Restoring parent frame should reactivate original typed payload");
+
+    deallocate_frame(&vm.register_file);
+    freeVM();
+    return true;
+}
+
+static bool test_global_typed_state_propagates_across_frames(void) {
+    initVM();
+
+    vm_store_i64_typed_hot(0, 11);
+    ASSERT_TRUE(vm.typed_regs.i64_regs[0] == 11,
+                "Root window should capture initial global value");
+
+    CallFrame* parent = allocate_frame(&vm.register_file);
+    ASSERT_TRUE(parent != NULL, "allocate_frame should produce parent frame");
+
+    vm_store_i64_typed_hot(0, 22);
+    ASSERT_TRUE(parent->typed_window->i64_regs[0] == 22,
+                "Parent window should observe updated global value");
+
+    CallFrame* child = allocate_frame(&vm.register_file);
+    ASSERT_TRUE(child != NULL, "allocate_frame should produce child frame");
+
+    vm_store_i64_typed_hot(0, 33);
+    ASSERT_TRUE(vm.typed_regs.i64_regs[0] == 33,
+                "Active child window should observe latest global write");
+
+    deallocate_frame(&vm.register_file);
+    ASSERT_TRUE(vm.typed_regs.i64_regs[0] == 33,
+                "Parent window should inherit child global writes");
+    ASSERT_TRUE(parent->typed_window->i64_regs[0] == 33,
+                "Parent typed cache should match propagated value");
+    ASSERT_TRUE(IS_I64(vm.register_file.globals[0]) && AS_I64(vm.register_file.globals[0]) == 33,
+                "Register file globals should store propagated value");
+
+    deallocate_frame(&vm.register_file);
+    ASSERT_TRUE(vm.typed_regs.root_window.i64_regs[0] == 33,
+                "Root window should retain latest global value after unwinding");
+    ASSERT_TRUE(IS_I64(vm.registers[0]) && AS_I64(vm.registers[0]) == 33,
+                "Mirror register array should reflect propagated global value");
+
+    freeVM();
+    return true;
+}
+
 int main(void) {
     bool (*tests[])(void) = {
         test_typed_register_deferred_boxing_flushes_on_read,
         test_typed_register_flushes_for_open_upvalue,
         test_range_iterator_uses_typed_registers,
         test_array_iterator_preserves_typed_loop_variable,
+        test_nested_frames_preserve_typed_windows,
+        test_global_typed_state_propagates_across_frames,
     };
 
     const char* names[] = {
@@ -249,6 +323,8 @@ int main(void) {
         "Open upvalues force boxed synchronization",
         "Range iterators keep loop variable typed",
         "Array iterators keep loop variable typed",
+        "Nested frames reuse typed windows without copying",
+        "Global typed state propagates across frames",
     };
 
     int passed = 0;


### PR DESCRIPTION
## Summary
- copy shared global and module slots between typed register windows when allocating or destroying frames
- limit typed-frame clearing to local ranges so shared caches stay intact across window swaps
- add a regression test ensuring global typed state survives nested frame calls