### PR TITLE
Fix REPL globals persistence

### DIFF
--- a/src/compiler/backend/codegen/statements.c
+++ b/src/compiler/backend/codegen/statements.c
@@ -1569,6 +1569,15 @@ int compile_assignment_internal(CompilerContext* ctx, TypedASTNode* assign,
             return -1;
         }
 
+        if (ctx->is_module && !ctx->compiling_function && var_name) {
+            Type* export_type = value_type ? value_type : assign->resolvedType;
+            if (!export_type) {
+                export_type = getPrimitiveType(TYPE_ANY);
+            }
+            record_module_export(ctx, var_name, MODULE_EXPORT_KIND_GLOBAL, export_type);
+            set_module_export_metadata(ctx, var_name, var_reg, export_type);
+        }
+
         set_location_from_node(ctx, assign);
         emit_move(ctx, var_reg, value_reg);
         compiler_free_temp(ctx->allocator, value_reg);


### PR DESCRIPTION
## Summary
- treat REPL evaluations as module compilations so global assignments register exports
- seed the type environment and compiler symbol table with previously exported REPL bindings
- mark new top-level assignments as exports to keep variable registers available across REPL inputs

https://chatgpt.com/codex/tasks/task_e_68e5744e59d4832585161e510a09c716