### PR TITLE
Allow math intrinsics to adapt integer literals

### DIFF
--- a/tests/expressions/math_literal_arguments.orus
+++ b/tests/expressions/math_literal_arguments.orus
@@ -1,0 +1,13 @@
+use math: sin, cos, pow, sqrt
+
+print("sin(0) literal argument:", sin(0) == 0.0)
+print("sin(0) cast to i32:", (sin(0) as i32) == 0)
+
+cos_zero = cos(0)
+print("cos(0) literal argument:", cos_zero == 1.0)
+
+pow_ints = pow(2, 8)
+print("pow(2, 8) with integer inputs:", pow_ints == 256.0)
+
+sqrt_int = sqrt(16)
+print("sqrt(16) with integer input:", sqrt_int == 4.0)


### PR DESCRIPTION
## Summary
- coerce numeric literal arguments to match math intrinsic parameter types during type inference
- normalize literal values when adapting so the runtime sees the expected numeric representation
- add a regression exercise covering sin/cos/pow/sqrt integer literal calls and casting

## Testing
- ./orus_debug tests/expressions/math_literal_arguments.orus

------
https://chatgpt.com/codex/tasks/task_e_68e5a8c88fc883258750c3e7dd52e0a9