### PR TITLE
Improve VM float printing and add regression tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -250,6 +250,7 @@ FUSED_WHILE_TEST_BIN = $(BUILDDIR)/tests/test_codegen_fused_while
 PEEPHOLE_TEST_BIN = $(BUILDDIR)/tests/test_constant_propagation
 TAGGED_UNION_TEST_BIN = $(BUILDDIR)/tests/test_vm_tagged_union
 TYPED_REGISTER_TEST_BIN = $(BUILDDIR)/tests/test_vm_typed_registers
+VM_PRINT_TEST_BIN = $(BUILDDIR)/tests/test_vm_print_format
 REGISTER_WINDOW_TEST_BIN = $(BUILDDIR)/tests/test_vm_register_windows
 SPILL_GC_TEST_BIN = $(BUILDDIR)/tests/test_vm_spill_gc_root
 REGISTER_ALLOCATOR_TEST_BIN = $(BUILDDIR)/tests/test_register_allocator
@@ -273,7 +274,7 @@ BUILTIN_RANGE_ORUS_FAIL_TESTS = \
     tests/builtins/range_float_step.orus \
     tests/builtins/range_overflow_stop.orus
 
-.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests fused-while-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests register-window-tests spill-gc-tests inc-cmp-jmp-tests add-i32-imm-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
+.PHONY: all clean test unit-test test-control-flow benchmark help debug release release-with-wasm profiling analyze install dist package bytecode-jump-tests source-map-tests scope-tracking-tests fused-while-tests peephole-tests cli-smoke-tests tagged-union-tests typed-register-tests vm-print-tests register-window-tests spill-gc-tests inc-cmp-jmp-tests add-i32-imm-tests register-allocator-tests builtin-input-tests builtin-range-tests test-optimizer wasm _test-run _benchmark-run
 
 all: build-info $(ORUS)
 
@@ -449,6 +450,9 @@ _test-run: $(ORUS)
 	@echo "\033[36m=== Typed Register Tests ===\033[0m"
 	@$(MAKE) typed-register-tests
 	@echo ""
+	@echo "\033[36m=== VM Print Formatting Tests ===\033[0m"
+	@$(MAKE) vm-print-tests
+	@echo ""
 	@echo "\033[36m=== Register Window Tests ===\033[0m"
 	@$(MAKE) register-window-tests
 	@echo ""
