### PR TITLE
Ensure floating-point values print without scientific notation

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -1238,6 +1238,7 @@ void writeChunk(Chunk* chunk, uint8_t byte, int line, int column, const char* fi
 int addConstant(Chunk* chunk, Value value);
 
 // Value operations
+void print_raw_f64(double value);
 void printValue(Value value);
 bool valuesEqual(Value a, Value b);
 

--- a/src/vm/runtime/builtin_print.c
+++ b/src/vm/runtime/builtin_print.c
@@ -104,7 +104,7 @@ static void print_formatted_value(Value value, const char* spec) {
                 snprintf(fmt, sizeof(fmt), "%%.%df", prec);
                 printf(fmt, AS_F64(value));
             } else {
-                printf("%.17g", AS_F64(value));
+                print_raw_f64(AS_F64(value));
             }
             break;
         }

--- a/src/vm/runtime/vm.c
+++ b/src/vm/runtime/vm.c
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <inttypes.h>
+#include <math.h>
 
 // Auto-detect computed goto support
 #ifndef USE_COMPUTED_GOTO
@@ -189,6 +190,37 @@ static char* cached_executable_dir = NULL;
 
 
 // Value operations
+void print_raw_f64(double value) {
+    if (isnan(value)) {
+        fputs("nan", stdout);
+        return;
+    }
+    if (isinf(value)) {
+        fputs(value < 0 ? "-inf" : "inf", stdout);
+        return;
+    }
+    if (value == 0.0) {
+        fputs("0", stdout);
+        return;
+    }
+
+    char buffer[512];
+    snprintf(buffer, sizeof(buffer), "%.17f", value);
+
+    char* decimal = strchr(buffer, '.');
+    if (decimal != NULL) {
+        char* end = buffer + strlen(buffer) - 1;
+        while (end > decimal && *end == '0') {
+            *end-- = '\0';
+        }
+        if (*end == '.') {
+            *end = '\0';
+        }
+    }
+
+    fputs(buffer, stdout);
+}
+
 void printValue(Value value) {
     switch (value.type) {
         case VAL_BOOL:
@@ -207,7 +239,7 @@ void printValue(Value value) {
             printf("%llu", (unsigned long long)AS_U64(value));
             break;
         case VAL_F64:
-            printf("%.17g", AS_F64(value));
+            print_raw_f64(AS_F64(value));
             break;
         case VAL_STRING: {
             const char* chars = string_get_chars(AS_STRING(value));


### PR DESCRIPTION
## Summary
- add a shared helper that renders f64 values without using scientific notation
- reuse the helper across builtin printing so float output is consistent