### PR TITLE
Add runtime coverage for core intrinsic binding

### DIFF
--- a/docs/STDLIB_ROADMAP.md
+++ b/docs/STDLIB_ROADMAP.md
@@ -24,13 +24,13 @@ This roadmap defines how the Orus standard library will evolve under the **Rust-
 * **Regression tests cover current resolver behavior.** The suite confirms that
   bundled `std/math.orus` resolves by default, selective imports expose only
   the requested names, and `ORUSPATH` can introduce alternate trees.【F:tests/modules/resolver/default_std_import.orus†L1-L5】【F:tests/modules/resolver/selective_std_import.orus†L1-L4】【F:tests/modules/resolver/oruspath_override.orus†L1-L4】【F:tests/modules/resolver/README.md†L1-L15】
+* **Core intrinsics bind directly to native implementations.** The compiler now
+  emits `OP_CALL_NATIVE_R` trampolines for `@[core]` functions and the loader
+  wires module exports to the VM’s native table so calls dispatch into the C
+  runtime, with dedicated backend coverage to lock in the behavior.【F:src/compiler/backend/codegen/functions.c†L472-L547】【F:src/vm/runtime/vm.c†L94-L214】【F:tests/unit/test_codegen_core_intrinsics.c†L1-L126】
 
 ### ⚠️ Gaps before executing this roadmap
 
-* **Attribute-based intrinsic binding is not implemented.** The planned
-  `@[core("...")]` syntax is currently documentation-only and will require
-  parser, type-checker, and codegen support before stdlib wrappers can call into
-  VM intrinsics.
 * **Stdlib modules are placeholders.** `std/math.orus` only offers integer
   helpers needed for resolver tests; it lacks floating-point APIs, constants,
   and visibility rules described later in this roadmap.【F:std/math.orus†L1-L8】
@@ -43,15 +43,13 @@ This roadmap defines how the Orus standard library will evolve under the **Rust-
 
 ### 🛠️ Proposed tasks to close readiness gaps
 
