### PR TITLE
Fix tail-call register window reuse

### DIFF
--- a/include/vm/register_file.h
+++ b/include/vm/register_file.h
@@ -31,6 +31,8 @@ void set_register(RegisterFile* rf, uint16_t id, Value value);
 // Phase 1: Frame management functions
 CallFrame* allocate_frame(RegisterFile* rf);
 void deallocate_frame(RegisterFile* rf);
+void register_file_clear_active_typed_frame(void);
+void register_file_reset_active_frame_storage(void);
 
 // Phase 1: Register type checking
 bool is_global_register(uint16_t id);

--- a/include/vm/vm_comparison.h
+++ b/include/vm/vm_comparison.h
@@ -13,14 +13,11 @@
 #include "../../src/vm/core/vm_internal.h"
 #include "vm/register_file.h"
 
-#define VM_TYPED_REGISTER_LIMIT \
-    ((uint16_t)(sizeof(((TypedRegisters*)0)->i32_regs) / sizeof(int32_t)))
+#define VM_TYPED_REGISTER_LIMIT ((uint16_t)TYPED_REGISTER_WINDOW_SIZE)
 
 // Frame-aware register access helpers shared across dispatch implementations
 
-static inline uint16_t vm_typed_register_capacity(void) {
-    return (uint16_t)(sizeof(vm.typed_regs.i32_regs) / sizeof(vm.typed_regs.i32_regs[0]));
-}
+static inline uint16_t vm_typed_register_capacity(void) { return VM_TYPED_REGISTER_LIMIT; }
 
 static inline bool vm_typed_reg_in_range(uint16_t id) {
     return id < VM_TYPED_REGISTER_LIMIT;

--- a/makefile
+++ b/makefile
@@ -250,6 +250,7 @@ FUSED_WHILE_TEST_BIN = $(BUILDDIR)/tests/test_codegen_fused_while
 PEEPHOLE_TEST_BIN = $(BUILDDIR)/tests/test_constant_propagation
 TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
 TYPED_REGISTER_TEST_BIN = $(BUILDDIR)/tests/test_vm_typed_registers
+REGISTER_WINDOW_TEST_BIN = $(BUILDDIR)/tests/test_vm_register_windows
 SPILL_GC_TEST_BIN = $(BUILDDIR)/tests/test_vm_spill_gc_root
 REGISTER_ALLOCATOR_TEST_BIN = $(BUILDDIR)/tests/test_register_allocator
 INC_CMP_JMP_TEST_BIN = $(BUILDDIR)/tests/test_vm_inc_cmp_jmp
@@ -270,7 +271,7 @@ BUILTIN_RANGE_ORUS_FAIL_TESTS = \
     tests/builtins/range_float_step.orus \
     tests/builtins/range_overflow_stop.orus
 
-.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests fused-while-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests spill-gc-tests inc-cmp-jmp-tests add-i32-imm-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
+.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests fused-while-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests register-window-tests spill-gc-tests inc-cmp-jmp-tests add-i32-imm-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
 
 all: build-info $(ORUS)
 
@@ -443,6 +444,9 @@ _test-run: $(ORUS)
 	@echo "\033[36m=== Typed Register Tests ===\033[0m"
 	@$(MAKE) typed-register-tests
 	@echo ""
+	@echo "\033[36m=== Register Window Tests ===\033[0m"
+	@$(MAKE) register-window-tests
+	@echo ""
 	@echo "\033[36m=== Spill GC Tests ===\033[0m"
 	@$(MAKE) spill-gc-tests
 	@echo ""
@@ -559,6 +563,15 @@ $(TYPED_REGISTER_TEST_BIN): tests/unit/test_vm_typed_registers.c $(COMPILER_OBJS
 typed-register-tests: $(TYPED_REGISTER_TEST_BIN)
 	@echo "Running typed register coherence tests..."
 	@./$(TYPED_REGISTER_TEST_BIN)
+
+$(REGISTER_WINDOW_TEST_BIN): tests/unit/test_vm_register_windows.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling register window reuse tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+register-window-tests: $(REGISTER_WINDOW_TEST_BIN)
+	@echo "Running register window reuse tests..."
+	@./$(REGISTER_WINDOW_TEST_BIN)
 
 $(SPILL_GC_TEST_BIN): tests/unit/test_vm_spill_gc_root.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/src/vm/core/vm_core.c
+++ b/src/vm/core/vm_core.c
@@ -41,12 +41,26 @@ void initVM(void) {
     }
 
     memset(&vm.typed_regs, 0, sizeof(TypedRegisters));
-    for (int i = 0; i < 32; i++) {
-        vm.typed_regs.heap_regs[i] = BOOL_VAL(false); // Default value instead of NIL_VAL
+    memset(&vm.typed_regs.root_window, 0, sizeof(TypedRegisterWindow));
+    for (int i = 0; i < TYPED_REGISTER_WINDOW_SIZE; i++) {
+        vm.typed_regs.root_window.heap_regs[i] = BOOL_VAL(false);
+        vm.typed_regs.root_window.reg_types[i] = REG_TYPE_NONE;
+        vm.typed_regs.root_window.dirty[i] = false;
     }
-    for (int i = 0; i < 256; i++) {
-        vm.typed_regs.reg_types[i] = REG_TYPE_NONE;
-    }
+    vm.typed_regs.root_window.next = NULL;
+    vm.typed_regs.active_window = &vm.typed_regs.root_window;
+    vm.typed_regs.free_windows = NULL;
+    vm.typed_regs.window_version = 0;
+    vm.typed_regs.active_depth = 0;
+    vm.typed_regs.i32_regs = vm.typed_regs.root_window.i32_regs;
+    vm.typed_regs.i64_regs = vm.typed_regs.root_window.i64_regs;
+    vm.typed_regs.u32_regs = vm.typed_regs.root_window.u32_regs;
+    vm.typed_regs.u64_regs = vm.typed_regs.root_window.u64_regs;
+    vm.typed_regs.f64_regs = vm.typed_regs.root_window.f64_regs;
+    vm.typed_regs.bool_regs = vm.typed_regs.root_window.bool_regs;
+    vm.typed_regs.heap_regs = vm.typed_regs.root_window.heap_regs;
+    vm.typed_regs.dirty = vm.typed_regs.root_window.dirty;
+    vm.typed_regs.reg_types = vm.typed_regs.root_window.reg_types;
     for (int i = 0; i < UINT8_COUNT; i++) {
         vm.globals[i] = BOOL_VAL(false); // Default value instead of NIL_VAL
         vm.globalTypes[i] = NULL;

--- a/src/vm/core/vm_memory.c
+++ b/src/vm/core/vm_memory.c
@@ -355,6 +355,18 @@ static void mark_spill_entry(uint16_t register_id, Value* value, void* user_data
     }
 }
 
+static void mark_typed_window(TypedRegisterWindow* window) {
+    if (!window) {
+        return;
+    }
+
+    for (int i = 0; i < TYPED_REGISTER_WINDOW_SIZE; i++) {
+        if (window->reg_types[i] == REG_TYPE_HEAP) {
+            markValue(window->heap_regs[i]);
+        }
+    }
+}
+
 static void markRoots() {
     for (int i = 0; i < REGISTER_COUNT; i++) {
         markValue(vm.registers[i]);
@@ -368,7 +380,10 @@ static void markRoots() {
         for (int i = 0; i < TEMP_REGISTERS; i++) {
             markValue(frame->temps[i]);
         }
+        mark_typed_window(frame->typed_window);
     }
+
+    mark_typed_window(&vm.typed_regs.root_window);
 
     // Mark temporary registers for the root context when no frame is active.
     for (int i = 0; i < TEMP_REGISTERS; i++) {

--- a/src/vm/dispatch/vm_dispatch_goto.c
+++ b/src/vm/dispatch/vm_dispatch_goto.c
@@ -1003,7 +1003,7 @@ InterpretResult vm_run_dispatch(void) {
 
     LABEL_OP_DEC_I32_R: {
             uint8_t reg = READ_BYTE();
-            const uint8_t typed_limit = (uint8_t)(sizeof(vm.typed_regs.i32_regs) / sizeof(vm.typed_regs.i32_regs[0]));
+            const uint8_t typed_limit = (uint8_t)TYPED_REGISTER_WINDOW_SIZE;
 
             if (reg < typed_limit && vm.typed_regs.reg_types[reg] == REG_TYPE_I32) {
     #if USE_FAST_ARITH
@@ -3087,7 +3087,98 @@ InterpretResult vm_run_dispatch(void) {
 
             Value funcValue = vm_get_register_safe(funcReg);
 
-            if (IS_I32(funcValue)) {
+            if (IS_CLOSURE(funcValue)) {
+                ObjClosure* closure = AS_CLOSURE(funcValue);
+                ObjFunction* function = closure->function;
+
+                if (argCount != function->arity) {
+                    vm_set_register_safe(resultReg, BOOL_VAL(false));
+                    DISPATCH();
+                }
+
+                Value tempArgs[FRAME_REGISTERS];
+                for (int i = 0; i < argCount; i++) {
+                    tempArgs[i] = vm_get_register_safe((uint16_t)(firstArgReg + i));
+                }
+
+                uint16_t paramBase = calculateParameterBaseRegister(function->arity);
+
+                CallFrame* window = vm.register_file.current_frame;
+                if (!window) {
+                    vm_set_register_safe(resultReg, BOOL_VAL(false));
+                    DISPATCH();
+                }
+
+                window->parameterBaseRegister = paramBase;
+                window->resultRegister = resultReg;
+                window->functionIndex = UINT16_MAX;
+                window->register_count = argCount;
+
+                if (vm.frameCount > 0) {
+                    CallFrame* frame = &vm.frames[vm.frameCount - 1];
+                    frame->parameterBaseRegister = paramBase;
+                    frame->resultRegister = resultReg;
+                    frame->functionIndex = UINT16_MAX;
+                    frame->register_count = argCount;
+                }
+
+                register_file_clear_active_typed_frame();
+                register_file_reset_active_frame_storage();
+
+                vm_set_register_safe(0, funcValue);
+
+                for (int i = 0; i < argCount; i++) {
+                    vm_set_register_safe((uint16_t)(paramBase + i), tempArgs[i]);
+                }
+
+                vm.chunk = function->chunk;
+                vm.ip = function->chunk->code;
+
+            } else if (IS_FUNCTION(funcValue)) {
+                ObjFunction* objFunction = AS_FUNCTION(funcValue);
+
+                if (argCount != objFunction->arity) {
+                    vm_set_register_safe(resultReg, BOOL_VAL(false));
+                    DISPATCH();
+                }
+
+                Value tempArgs[FRAME_REGISTERS];
+                for (int i = 0; i < argCount; i++) {
+                    tempArgs[i] = vm_get_register_safe((uint16_t)(firstArgReg + i));
+                }
+
+                uint16_t paramBase = calculateParameterBaseRegister(objFunction->arity);
+
+                CallFrame* window = vm.register_file.current_frame;
+                if (!window) {
+                    vm_set_register_safe(resultReg, BOOL_VAL(false));
+                    DISPATCH();
+                }
+
+                window->parameterBaseRegister = paramBase;
+                window->resultRegister = resultReg;
+                window->functionIndex = UINT16_MAX;
+                window->register_count = argCount;
+
+                if (vm.frameCount > 0) {
+                    CallFrame* frame = &vm.frames[vm.frameCount - 1];
+                    frame->parameterBaseRegister = paramBase;
+                    frame->resultRegister = resultReg;
+                    frame->functionIndex = UINT16_MAX;
+                    frame->register_count = argCount;
+                }
+
+                register_file_clear_active_typed_frame();
+                register_file_reset_active_frame_storage();
+
+                for (int i = 0; i < argCount; i++) {
+                    vm_set_register_safe((uint16_t)(paramBase + i), tempArgs[i]);
+                }
+
+                vm.chunk = objFunction->chunk;
+                vm.ip = objFunction->chunk->code;
+
+            } else if (IS_I32(funcValue)) {
                 int functionIndex = AS_I32(funcValue);
 
                 if (functionIndex < 0 || functionIndex >= vm.functionCount) {

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -542,7 +542,7 @@ InterpretResult vm_run_dispatch(void) {
 
                 case OP_DEC_I32_R: {
                     uint8_t reg = READ_BYTE();
-                    const uint8_t typed_limit = (uint8_t)(sizeof(vm.typed_regs.i32_regs) / sizeof(vm.typed_regs.i32_regs[0]));
+                    const uint8_t typed_limit = (uint8_t)TYPED_REGISTER_WINDOW_SIZE;
 
                     if (reg < typed_limit && vm.typed_regs.reg_types[reg] == REG_TYPE_I32) {
     #if USE_FAST_ARITH
@@ -2462,7 +2462,98 @@ InterpretResult vm_run_dispatch(void) {
 
                     Value funcValue = vm_get_register_safe(funcReg);
 
-                    if (IS_I32(funcValue)) {
+                    if (IS_CLOSURE(funcValue)) {
+                        ObjClosure* closure = AS_CLOSURE(funcValue);
+                        ObjFunction* objFunction = closure->function;
+
+                        if (argCount != objFunction->arity) {
+                            vm_set_register_safe(resultReg, BOOL_VAL(false));
+                            break;
+                        }
+
+                        Value tempArgs[FRAME_REGISTERS];
+                        for (int i = 0; i < argCount; i++) {
+                            tempArgs[i] = vm_get_register_safe((uint16_t)(firstArgReg + i));
+                        }
+
+                        uint16_t paramBase = calculateParameterBaseRegister(objFunction->arity);
+
+                        CallFrame* window = vm.register_file.current_frame;
+                        if (!window) {
+                            vm_set_register_safe(resultReg, BOOL_VAL(false));
+                            break;
+                        }
+
+                        window->parameterBaseRegister = paramBase;
+                        window->resultRegister = resultReg;
+                        window->functionIndex = UINT16_MAX;
+                        window->register_count = argCount;
+
+                        if (vm.frameCount > 0) {
+                            CallFrame* frame = &vm.frames[vm.frameCount - 1];
+                            frame->parameterBaseRegister = paramBase;
+                            frame->resultRegister = resultReg;
+                            frame->functionIndex = UINT16_MAX;
+                            frame->register_count = argCount;
+                        }
+
+                        register_file_clear_active_typed_frame();
+                        register_file_reset_active_frame_storage();
+
+                        vm_set_register_safe(0, funcValue);
+
+                        for (int i = 0; i < argCount; i++) {
+                            vm_set_register_safe((uint16_t)(paramBase + i), tempArgs[i]);
+                        }
+
+                        vm.chunk = objFunction->chunk;
+                        vm.ip = objFunction->chunk->code;
+
+                    } else if (IS_FUNCTION(funcValue)) {
+                        ObjFunction* objFunction = AS_FUNCTION(funcValue);
+
+                        if (argCount != objFunction->arity) {
+                            vm_set_register_safe(resultReg, BOOL_VAL(false));
+                            break;
+                        }
+
+                        Value tempArgs[FRAME_REGISTERS];
+                        for (int i = 0; i < argCount; i++) {
+                            tempArgs[i] = vm_get_register_safe((uint16_t)(firstArgReg + i));
+                        }
+
+                        uint16_t paramBase = calculateParameterBaseRegister(objFunction->arity);
+
+                        CallFrame* window = vm.register_file.current_frame;
+                        if (!window) {
+                            vm_set_register_safe(resultReg, BOOL_VAL(false));
+                            break;
+                        }
+
+                        window->parameterBaseRegister = paramBase;
+                        window->resultRegister = resultReg;
+                        window->functionIndex = UINT16_MAX;
+                        window->register_count = argCount;
+
+                        if (vm.frameCount > 0) {
+                            CallFrame* frame = &vm.frames[vm.frameCount - 1];
+                            frame->parameterBaseRegister = paramBase;
+                            frame->resultRegister = resultReg;
+                            frame->functionIndex = UINT16_MAX;
+                            frame->register_count = argCount;
+                        }
+
+                        register_file_clear_active_typed_frame();
+                        register_file_reset_active_frame_storage();
+
+                        for (int i = 0; i < argCount; i++) {
+                            vm_set_register_safe((uint16_t)(paramBase + i), tempArgs[i]);
+                        }
+
+                        vm.chunk = objFunction->chunk;
+                        vm.ip = objFunction->chunk->code;
+
+                    } else if (IS_I32(funcValue)) {
                         int functionIndex = AS_I32(funcValue);
 
                         if (functionIndex < 0 || functionIndex >= vm.functionCount) {

--- a/tests/unit/test_vm_register_windows.c
+++ b/tests/unit/test_vm_register_windows.c
@@ -6,6 +6,7 @@
 
 #include "vm/vm.h"
 #include "vm/vm_comparison.h"
+#include "vm/vm_dispatch.h"
 #include "runtime/memory.h"
 #include "vm/spill_manager.h"
 

--- a/tests/unit/test_vm_typed_registers.c
+++ b/tests/unit/test_vm_typed_registers.c
@@ -4,6 +4,7 @@
 #include "vm/vm.h"
 #include "vm/vm_comparison.h"
 #include "vm/vm_dispatch.h"
+#include "vm/register_file.h"
 #include "runtime/memory.h"
 
 #define ASSERT_TRUE(cond, message)                                                         \
@@ -236,12 +237,85 @@ static bool test_array_iterator_preserves_typed_loop_variable(void) {
     return true;
 }
 
+static bool test_nested_frames_preserve_typed_windows(void) {
+    initVM();
+
+    CallFrame* parent = allocate_frame(&vm.register_file);
+    ASSERT_TRUE(parent != NULL, "allocate_frame should return parent frame");
+
+    const uint16_t reg = FRAME_REG_START;
+    vm_store_i64_typed_hot(reg, 17);
+    ASSERT_TRUE(parent->typed_window != NULL, "Parent frame should own typed window");
+    ASSERT_TRUE(parent->typed_window->i64_regs[reg] == 17,
+                "Parent typed window should capture initial value");
+
+    CallFrame* child = allocate_frame(&vm.register_file);
+    ASSERT_TRUE(child != NULL, "allocate_frame should return child frame");
+    ASSERT_TRUE(child->typed_window != parent->typed_window,
+                "Child frame should receive distinct typed window");
+
+    vm_store_i64_typed_hot(reg, 99);
+    ASSERT_TRUE(vm.typed_regs.i64_regs[reg] == 99,
+                "Active typed window should reflect child writes");
+    ASSERT_TRUE(parent->typed_window->i64_regs[reg] == 17,
+                "Parent typed window should remain untouched during child execution");
+
+    deallocate_frame(&vm.register_file);
+    ASSERT_TRUE(vm.typed_regs.i64_regs[reg] == 17,
+                "Restoring parent frame should reactivate original typed payload");
+
+    deallocate_frame(&vm.register_file);
+    freeVM();
+    return true;
+}
+
+static bool test_global_typed_state_propagates_across_frames(void) {
+    initVM();
+
+    vm_store_i64_typed_hot(0, 11);
+    ASSERT_TRUE(vm.typed_regs.i64_regs[0] == 11,
+                "Root window should capture initial global value");
+
+    CallFrame* parent = allocate_frame(&vm.register_file);
+    ASSERT_TRUE(parent != NULL, "allocate_frame should produce parent frame");
+
+    vm_store_i64_typed_hot(0, 22);
+    ASSERT_TRUE(parent->typed_window->i64_regs[0] == 22,
+                "Parent window should observe updated global value");
+
+    CallFrame* child = allocate_frame(&vm.register_file);
+    ASSERT_TRUE(child != NULL, "allocate_frame should produce child frame");
+
+    vm_store_i64_typed_hot(0, 33);
+    ASSERT_TRUE(vm.typed_regs.i64_regs[0] == 33,
+                "Active child window should observe latest global write");
+
+    deallocate_frame(&vm.register_file);
+    ASSERT_TRUE(vm.typed_regs.i64_regs[0] == 33,
+                "Parent window should inherit child global writes");
+    ASSERT_TRUE(parent->typed_window->i64_regs[0] == 33,
+                "Parent typed cache should match propagated value");
+    ASSERT_TRUE(IS_I64(vm.register_file.globals[0]) && AS_I64(vm.register_file.globals[0]) == 33,
+                "Register file globals should store propagated value");
+
+    deallocate_frame(&vm.register_file);
+    ASSERT_TRUE(vm.typed_regs.root_window.i64_regs[0] == 33,
+                "Root window should retain latest global value after unwinding");
+    ASSERT_TRUE(IS_I64(vm.registers[0]) && AS_I64(vm.registers[0]) == 33,
+                "Mirror register array should reflect propagated global value");
+
+    freeVM();
+    return true;
+}
+
 int main(void) {
     bool (*tests[])(void) = {
         test_typed_register_deferred_boxing_flushes_on_read,
         test_typed_register_flushes_for_open_upvalue,
         test_range_iterator_uses_typed_registers,
         test_array_iterator_preserves_typed_loop_variable,
+        test_nested_frames_preserve_typed_windows,
+        test_global_typed_state_propagates_across_frames,
     };
 
     const char* names[] = {
@@ -249,6 +323,8 @@ int main(void) {
         "Open upvalues force boxed synchronization",
         "Range iterators keep loop variable typed",
         "Array iterators keep loop variable typed",
+        "Nested frames reuse typed windows without copying",
+        "Global typed state propagates across frames",
     };
 
     int passed = 0;


### PR DESCRIPTION
## Summary
- add helpers to clear the active typed window and frame storage before reusing a call frame
- update the tail-call dispatchers to reset typed state when reusing frames for closures and functions
- integrate the register window regression tests into the default `make test` pipeline

## Testing
- make register-window-tests
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e4221905988325999f85598228dc17