### PR TITLE
Improve module resolution search paths and add resolver tests

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -1210,7 +1210,7 @@ void initDispatchTable(void);
 InterpretResult interpret(const char* source);
 
 /** Execute an Orus module loaded from disk. */
-InterpretResult interpret_module(const char* path);
+InterpretResult interpret_module(const char* path, const char* module_name);
 
 // Chunk operations
 void initChunk(Chunk* chunk);

--- a/std/math.orus
+++ b/std/math.orus
@@ -1,0 +1,8 @@
+// Minimal standard math module for resolver tests
+pub PI:i32 := 314
+
+pub fn add(left: i32, right: i32) -> i32:
+    return left + right
+
+pub fn scale(value: i32, factor: i32) -> i32:
+    return value * factor

--- a/tests/modules/resolver/README.md
+++ b/tests/modules/resolver/README.md
@@ -1,0 +1,15 @@
+# Module resolver tests
+
+This directory exercises the module resolution pipeline.
+
+* `default_std_import.orus` verifies that bare module names resolve to the
+  bundled `std/` directory next to the executable. It prints boolean checks for
+  `math.add`, `math.scale`, and `math.PI`.
+* `selective_std_import.orus` ensures selective imports pick individual symbols
+  from the same standard module.
+* `oruspath_override.orus` demonstrates overriding the search roots with the
+  `ORUSPATH` environment variable:
+
+```sh
+ORUSPATH=tests/modules/resolver/lib ./orus tests/modules/resolver/oruspath_override.orus
+```

--- a/tests/modules/resolver/default_std_import.orus
+++ b/tests/modules/resolver/default_std_import.orus
@@ -1,0 +1,5 @@
+use math
+
+print(math.add(12, 30) == 42)
+print(math.scale(3, 4) == 12)
+print(math.PI == 314)

--- a/tests/modules/resolver/lib/extra/utils.orus
+++ b/tests/modules/resolver/lib/extra/utils.orus
@@ -1,0 +1,2 @@
+pub fn greet(name):
+    return "hello " + name

--- a/tests/modules/resolver/oruspath_override.orus
+++ b/tests/modules/resolver/oruspath_override.orus
@@ -1,0 +1,4 @@
+use extra.utils as extra
+
+message = extra.greet("resolver")
+print(message)

--- a/tests/modules/resolver/selective_std_import.orus
+++ b/tests/modules/resolver/selective_std_import.orus
@@ -1,0 +1,4 @@
+use math: PI, add
+
+print(add(5, 7) == 12)
+print(PI == 314)


### PR DESCRIPTION
## Summary
- derive module search roots from the importing file, the executable's sibling std directory, and ORUSPATH entries while caching resolved locations
- pass the logical module name into interpret_module so loaded modules register under the requested identifier
- add a minimal std/math module and resolver-focused tests covering default imports, selective imports, and ORUSPATH overrides