-1. **Implement attribute-bound intrinsics.**
-   * Extend the parser to accept `@[core("symbol")]` metadata on function
-     declarations and thread the attribute through the typed AST.
-   * Teach the type-checker to validate intrinsic signatures against the
-     corresponding VM declarations.
-   * Update codegen to emit trampoline stubs that dispatch to the registered
-     intrinsic during module linking.
-   * Add end-to-end tests covering missing attributes, mismatched signatures,
-     and successful intrinsic calls from `std/math`.
+1. **Polish attribute-bound intrinsics.**
+   * Expand the stdlib wrappers so public APIs delegate to the new trampolines
+     and verify cross-module re-exports continue to work.
+   * Harden diagnostics around duplicate bindings or missing native
+     implementations now that the VM wires symbols at load time.
+   * Add integration coverage exercising module imports that forward these
+     trampolines to downstream users.
 
 2. **Author the real math module.**
    * Replace the placeholder helpers with the full floating-point API (trig,

--- a/include/compiler/codegen/modules.h
+++ b/include/compiler/codegen/modules.h
@@ -7,6 +7,8 @@
 
 void record_module_export(CompilerContext* ctx, const char* name, ModuleExportKind kind, Type* type);
 void set_module_export_metadata(CompilerContext* ctx, const char* name, int reg, Type* type);
+void set_module_export_function_index(CompilerContext* ctx, const char* name, int function_index);
+void set_module_export_intrinsic(CompilerContext* ctx, const char* name, const char* symbol);
 bool finalize_import_symbol(CompilerContext* ctx, const char* module_name, const char* symbol_name,
                             const char* alias_name, ModuleExportKind kind, uint16_t register_index,
                             Type* exported_type, SrcLocation location);

--- a/include/vm/module_manager.h
+++ b/include/vm/module_manager.h
@@ -29,6 +29,7 @@ typedef struct RegisterModule {
         uint16_t* exported_registers;     // Register IDs of exports (or MODULE_EXPORT_NO_REGISTER)
         ModuleExportKind* exported_kinds; // Kind of each exported symbol
         Type** exported_types;            // Type metadata for exports
+        char** exported_intrinsics;       // Optional intrinsic symbol per export
         uint16_t export_count;            // Number of exports
     } exports;
     
@@ -77,7 +78,7 @@ bool free_module_register(ModuleManager* manager, const char* module_name, uint1
 
 // Phase 3: Import/Export functionality
 bool register_module_export(RegisterModule* module, const char* name, ModuleExportKind kind, int register_index,
-                            Type* type);
+                            Type* type, const char* intrinsic_symbol);
 bool import_variable(RegisterModule* dest_module, const char* var_name, RegisterModule* src_module);
 uint16_t resolve_import(ModuleManager* manager, const char* module_name, const char* var_name);
 bool module_manager_resolve_export(ModuleManager* manager, const char* module_name, const char* symbol_name,

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -423,6 +423,8 @@ typedef struct {
     ModuleExportKind kind;
     int register_index;
     Type* type;
+    int function_index;
+    char* intrinsic_symbol;
 } ModuleExportEntry;
 
 #define MODULE_EXPORT_NO_REGISTER UINT16_MAX
@@ -988,9 +990,12 @@ static inline void compiler_reset_exports(Compiler* compiler) {
     }
     for (int i = 0; i < compiler->exportCount; ++i) {
         free(compiler->exports[i].name);
+        free(compiler->exports[i].intrinsic_symbol);
         compiler->exports[i].name = NULL;
         compiler->exports[i].kind = MODULE_EXPORT_KIND_GLOBAL;
         compiler->exports[i].register_index = -1;
+        compiler->exports[i].function_index = -1;
+        compiler->exports[i].intrinsic_symbol = NULL;
         if (compiler->exports[i].type) {
             module_free_export_type(compiler->exports[i].type);
             compiler->exports[i].type = NULL;

--- a/makefile
+++ b/makefile
@@ -258,6 +258,8 @@ FUSED_LOOP_BYTECODE_TEST_BIN = $(BUILDDIR)/tests/test_fused_loop_bytecode
 ADD_I32_IMM_TEST_BIN = $(BUILDDIR)/tests/test_vm_add_i32_imm
 BUILTIN_INPUT_TEST_BIN = $(BUILDDIR)/tests/test_builtin_input
 CONSTANT_FOLD_TEST_BIN = $(BUILDDIR)/tests/test_constant_folding
+CORE_INTRINSIC_TEST_BIN = $(BUILDDIR)/tests/test_codegen_core_intrinsics
+CORE_INTRINSIC_RUNTIME_TEST_BIN = $(BUILDDIR)/tests/test_vm_core_intrinsics
 BUILTIN_SORTED_ORUS_TESTS = \
     tests/builtins/sorted_runtime.orus
 BUILTIN_SORTED_ORUS_FAIL_TESTS = \
@@ -429,6 +431,9 @@ _test-run: $(ORUS)
 	@echo "\033[36m=== Scope Tracking Tests ===\033[0m"
 	@$(MAKE) scope-tracking-tests
 	@echo ""
+	@echo "\033[36m=== Core Intrinsic Codegen Tests ===\033[0m"
+	@$(MAKE) core-intrinsic-tests
+	@echo ""
 	@echo "\033[36m=== Fused While Codegen Tests ===\033[0m"
 	@$(MAKE) fused-while-tests
 	@echo ""
@@ -518,6 +523,22 @@ $(SCOPE_TRACKING_TEST_BIN): tests/unit/test_scope_stack.c $(COMPILER_OBJS) $(VM_
 scope-tracking-tests: $(SCOPE_TRACKING_TEST_BIN)
 	@echo "Running scope tracking tests..."
 	@./$(SCOPE_TRACKING_TEST_BIN)
+
+$(CORE_INTRINSIC_TEST_BIN): tests/unit/test_codegen_core_intrinsics.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling core intrinsic codegen tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+$(CORE_INTRINSIC_RUNTIME_TEST_BIN): tests/unit/test_vm_core_intrinsics.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling core intrinsic runtime tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+core-intrinsic-tests: $(CORE_INTRINSIC_TEST_BIN) $(CORE_INTRINSIC_RUNTIME_TEST_BIN)
+	@echo "Running core intrinsic codegen tests..."
+	@./$(CORE_INTRINSIC_TEST_BIN)
+	@echo "Running core intrinsic runtime tests..."
+	@./$(CORE_INTRINSIC_RUNTIME_TEST_BIN)
 
 $(FUSED_WHILE_TEST_BIN): tests/unit/test_codegen_fused_while.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/src/compiler/backend/codegen/modules.c
+++ b/src/compiler/backend/codegen/modules.c
@@ -63,6 +63,8 @@ void record_module_export(CompilerContext* ctx, const char* name, ModuleExportKi
     }
 
     ctx->module_exports[ctx->module_export_count].type = cloned_type;
+    ctx->module_exports[ctx->module_export_count].function_index = -1;
+    ctx->module_exports[ctx->module_export_count].intrinsic_symbol = NULL;
     ctx->module_export_count++;
 }
 
@@ -83,6 +85,38 @@ void set_module_export_metadata(CompilerContext* ctx, const char* name, int reg,
             entry->type = cloned;
         }
     }
+}
+
+void set_module_export_function_index(CompilerContext* ctx, const char* name, int function_index) {
+    if (!ctx || !ctx->is_module || !name || function_index < 0) {
+        return;
+    }
+
+    ModuleExportEntry* entry = find_module_export_entry(ctx, name);
+    if (!entry) {
+        return;
+    }
+
+    entry->function_index = function_index;
+}
+
+void set_module_export_intrinsic(CompilerContext* ctx, const char* name, const char* symbol) {
+    if (!ctx || !ctx->is_module || !name || !symbol) {
+        return;
+    }
+
+    ModuleExportEntry* entry = find_module_export_entry(ctx, name);
+    if (!entry) {
+        return;
+    }
+
+    char* copy = orus_strdup(symbol);
+    if (!copy) {
+        return;
+    }
+
+    free(entry->intrinsic_symbol);
+    entry->intrinsic_symbol = copy;
 }
 
 static bool module_import_exists(const CompilerContext* ctx, const char* module_name, const char* symbol_name) {

--- a/src/compiler/backend/compiler.c
+++ b/src/compiler/backend/compiler.c
@@ -724,10 +724,13 @@ void free_compiler_context(CompilerContext* ctx) {
     if (ctx->module_exports) {
         for (int i = 0; i < ctx->module_export_count; i++) {
             free(ctx->module_exports[i].name);
+            free(ctx->module_exports[i].intrinsic_symbol);
             if (ctx->module_exports[i].type) {
                 module_free_export_type(ctx->module_exports[i].type);
                 ctx->module_exports[i].type = NULL;
             }
+            ctx->module_exports[i].intrinsic_symbol = NULL;
+            ctx->module_exports[i].function_index = -1;
         }
         free(ctx->module_exports);
     }
@@ -764,6 +767,8 @@ void initCompiler(Compiler* compiler, Chunk* chunk, const char* fileName, const 
             compiler->exports[i].kind = MODULE_EXPORT_KIND_GLOBAL;
             compiler->exports[i].register_index = -1;
             compiler->exports[i].type = NULL;
+            compiler->exports[i].function_index = -1;
+            compiler->exports[i].intrinsic_symbol = NULL;
             compiler->imports[i].module_name = NULL;
             compiler->imports[i].symbol_name = NULL;
             compiler->imports[i].alias_name = NULL;
@@ -901,6 +906,12 @@ static bool copy_compiled_bytecode(Compiler* legacy_compiler, CompilerContext* c
                 }
                 legacy_compiler->exports[i].register_index = ctx->module_exports[i].register_index;
                 legacy_compiler->exports[i].type = ctx->module_exports[i].type;
+                legacy_compiler->exports[i].function_index = ctx->module_exports[i].function_index;
+                if (ctx->module_exports[i].intrinsic_symbol) {
+                    legacy_compiler->exports[i].intrinsic_symbol = orus_strdup(ctx->module_exports[i].intrinsic_symbol);
+                } else {
+                    legacy_compiler->exports[i].intrinsic_symbol = NULL;
+                }
                 ctx->module_exports[i].type = NULL;
                 if (!legacy_compiler->exports[i].name && ctx->module_exports[i].name) {
                     legacy_compiler->exportCount = i;

--- a/src/vm/dispatch/vm_dispatch_switch.c
+++ b/src/vm/dispatch/vm_dispatch_switch.c
@@ -2283,6 +2283,43 @@ InterpretResult vm_run_dispatch(void) {
                 }
 
                 // Function operations
+                case OP_CALL_NATIVE_R: {
+                    uint8_t nativeIndex = READ_BYTE();
+                    uint8_t firstArgReg = READ_BYTE();
+                    uint8_t argCount = READ_BYTE();
+                    uint8_t resultReg = READ_BYTE();
+
+                    if (nativeIndex >= (uint8_t)vm.nativeFunctionCount) {
+                        VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(),
+                                        "Native function index %u out of range", nativeIndex);
+                    }
+
+                    NativeFunction* native = &vm.nativeFunctions[nativeIndex];
+                    if (!native->function) {
+                        VM_ERROR_RETURN(ERROR_RUNTIME, CURRENT_LOCATION(),
+                                        "Native function %u is unbound", nativeIndex);
+                    }
+
+                    if (native->arity >= 0 && native->arity != argCount) {
+                        VM_ERROR_RETURN(ERROR_ARGUMENT, CURRENT_LOCATION(),
+                                        "Native function expected %d argument(s) but received %u",
+                                        native->arity, argCount);
+                    }
+
+                    Value args_storage[FRAME_REGISTERS];
+                    Value* args_ptr = NULL;
+                    if (argCount > 0) {
+                        args_ptr = args_storage;
+                        for (int i = 0; i < argCount; ++i) {
+                            args_storage[i] = vm_get_register_safe((uint16_t)(firstArgReg + i));
+                        }
+                    }
+
+                    Value result = native->function(argCount, args_ptr);
+                    vm_set_register_safe(resultReg, result);
+                    break;
+                }
+
                 case OP_CALL_R: {
                     DEBUG_VM_PRINT("OP_CALL_R executed");
                     uint8_t funcReg = READ_BYTE();

--- a/src/vm/module_manager.c
+++ b/src/vm/module_manager.c
@@ -196,12 +196,16 @@ void free_module_manager(ModuleManager* manager) {
         if (current->exports.exported_names) {
             for (uint16_t i = 0; i < current->exports.export_count; i++) {
                 free(current->exports.exported_names[i]);
+                if (current->exports.exported_intrinsics) {
+                    free(current->exports.exported_intrinsics[i]);
+                }
                 if (current->exports.exported_types && i < current->exports.export_count) {
                     module_free_export_type(current->exports.exported_types[i]);
                 }
             }
             free(current->exports.exported_names);
         }
+        free(current->exports.exported_intrinsics);
         free(current->exports.exported_registers);
         free(current->exports.exported_kinds);
         if (current->exports.exported_types) {
@@ -263,6 +267,7 @@ RegisterModule* load_module(ModuleManager* manager, const char* module_name) {
     module->exports.exported_registers = NULL;
     module->exports.exported_kinds = NULL;
     module->exports.exported_types = NULL;
+    module->exports.exported_intrinsics = NULL;
     module->exports.export_count = 0;
     
     // Initialize imports
@@ -340,7 +345,7 @@ uint16_t allocate_module_register(ModuleManager* manager, const char* module_nam
 
 // Phase 3: Export variable from module
 bool register_module_export(RegisterModule* module, const char* name, ModuleExportKind kind, int register_index,
-                            Type* type) {
+                            Type* type, const char* intrinsic_symbol) {
     if (!module || !name) {
         return false;
     }
@@ -351,6 +356,13 @@ bool register_module_export(RegisterModule* module, const char* name, ModuleExpo
     }
 
     Type* adopted_type = type;
+    char* intrinsic_copy = NULL;
+    if (intrinsic_symbol) {
+        intrinsic_copy = duplicate_string(intrinsic_symbol);
+        if (!intrinsic_copy) {
+            return false;
+        }
+    }
 
     // Update existing entry if it already exists
     for (uint16_t i = 0; i < module->exports.export_count; i++) {
@@ -363,9 +375,23 @@ bool register_module_export(RegisterModule* module, const char* name, ModuleExpo
             } else if (adopted_type) {
                 module->exports.exported_types = (Type**)calloc(module->exports.export_count, sizeof(Type*));
                 if (!module->exports.exported_types) {
+                    free(intrinsic_copy);
                     return false;
                 }
                 module->exports.exported_types[i] = adopted_type;
+            }
+            if (module->exports.exported_intrinsics) {
+                free(module->exports.exported_intrinsics[i]);
+                module->exports.exported_intrinsics[i] = intrinsic_copy;
+            } else if (intrinsic_copy) {
+                module->exports.exported_intrinsics = (char**)calloc(module->exports.export_count, sizeof(char*));
+                if (!module->exports.exported_intrinsics) {
+                    free(intrinsic_copy);
+                    return false;
+                }
+                module->exports.exported_intrinsics[i] = intrinsic_copy;
+            } else {
+                free(intrinsic_copy);
             }
             return true;
         }
@@ -375,30 +401,42 @@ bool register_module_export(RegisterModule* module, const char* name, ModuleExpo
 
     char** names = (char**)realloc(module->exports.exported_names, new_count * sizeof(char*));
     if (!names) {
+        free(intrinsic_copy);
         return false;
     }
     module->exports.exported_names = names;
 
     uint16_t* registers = (uint16_t*)realloc(module->exports.exported_registers, new_count * sizeof(uint16_t));
     if (!registers) {
+        free(intrinsic_copy);
         return false;
     }
     module->exports.exported_registers = registers;
 
     ModuleExportKind* kinds = (ModuleExportKind*)realloc(module->exports.exported_kinds, new_count * sizeof(ModuleExportKind));
     if (!kinds) {
+        free(intrinsic_copy);
         return false;
     }
     module->exports.exported_kinds = kinds;
 
     Type** types = (Type**)realloc(module->exports.exported_types, new_count * sizeof(Type*));
     if (!types) {
+        free(intrinsic_copy);
         return false;
     }
     module->exports.exported_types = types;
 
+    char** intrinsics = (char**)realloc(module->exports.exported_intrinsics, new_count * sizeof(char*));
+    if (!intrinsics) {
+        free(intrinsic_copy);
+        return false;
+    }
+    module->exports.exported_intrinsics = intrinsics;
+
     char* copy = (char*)malloc(strlen(name) + 1);
     if (!copy) {
+        free(intrinsic_copy);
         return false;
     }
     strcpy(copy, name);
@@ -407,6 +445,7 @@ bool register_module_export(RegisterModule* module, const char* name, ModuleExpo
     module->exports.exported_registers[module->exports.export_count] = stored_register;
     module->exports.exported_kinds[module->exports.export_count] = kind;
     module->exports.exported_types[module->exports.export_count] = adopted_type;
+    module->exports.exported_intrinsics[module->exports.export_count] = intrinsic_copy;
     module->exports.export_count = new_count;
 
     return true;

--- a/src/vm/runtime/vm.c
+++ b/src/vm/runtime/vm.c
@@ -106,6 +106,132 @@ const IntrinsicSignatureInfo* vm_get_intrinsic_signature(const char* symbol) {
     return NULL;
 }
 
+static Value intrinsic_native_sin(int argCount, Value* args) {
+    (void)argCount;
+    if (!args) {
+        return F64_VAL(0.0);
+    }
+    double operand = IS_F64(args[0]) ? AS_F64(args[0]) : 0.0;
+    return F64_VAL(sin(operand));
+}
+
+static Value intrinsic_native_cos(int argCount, Value* args) {
+    (void)argCount;
+    if (!args) {
+        return F64_VAL(0.0);
+    }
+    double operand = IS_F64(args[0]) ? AS_F64(args[0]) : 0.0;
+    return F64_VAL(cos(operand));
+}
+
+static Value intrinsic_native_pow(int argCount, Value* args) {
+    (void)argCount;
+    if (!args) {
+        return F64_VAL(1.0);
+    }
+    double base = IS_F64(args[0]) ? AS_F64(args[0]) : 0.0;
+    double exp = (argCount > 1 && IS_F64(args[1])) ? AS_F64(args[1]) : 0.0;
+    return F64_VAL(pow(base, exp));
+}
+
+static Value intrinsic_native_sqrt(int argCount, Value* args) {
+    (void)argCount;
+    if (!args) {
+        return F64_VAL(0.0);
+    }
+    double operand = IS_F64(args[0]) ? AS_F64(args[0]) : 0.0;
+    return F64_VAL(sqrt(operand));
+}
+
+typedef struct {
+    const char* symbol;
+    NativeFn function;
+} IntrinsicBinding;
+
+static const IntrinsicBinding core_intrinsic_bindings[] = {
+    {"__c_sin", intrinsic_native_sin},
+    {"__c_cos", intrinsic_native_cos},
+    {"__c_pow", intrinsic_native_pow},
+    {"__c_sqrt", intrinsic_native_sqrt},
+};
+
+static NativeFn vm_lookup_core_intrinsic(const char* symbol) {
+    if (!symbol) {
+        return NULL;
+    }
+    for (size_t i = 0; i < sizeof(core_intrinsic_bindings) / sizeof(core_intrinsic_bindings[0]); ++i) {
+        if (strcmp(core_intrinsic_bindings[i].symbol, symbol) == 0) {
+            return core_intrinsic_bindings[i].function;
+        }
+    }
+    return NULL;
+}
+
+static int vm_bind_core_intrinsic(const char* symbol, const IntrinsicSignatureInfo* signature) {
+    if (!symbol || !signature) {
+        return -1;
+    }
+
+    size_t symbol_len = strlen(symbol);
+
+    for (int i = 0; i < vm.nativeFunctionCount; ++i) {
+        NativeFunction* existing = &vm.nativeFunctions[i];
+        if (existing->name && existing->name->length == (int)symbol_len &&
+            strncmp(existing->name->chars, symbol, symbol_len) == 0) {
+            return i;
+        }
+    }
+
+    if (vm.nativeFunctionCount >= MAX_NATIVES) {
+        return -1;
+    }
+
+    NativeFn fn = vm_lookup_core_intrinsic(symbol);
+    if (!fn) {
+        return -1;
+    }
+
+    NativeFunction* slot = &vm.nativeFunctions[vm.nativeFunctionCount];
+    memset(slot, 0, sizeof(*slot));
+    slot->function = fn;
+    slot->arity = signature->paramCount;
+    slot->returnType = getPrimitiveType(signature->returnType);
+    slot->name = allocateString(symbol, (int)symbol_len);
+    if (!slot->name) {
+        slot->function = NULL;
+        slot->arity = 0;
+        slot->returnType = NULL;
+        return -1;
+    }
+
+    int bound_index = vm.nativeFunctionCount;
+    vm.nativeFunctionCount++;
+    return bound_index;
+}
+
+static void vm_patch_intrinsic_stub(int function_index, int native_index) {
+    if (function_index < 0 || function_index >= vm.functionCount) {
+        return;
+    }
+    if (native_index < 0 || native_index >= MAX_NATIVES) {
+        return;
+    }
+
+    Function* fn = &vm.functions[function_index];
+    if (!fn->chunk || !fn->chunk->code) {
+        return;
+    }
+
+    int start = fn->start;
+    if (start < 0 || start + 1 >= fn->chunk->count) {
+        return;
+    }
+    if (fn->chunk->code[start] != OP_CALL_NATIVE_R) {
+        return;
+    }
+    fn->chunk->code[start + 1] = (uint8_t)native_index;
+}
+
 // Forward declarations
 static InterpretResult run(void);
 void runtimeError(ErrorType type, SrcLocation location,
@@ -1652,6 +1778,25 @@ InterpretResult interpret_module(const char* path, const char* module_name_hint)
         module_entry = load_module(vm.register_file.module_manager, module_name);
     }
 
+    if (compiler.isModule) {
+        for (int i = 0; i < compiler.exportCount; ++i) {
+            ModuleExportEntry* entry = &compiler.exports[i];
+            if (!entry->name || !entry->intrinsic_symbol || entry->function_index < 0) {
+                continue;
+            }
+
+            const IntrinsicSignatureInfo* signature = vm_get_intrinsic_signature(entry->intrinsic_symbol);
+            if (!signature) {
+                continue;
+            }
+
+            int native_index = vm_bind_core_intrinsic(entry->intrinsic_symbol, signature);
+            if (native_index >= 0) {
+                vm_patch_intrinsic_stub(entry->function_index, native_index);
+            }
+        }
+    }
+
     // Store current VM state
     Chunk* oldChunk = vm.chunk;
     uint8_t* oldIP = vm.ip;
@@ -1686,7 +1831,8 @@ InterpretResult interpret_module(const char* path, const char* module_name_hint)
 
                 Type* exported_type = entry->type;
                 bool registered = register_module_export(module_entry, entry->name, entry->kind,
-                                                        entry->register_index, exported_type);
+                                                        entry->register_index, exported_type,
+                                                        entry->intrinsic_symbol);
                 if (!registered && exported_type) {
                     module_free_export_type(exported_type);
                     exported_type = NULL;

--- a/tests/unit/fixtures/core_intrinsic_module.orus
+++ b/tests/unit/fixtures/core_intrinsic_module.orus
@@ -1,0 +1,3 @@
+@[core("__c_sin")]
+pub fn sin(x: f64) -> f64
+

--- a/tests/unit/test_codegen_core_intrinsics.c
+++ b/tests/unit/test_codegen_core_intrinsics.c
@@ -1,0 +1,143 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "compiler/compiler.h"
+#include "compiler/parser.h"
+#include "compiler/typed_ast.h"
+#include "compiler/error_reporter.h"
+#include "debug/debug_config.h"
+#include "type/type.h"
+#include "vm/vm.h"
+
+#define ASSERT_TRUE(cond, message)                                                         \
+    do {                                                                                   \
+        if (!(cond)) {                                                                     \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", message, __FILE__, __LINE__); \
+            return false;                                                                  \
+        }                                                                                  \
+    } while (0)
+
+typedef struct {
+    CompilerContext* ctx;
+    TypedASTNode* typed;
+    ASTNode* ast;
+} CompiledModule;
+
+static bool compile_module_source(const char* source, const char* filename, CompiledModule* out) {
+    memset(out, 0, sizeof(*out));
+
+    ASTNode* ast = parseSource(source);
+    if (!ast) {
+        return false;
+    }
+    ast->location.file = filename;
+
+    init_type_inference();
+    TypeEnv* env = type_env_new(NULL);
+    if (!env) {
+        cleanup_type_inference();
+        freeAST(ast);
+        return false;
+    }
+
+    TypedASTNode* typed = generate_typed_ast(ast, env);
+    if (!typed) {
+        cleanup_type_inference();
+        freeAST(ast);
+        return false;
+    }
+
+    CompilerContext* ctx = init_compiler_context(typed);
+    if (!ctx) {
+        cleanup_type_inference();
+        free_typed_ast_node(typed);
+        freeAST(ast);
+        return false;
+    }
+
+    ctx->is_module = true;
+
+    if (!compile_to_bytecode(ctx)) {
+        free_compiler_context(ctx);
+        free_typed_ast_node(typed);
+        freeAST(ast);
+        cleanup_type_inference();
+        return false;
+    }
+
+    out->ctx = ctx;
+    out->typed = typed;
+    out->ast = ast;
+    return true;
+}
+
+static void destroy_compiled_module(CompiledModule* module) {
+    if (!module) {
+        return;
+    }
+    free_compiler_context(module->ctx);
+    free_typed_ast_node(module->typed);
+    freeAST(module->ast);
+    cleanup_type_inference();
+}
+
+static bool test_core_intrinsic_emits_native_call(void) {
+    const char* source =
+        "@[core(\"__c_sin\")]\n"
+        "pub fn sin(x: f64) -> f64\n";
+
+    CompiledModule module;
+    if (!compile_module_source(source, "core_intrinsic.orus", &module)) {
+        fprintf(stderr, "Failed to compile core intrinsic module\n");
+        return false;
+    }
+
+    ASSERT_TRUE(module.ctx->module_export_count == 1, "expected exactly one module export");
+    ModuleExportEntry* export_entry = &module.ctx->module_exports[0];
+    ASSERT_TRUE(export_entry->intrinsic_symbol != NULL, "export should record intrinsic symbol");
+    ASSERT_TRUE(strcmp(export_entry->intrinsic_symbol, "__c_sin") == 0,
+                "export stored incorrect intrinsic symbol");
+    ASSERT_TRUE(export_entry->function_index >= 0, "export missing function index metadata");
+
+    int function_index = export_entry->function_index;
+    ASSERT_TRUE(function_index < module.ctx->function_count,
+                "function index out of bounds for compiled module");
+
+    BytecodeBuffer* chunk = module.ctx->function_chunks[function_index];
+    ASSERT_TRUE(chunk != NULL, "compiled function chunk missing");
+    ASSERT_TRUE(chunk->count >= 6, "intrinsic trampoline should contain call and return instructions");
+    ASSERT_TRUE(chunk->instructions[0] == OP_CALL_NATIVE_R, "trampoline must call native opcode");
+    ASSERT_TRUE(chunk->instructions[5] == OP_RETURN_R, "trampoline must return value register");
+
+    destroy_compiled_module(&module);
+    return true;
+}
+
+int main(void) {
+    debug_init();
+
+    struct {
+        const char* name;
+        bool (*fn)(void);
+    } tests[] = {
+        {"core intrinsic codegen emits native trampoline", test_core_intrinsic_emits_native_call},
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; ++i) {
+        if (tests[i].fn()) {
+            printf("[PASS] %s\n", tests[i].name);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", tests[i].name);
+            return 1;
+        }
+    }
+
+    printf("%d/%d core intrinsic codegen tests passed\n", passed, total);
+    return 0;
+}

--- a/tests/unit/test_vm_core_intrinsics.c
+++ b/tests/unit/test_vm_core_intrinsics.c
@@ -1,0 +1,117 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "vm/vm.h"
+#include "vm/module_manager.h"
+#include "vm/vm_string_ops.h"
+
+#define ASSERT_TRUE(cond, message)                                                         \
+    do {                                                                                   \
+        if (!(cond)) {                                                                     \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", message, __FILE__, __LINE__); \
+            return false;                                                                  \
+        }                                                                                  \
+    } while (0)
+
+static bool native_table_contains(const char* symbol, int* out_index) {
+    if (!symbol || !out_index) {
+        return false;
+    }
+
+    size_t target_len = strlen(symbol);
+    for (int i = 0; i < vm.nativeFunctionCount; ++i) {
+        NativeFunction* entry = &vm.nativeFunctions[i];
+        const char* name_chars = entry->name ? string_get_chars(entry->name) : NULL;
+        if (!name_chars) {
+            continue;
+        }
+        if (strncmp(name_chars, symbol, target_len) == 0 && entry->name->length == (int)target_len) {
+            *out_index = i;
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool module_records_intrinsic(const char* module_name, const char* export_name, const char* intrinsic) {
+    RegisterModule* module = find_module(vm.register_file.module_manager, module_name);
+    if (!module || !module->exports.export_count) {
+        return false;
+    }
+
+    for (uint16_t i = 0; i < module->exports.export_count; ++i) {
+        const char* name = module->exports.exported_names ? module->exports.exported_names[i] : NULL;
+        if (!name || strcmp(name, export_name) != 0) {
+            continue;
+        }
+        const char* recorded = module->exports.exported_intrinsics ? module->exports.exported_intrinsics[i] : NULL;
+        return recorded && strcmp(recorded, intrinsic) == 0;
+    }
+
+    return false;
+}
+
+static bool test_module_binds_core_intrinsic_to_native(void) {
+    const char* module_path = "tests/unit/fixtures/core_intrinsic_module.orus";
+    const char* module_name = "core_intrinsic_module";
+    const char* intrinsic_symbol = "__c_sin";
+
+    initVM();
+
+    InterpretResult result = interpret_module(module_path, module_name);
+    if (result != INTERPRET_OK) {
+        fprintf(stderr, "interpret_module failed with result %d\n", result);
+        freeVM();
+        return false;
+    }
+
+    int native_index = -1;
+    ASSERT_TRUE(native_table_contains(intrinsic_symbol, &native_index),
+                "intrinsic should be present in native function table");
+
+    bool patched = false;
+    for (int i = 0; i < vm.functionCount; ++i) {
+        Function* fn = &vm.functions[i];
+        if (!fn->chunk || !fn->chunk->code || fn->chunk->count < 5) {
+            continue;
+        }
+        if (fn->chunk->code[0] == OP_CALL_NATIVE_R && fn->chunk->code[1] == (uint8_t)native_index) {
+            patched = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(patched, "compiled module function should call the bound native index");
+
+    ASSERT_TRUE(module_records_intrinsic(module_name, "sin", intrinsic_symbol),
+                "module manager should remember intrinsic symbol for export");
+
+    freeVM();
+    return true;
+}
+
+int main(void) {
+    struct {
+        const char* name;
+        bool (*fn)(void);
+    } tests[] = {
+        {"module binds core intrinsic to native table", test_module_binds_core_intrinsic_to_native},
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; ++i) {
+        if (tests[i].fn()) {
+            printf("[PASS] %s\n", tests[i].name);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", tests[i].name);
+            return 1;
+        }
+    }
+
+    printf("%d/%d core intrinsic runtime tests passed\n", passed, total);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a fixture module and runtime unit test to ensure @[core] exports are bound to native VM functions when modules load
- extend the core-intrinsic-tests target to build and execute both codegen and runtime coverage

## Testing
- make core-intrinsic-tests

------
https://chatgpt.com/codex/tasks/task_e_68e57117616883258a62d51e3811b477