@@ -584,6 +588,15 @@ $(TYPED_REGISTER_TEST_BIN): tests/unit/test_vm_typed_registers.c $(COMPILER_OBJS
 typed-register-tests: $(TYPED_REGISTER_TEST_BIN)
 	@echo "Running typed register coherence tests..."
 	@./$(TYPED_REGISTER_TEST_BIN)
+
+$(VM_PRINT_TEST_BIN): tests/unit/test_vm_print_format.c $(COMPILER_OBJS) $(VM_OBJS)
+	@mkdir -p $(dir $@)
+	@echo "Compiling VM print formatting tests..."
+	@$(CC) $(CFLAGS) $(INCLUDES) -o $@ $^ $(LDFLAGS)
+
+vm-print-tests: $(VM_PRINT_TEST_BIN)
+	@echo "Running VM print formatting tests..."
+	@./$(VM_PRINT_TEST_BIN)
 
 $(REGISTER_WINDOW_TEST_BIN): tests/unit/test_vm_register_windows.c $(COMPILER_OBJS) $(VM_OBJS)
 	@mkdir -p $(dir $@)

--- a/src/vm/runtime/vm.c
+++ b/src/vm/runtime/vm.c
@@ -205,7 +205,24 @@ void print_raw_f64(double value) {
     }
 
     char buffer[512];
-    snprintf(buffer, sizeof(buffer), "%.17f", value);
+    const double abs_value = fabs(value);
+    const char* format = "%.17f";
+    if (abs_value > 0.0 && abs_value < 1e-4) {
+        format = "%.17g";
+    }
+
+    snprintf(buffer, sizeof(buffer), format, value);
+
+    char* exponent = strchr(buffer, 'e');
+    if (!exponent) {
+        exponent = strchr(buffer, 'E');
+    }
+
+    char exponent_part[64] = {0};
+    if (exponent) {
+        strncpy(exponent_part, exponent, sizeof(exponent_part) - 1);
+        *exponent = '\0';
+    }
 
     char* decimal = strchr(buffer, '.');
     if (decimal != NULL) {
@@ -216,6 +233,10 @@ void print_raw_f64(double value) {
         if (*end == '.') {
             *end = '\0';
         }
+    }
+
+    if (exponent_part[0] != '\0') {
+        strncat(buffer, exponent_part, sizeof(buffer) - strlen(buffer) - 1);
     }
 
     fputs(buffer, stdout);

--- a/tests/unit/test_vm_print_format.c
+++ b/tests/unit/test_vm_print_format.c
@@ -1,0 +1,133 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "vm/vm.h"
+
+#define ASSERT_TRUE(cond, message)                                                         \
+    do {                                                                                   \
+        if (!(cond)) {                                                                     \
+            fprintf(stderr, "Assertion failed: %s (%s:%d)\n", message, __FILE__, __LINE__); \
+            return false;                                                                  \
+        }                                                                                  \
+    } while (0)
+
+static bool capture_print_output(double value, char* buffer, size_t buffer_size) {
+    if (!buffer || buffer_size == 0) {
+        return false;
+    }
+
+    if (fflush(stdout) != 0) {
+        return false;
+    }
+
+    int original_fd = dup(fileno(stdout));
+    if (original_fd < 0) {
+        return false;
+    }
+
+    FILE* tmp = tmpfile();
+    if (!tmp) {
+        close(original_fd);
+        return false;
+    }
+
+    int tmp_fd = fileno(tmp);
+    if (tmp_fd < 0) {
+        fclose(tmp);
+        close(original_fd);
+        return false;
+    }
+
+    if (dup2(tmp_fd, fileno(stdout)) < 0) {
+        fclose(tmp);
+        close(original_fd);
+        return false;
+    }
+
+    print_raw_f64(value);
+
+    if (fflush(stdout) != 0) {
+        dup2(original_fd, fileno(stdout));
+        close(original_fd);
+        fclose(tmp);
+        return false;
+    }
+
+    if (fseek(tmp, 0, SEEK_SET) != 0) {
+        dup2(original_fd, fileno(stdout));
+        close(original_fd);
+        fclose(tmp);
+        return false;
+    }
+
+    size_t read = fread(buffer, 1, buffer_size - 1, tmp);
+    buffer[read] = '\0';
+
+    dup2(original_fd, fileno(stdout));
+    close(original_fd);
+    fclose(tmp);
+
+    return true;
+}
+
+static bool test_prints_small_magnitudes_as_non_zero(void) {
+    char output[128];
+    ASSERT_TRUE(capture_print_output(1e-18, output, sizeof(output)),
+                "capture_print_output should succeed");
+    double parsed = strtod(output, NULL);
+    ASSERT_TRUE(parsed != 0.0, "Formatted output should not parse to zero for 1e-18");
+    ASSERT_TRUE(strchr(output, 'e') != NULL || strchr(output, 'E') != NULL,
+                "Small magnitudes should use scientific notation");
+    return true;
+}
+
+static bool test_preserves_exponent_when_trimming(void) {
+    char output[128];
+    ASSERT_TRUE(capture_print_output(1.23e-5, output, sizeof(output)),
+                "capture_print_output should succeed");
+    ASSERT_TRUE(strchr(output, 'e') != NULL || strchr(output, 'E') != NULL,
+                "Exponent should be preserved after trimming");
+    ASSERT_TRUE(strstr(output, "e-") != NULL, "Exponent sign should be present");
+    return true;
+}
+
+static bool test_trims_trailing_zeros_for_fixed_point(void) {
+    char output[128];
+    ASSERT_TRUE(capture_print_output(42.0, output, sizeof(output)),
+                "capture_print_output should succeed");
+    ASSERT_TRUE(strcmp(output, "42") == 0, "Trailing zeros should be trimmed in fixed format");
+    return true;
+}
+
+int main(void) {
+    struct {
+        const char* name;
+        bool (*fn)(void);
+    } tests[] = {
+        {"prints very small magnitudes as non-zero", test_prints_small_magnitudes_as_non_zero},
+        {"preserves exponent when trimming", test_preserves_exponent_when_trimming},
+        {"trims trailing zeros for fixed-point output", test_trims_trailing_zeros_for_fixed_point},
+    };
+
+    int passed = 0;
+    int total = (int)(sizeof(tests) / sizeof(tests[0]));
+
+    for (int i = 0; i < total; ++i) {
+        if (tests[i].fn()) {
+            printf("[PASS] %s\n", tests[i].name);
+            passed++;
+        } else {
+            printf("[FAIL] %s\n", tests[i].name);
+            return 1;
+        }
+    }
+
+    printf("%d/%d VM print formatting tests passed\n", passed, total);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- update `print_raw_f64` to use a scientific-aware format for tiny magnitudes and keep exponent strings intact when trimming trailing zeroes
- add a VM print formatting unit test suite and wire it into the build to guard against regressing very small float output