### PR TITLE
Ensure std is visible at the macOS install prefix

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -194,6 +194,10 @@ if [ "$BIN_DIR" != "$PREFIX_BIN_DIR" ]; then
     ln -sfn "$BINARY_PATH" "${BIN_DIR}/orus"
 fi
 
+ln -sfn "$STAGE_DIR" "${INSTALL_PREFIX}/latest"
+ln -sfn "$BINARY_PATH" "${INSTALL_PREFIX}/orus"
+ln -sfn "$STD_PATH" "${INSTALL_PREFIX}/std"
+
 printf '\nInstalled Orus %s to %s\n' "$RELEASE_TAG" "$STAGE_DIR"
 printf 'Symlinked binary to %s\n' "${PREFIX_BIN_DIR}/orus"
 if [ "$BIN_DIR" != "$PREFIX_BIN_DIR" ]; then


### PR DESCRIPTION
## Summary
- update the install script to link the extracted release directory back into /Library/Orus
- ensure the orus binary and std directory are both exposed beside the release symlink

## Testing
- sh -n scripts/install.sh

------
https://chatgpt.com/codex/tasks/task_e_68e62799d7a483259e4ff07c7858b2ce