### PR TITLE
Validate core intrinsic signatures

### DIFF
--- a/docs/STDLIB_ROADMAP.md
+++ b/docs/STDLIB_ROADMAP.md
@@ -145,6 +145,12 @@ These are registered inside the VM under internal symbol names:
 `__c_sin`, `__c_cos`, `__c_pow`, `__c_sqrt`.
 They are *never directly visible* to user code.
 
+The VM now exposes a **canonical intrinsic signature table** (see
+`src/vm/runtime/vm.c`) that records each `__c_*` symbol’s arity and expected
+Orus types. During type inference the compiler queries this registry to ensure
+stdlib wrappers match the VM contract and to surface precise diagnostics when a
+signature drifts.
+
 ---
 
 ### **Orus Wrapper (public stdlib module)**
@@ -181,6 +187,8 @@ const E: f64 = 2.718281828459045
 
   > “This function’s body lives in the VM core under the given symbol.”
 * Users never call `__c_*` directly — they only see `math.sin`, `math.cos`, etc.
+* Typed AST nodes cache the validated intrinsic signature so later passes can
+  reference the VM symbol when reporting errors.
 
 ---
 

--- a/include/compiler/typed_ast.h
+++ b/include/compiler/typed_ast.h
@@ -165,6 +165,7 @@ struct TypedASTNode {
             const char* methodStructName;
             bool isCoreIntrinsic;
             const char* coreIntrinsicSymbol;
+            const IntrinsicSignatureInfo* intrinsicSignature;
         } function;
         struct {
             TypedASTNode* callee;

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -291,6 +291,17 @@ struct Type {
     TypeExtension* ext;
 };
 
+#define ORUS_MAX_INTRINSIC_PARAMS 8
+
+typedef struct {
+    const char* symbol;
+    int paramCount;
+    TypeKind paramTypes[ORUS_MAX_INTRINSIC_PARAMS];
+    TypeKind returnType;
+} IntrinsicSignatureInfo;
+
+const IntrinsicSignatureInfo* vm_get_intrinsic_signature(const char* symbol);
+
 // Function
 typedef struct {
     int start;

--- a/src/compiler/typed_ast.c
+++ b/src/compiler/typed_ast.c
@@ -223,6 +223,7 @@ TypedASTNode* create_typed_ast_node(ASTNode* original) {
             typed->typed.function.methodStructName = original->function.methodStructName;
             typed->typed.function.isCoreIntrinsic = original->function.hasCoreIntrinsic;
             typed->typed.function.coreIntrinsicSymbol = original->function.coreIntrinsicSymbol;
+            typed->typed.function.intrinsicSignature = NULL;
             break;
         case NODE_CALL:
             typed->typed.call.callee = NULL;

--- a/src/type/type_inference.c
+++ b/src/type/type_inference.c
@@ -4348,12 +4348,107 @@ static TypedASTNode* generate_typed_ast_recursive(ASTNode* ast, TypeEnv* type_en
             }
             break;
 
-        case NODE_FUNCTION:
+        case NODE_FUNCTION: {
             if (ast->function.returnType) {
-                typed->typed.function.returnType = generate_typed_ast_recursive(ast->function.returnType, type_env);
+                typed->typed.function.returnType =
+                    generate_typed_ast_recursive(ast->function.returnType, type_env);
+                if (ast->function.returnType && !typed->typed.function.returnType) {
+                    free_typed_ast_node(typed);
+                    return NULL;
+                }
             }
-            typed->typed.function.body = generate_typed_ast_recursive(ast->function.body, type_env);
+
+            if (ast->function.hasCoreIntrinsic) {
+                const char* symbol = ast->function.coreIntrinsicSymbol;
+                const char* fn_name = ast->function.name ? ast->function.name : "<anonymous>";
+                const char* reported_symbol = symbol ? symbol : "<unknown>";
+
+                if (ast->function.body) {
+                    report_compile_error(E1006_INVALID_SYNTAX, ast->location,
+                                         "Core intrinsic '%s' bound to function '%s' cannot declare a body.",
+                                         reported_symbol, fn_name);
+                    free_typed_ast_node(typed);
+                    return NULL;
+                }
+
+                const IntrinsicSignatureInfo* signature = vm_get_intrinsic_signature(symbol);
+                if (!signature) {
+                    report_compile_error(E2003_UNDEFINED_TYPE, ast->location,
+                                         "Function '%s' references unknown core intrinsic symbol '%s'.",
+                                         fn_name, reported_symbol);
+                    free_typed_ast_node(typed);
+                    return NULL;
+                }
+
+                Type* function_type = typed->resolvedType;
+                if (!function_type || function_type->kind != TYPE_FUNCTION) {
+                    report_compile_error(E2002_INCOMPATIBLE_TYPES, ast->location,
+                                         "Function '%s' must resolve to a function type to bind intrinsic '%s'.",
+                                         fn_name, signature->symbol);
+                    free_typed_ast_node(typed);
+                    return NULL;
+                }
+
+                int actual_params = function_type->info.function.arity;
+                if (actual_params != signature->paramCount) {
+                    report_compile_error(E2009_ARGUMENT_COUNT_MISMATCH, ast->location,
+                                         "Intrinsic '%s' expects %d parameter(s) but function '%s' declares %d.",
+                                         signature->symbol, signature->paramCount, fn_name, actual_params);
+                    free_typed_ast_node(typed);
+                    return NULL;
+                }
+
+                if (signature->paramCount > 0) {
+                    if (!function_type->info.function.paramTypes) {
+                        report_compile_error(E2002_INCOMPATIBLE_TYPES, ast->location,
+                                             "Intrinsic '%s' requires parameter types but function '%s' is missing annotations.",
+                                             signature->symbol, fn_name);
+                        free_typed_ast_node(typed);
+                        return NULL;
+                    }
+
+                    for (int i = 0; i < signature->paramCount; i++) {
+                        Type* param_type = function_type->info.function.paramTypes[i];
+                        TypeKind param_kind = param_type ? param_type->kind : TYPE_UNKNOWN;
+                        if (param_kind != signature->paramTypes[i]) {
+                            report_compile_error(
+                                E2002_INCOMPATIBLE_TYPES,
+                                ast->location,
+                                "Parameter %d of intrinsic '%s' must be %s but function '%s' resolved to %s.",
+                                i + 1,
+                                signature->symbol,
+                                getTypeName(signature->paramTypes[i]),
+                                fn_name,
+                                getTypeName(param_kind));
+                            free_typed_ast_node(typed);
+                            return NULL;
+                        }
+                    }
+                }
+
+                Type* return_type = function_type->info.function.returnType;
+                TypeKind return_kind = return_type ? return_type->kind : TYPE_UNKNOWN;
+                if (return_kind != signature->returnType) {
+                    report_compile_error(E2002_INCOMPATIBLE_TYPES, ast->location,
+                                         "Intrinsic '%s' must return %s but function '%s' resolved to %s.",
+                                         signature->symbol, getTypeName(signature->returnType), fn_name,
+                                         getTypeName(return_kind));
+                    free_typed_ast_node(typed);
+                    return NULL;
+                }
+
+                typed->typed.function.intrinsicSignature = signature;
+                typed->typed.function.body = NULL;
+            } else if (ast->function.body) {
+                typed->typed.function.body =
+                    generate_typed_ast_recursive(ast->function.body, type_env);
+                if (!typed->typed.function.body && ast->function.body) {
+                    free_typed_ast_node(typed);
+                    return NULL;
+                }
+            }
             break;
+        }
 
         case NODE_CALL:
             typed->typed.call.callee = generate_typed_ast_recursive(ast->call.callee, type_env);

--- a/src/vm/runtime/vm.c
+++ b/src/vm/runtime/vm.c
@@ -81,6 +81,31 @@ bool vm_get_error_report_pending(void) {
     return vm_error_report_pending;
 }
 
+static const IntrinsicSignatureInfo intrinsic_signature_table[] = {
+    {"__c_sin", 1, {TYPE_F64}, TYPE_F64},
+    {"__c_cos", 1, {TYPE_F64}, TYPE_F64},
+    {"__c_pow", 2, {TYPE_F64, TYPE_F64}, TYPE_F64},
+    {"__c_sqrt", 1, {TYPE_F64}, TYPE_F64},
+};
+
+static const size_t intrinsic_signature_table_count =
+    sizeof(intrinsic_signature_table) / sizeof(intrinsic_signature_table[0]);
+
+const IntrinsicSignatureInfo* vm_get_intrinsic_signature(const char* symbol) {
+    if (!symbol) {
+        return NULL;
+    }
+
+    for (size_t i = 0; i < intrinsic_signature_table_count; i++) {
+        const IntrinsicSignatureInfo* entry = &intrinsic_signature_table[i];
+        if (entry->symbol && strcmp(entry->symbol, symbol) == 0) {
+            return entry;
+        }
+    }
+
+    return NULL;
+}
+
 // Forward declarations
 static InterpretResult run(void);
 void runtimeError(ErrorType type, SrcLocation location,

--- a/tests/unit/test_scope_stack.c
+++ b/tests/unit/test_scope_stack.c
@@ -238,6 +238,27 @@ static bool test_core_attribute_preserves_intrinsic_metadata(void) {
         goto cleanup;
     }
 
+    if (!typed_fn->typed.function.intrinsicSignature) {
+        fprintf(stderr, "Typed AST missing intrinsic signature metadata\n");
+        success = false;
+        goto cleanup;
+    }
+
+    if (strcmp(typed_fn->typed.function.intrinsicSignature->symbol, "__c_sin") != 0) {
+        fprintf(stderr, "Intrinsic signature stored unexpected symbol '%s'\n",
+                typed_fn->typed.function.intrinsicSignature->symbol);
+        success = false;
+        goto cleanup;
+    }
+
+    if (typed_fn->typed.function.intrinsicSignature->paramCount != 1 ||
+        typed_fn->typed.function.intrinsicSignature->paramTypes[0] != TYPE_F64 ||
+        typed_fn->typed.function.intrinsicSignature->returnType != TYPE_F64) {
+        fprintf(stderr, "Intrinsic signature did not record expected f64 -> f64 mapping\n");
+        success = false;
+        goto cleanup;
+    }
+
 cleanup:
     free_typed_ast_node(typed);
     freeAST(ast);


### PR DESCRIPTION
## Summary
- add a canonical intrinsic signature registry in the VM and expose lookup helpers
- enforce @[core] bindings during typed AST generation, storing the validated signature metadata
- document the registry in the stdlib roadmap and extend the scope tracking test expectations